### PR TITLE
Include polyfills in the welcome page

### DIFF
--- a/frontend/index.js
+++ b/frontend/index.js
@@ -2,4 +2,6 @@ import { html, render } from "./common/Preact.js"
 
 import { Welcome } from "./components/Welcome.js"
 
+import "./common/Polyfill.js"
+
 render(html`<${Welcome} />`, document.querySelector("main"))


### PR DESCRIPTION
Recent sessions don't present in the Safari browser as `event.text()` is undefined. 

Without polyfills.
<img width="1072" alt="Screen Shot 2020-08-01 at 9 28 55 am" src="https://user-images.githubusercontent.com/24236593/89088074-dac61500-d3d9-11ea-9bfe-d341de0d3288.png">

With polyfills.
<img width="1072" alt="Screen Shot 2020-08-01 at 9 30 50 am" src="https://user-images.githubusercontent.com/24236593/89088085-e74a6d80-d3d9-11ea-97dc-8350e1eeb192.png">
