### PR TITLE
fixed wrong backtrace on cell output display

### DIFF
--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -63,7 +63,7 @@ function move_vars(old_workspace_name::Symbol, new_workspace_name::Symbol, vars_
 
             # free memory for other variables
             # & delete methods created in the old module:
-            # for example, the old module might extend an imported function: 
+            # for example, the old module might extend an imported function:
             # `import Base: show; show(io::IO, x::Flower) = print(io, "🌷")`
             # when you delete/change this cell, you want this extension to disappear.
             if isdefined(old_workspace, symbol)
@@ -126,7 +126,7 @@ function format_output(val::Any)::Tuple{String, MIME}
         mimes = [MIME("text/html"), MIME("image/svg+xml"), MIME("image/png"), MIME("image/jpg"), MIME("text/plain")]
         first(filter(m->Base.invokelatest(showable, m, val), mimes))
     end
-    
+
     if val === nothing
         "", mime
     else
@@ -139,7 +139,7 @@ function format_output(val::Any)::Tuple{String, MIME}
             end
             result, mime
         catch ex
-            "Failed to show value: \n" * sprint(showerror, ex, stacktrace(backtrace())), MIME("text/plain")
+            "Failed to show value: \n" * sprint(showerror, ex, stacktrace(catch_backtrace())), MIME("text/plain")
         end
     end
 end

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -55,7 +55,7 @@ function move_vars(old_workspace_name::Symbol, new_workspace_name::Symbol, vars_
                     Core.eval(new_workspace, :(import ..($(old_workspace_name)).$(symbol)))
                 catch ex
                     @warn "Failed to move variable $(symbol) to new workspace:"
-                    showerror(stderr, ex, stacktrace(backtrace()))
+                    showerror(stderr, ex, stacktrace(catch_backtrace()))
                 end
             end
         else
@@ -76,7 +76,7 @@ function move_vars(old_workspace_name::Symbol, new_workspace_name::Symbol, vars_
                         Base.delete_method.(filter(m -> startswith(nameof(m.module) |> string, "workspace"), ms))
                     catch ex
                         @warn "Failed to delete methods for $(symbol)"
-                        showerror(stderr, ex, stacktrace(backtrace()))
+                        showerror(stderr, ex, stacktrace(catch_backtrace()))
                     end
                 end
 

--- a/src/webserver/Dynamic.jl
+++ b/src/webserver/Dynamic.jl
@@ -225,7 +225,7 @@ responses[:movenotebookfile] = (body, notebook::Notebook; initiator::Union{Initi
             (success=true, reason="")
         end
     catch ex
-        showerror(stderr, stacktrace(backtrace()))
+        showerror(stderr, stacktrace(catch_backtrace()))
         (success=false, reason=sprint(showerror, ex))
     end
 


### PR DESCRIPTION
This fixed #93 

The MWE
```
### A Pluto.jl notebook ###
# v0.7.5

using Markdown
# ╔═╡ a6ebc12e-884a-11ea-1734-bf9535b30668
struct Dummy end

# ╔═╡ 01be751a-884b-11ea-2f53-f3b983edaaa7
Base.show(io::IO, t::Dummy) = error("test")

# ╔═╡ 06538a46-884b-11ea-2bb4-057a42ebb71d
Dummy()

# ╔═╡ Cell order:
# ╠═a6ebc12e-884a-11ea-1734-bf9535b30668
# ╠═01be751a-884b-11ea-2f53-f3b983edaaa7
# ╠═06538a46-884b-11ea-2bb4-057a42ebb71d
```
now correctly displays
```
Failed to show value: 
test
Stacktrace:
 [1] show(::IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}, ::Main.workspace2.Dummy) at ./none:1
 [2] show(::IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}, ::MIME{Symbol("text/plain")}, ::Main.workspace2.Dummy) at ./multimedia.jl:47
 [3] __binrepr(::MIME{Symbol("text/plain")}, ::Main.workspace2.Dummy, ::IOContext{Base.PipeEndpoint}) at ./multimedia.jl:159
 [4] _textrepr(::MIME{Symbol("text/plain")}, ::Main.workspace2.Dummy, ::IOContext{Base.PipeEndpoint}) at ./multimedia.jl:149
 [5] repr(::MIME{Symbol("text/plain")}, ::Main.workspace2.Dummy; context::IOContext{Base.PipeEndpoint}) at ./multimedia.jl:145
 [6] (::Base.var"#inner#2"{Base.Iterators.Pairs{Symbol,IOContext{Base.PipeEndpoint},Tuple{Symbol},NamedTuple{(:context,),Tuple{IOContext{Base.PipeEndpoint}}}},typeof(repr),Tuple{MIME{Symbol("text/plain")},Main.workspace2.Dummy}})() at ./essentials.jl:715
 [7] #invokelatest#1 at ./essentials.jl:716 [inlined]
 [8] format_output(::Main.workspace2.Dummy) at Pluto.jl/src/runner/PlutoRunner.jl:134
 [9] fetch_formatted_ans() at Pluto.jl/src/runner/PlutoRunner.jl:24
 [10] top-level scope at Pluto.jl/src/react/WorkspaceManager.jl:0
 [11] (::Distributed.var"#104#106"{Distributed.CallMsg{:call_fetch}})() at /build/julia/src/julia-1.4.1/usr/share/julia/stdlib/v1.4/Distributed/src/process_messages.jl:294
 [12] run_work_thunk(::Distributed.var"#104#106"{Distributed.CallMsg{:call_fetch}}, ::Bool) at /build/julia/src/julia-1.4.1/usr/share/julia/stdlib/v1.4/Distributed/src/process_messages.jl:79
 [13] macro expansion at /build/julia/src/julia-1.4.1/usr/share/julia/stdlib/v1.4/Distributed/src/process_messages.jl:294 [inlined]
 [14] (::Distributed.var"#103#105"{Distributed.CallMsg{:call_fetch},Distributed.MsgHeader,Sockets.TCPSocket})() at ./task.jl:358
```
Should I add tests for this? If yes, how could I do that?