### PR TITLE
Blob text polyfill

### DIFF
--- a/assets/client.js
+++ b/assets/client.js
@@ -101,7 +101,6 @@ class PlutoConnection {
     }
 
     handleMessage(event) {
-
         event.data.text().then((msg) => JSON.parse(msg)).then((update) => {
             const forMe = !(("notebookID" in update) && (update.notebookID != this.notebookID))
             if (!forMe) {

--- a/assets/client.js
+++ b/assets/client.js
@@ -79,8 +79,30 @@ class PlutoConnection {
         return this.send(messageType, body, cellID, true)
     }
 
+    readBlob(blob) { // Event-based fill-in for newer Blob.text().
+
+        const reader = new FileReader()
+
+        const p = new Promise((res, rej) => {
+            // on read success
+            reader.onload = () => {
+                res(reader.result)
+            }
+            // on failure
+            reader.onerror = (e) => {
+                reader.abort()
+                rej(e)
+            }
+        })
+
+        reader.readAsText(blob)
+
+        return p
+    }
+
     handleMessage(event) {
-        event.data.text().then((msg) => JSON.parse(msg)).then((update) => {
+
+        this.readBlob(event.data).then((msg) => JSON.parse(msg)).then((update) => {
             const forMe = !(("notebookID" in update) && (update.notebookID != this.notebookID))
             if (!forMe) {
                 console.log("Update message not meant for this notebook")


### PR DESCRIPTION
Instead of making a new class method to use Blob::text, add it as a polyfill.
This makes the code for Chrome and Firefox easier to reason about, and keeps Safari in the "unofficially support" category, instead of changing the code to work with it.

Attempt to supersede the (awesome) original code from #134