### PR TITLE
Remove colon in noAutocomplete regex

### DIFF
--- a/assets/editor.js
+++ b/assets/editor.js
@@ -755,7 +755,7 @@ if ("fonts" in document) {
 
 /* AUTOCOMPLETE */
 
-const noAutocomplete = " \t\r\n([])+-=/,:;'\"!#$%^&*~`<>|"
+const noAutocomplete = " \t\r\n([])+-=/,;'\"!#$%^&*~`<>|"
 
 function onTabKey(cm) {
     const cursor = cm.getCursor()


### PR DESCRIPTION
This colon prevents emoji (\:balloon:<tab>) from working.