### PR TITLE
wip: add support for vega mime types

### DIFF
--- a/frontend/components/CellOutput.js
+++ b/frontend/components/CellOutput.js
@@ -70,6 +70,21 @@ const OutputBody = ({ mime, body, cell_id, all_completed_promise, requests }) =>
             return html`<div><${ErrorMessage} cell_id=${cell_id} requests=${requests} ...${JSON.parse(body)} /></div>`
             break
 
+        case "application/vnd.vegalite.v4+json":
+        case "application/vnd.vega.v5+json":
+            let vg = window.require("vega-lite@4", "vega@5", "vega-embed")
+                .then((res) => {
+                    res.embed(`#vega-${cell_id}`, JSON.parse(body))
+                })
+                .catch((err) => {
+                    // fall back to plain svg
+                    return html`<${OutputBody} mime="image/svg+xml" cell_id=${cell_id} body=${body} all_completed_promise=${all_completed_promise} requests=${requests} />`
+                })
+
+            return html`
+                <div id="vega-${cell_id}" style="width:100%;height:100%;"></div>
+            `
+            break
         case "text/plain":
         default:
             if (body) {

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -273,7 +273,6 @@ data:image/png;base64,ahsdf87hf278hwh7823hr...
 """
 function show_richest(io::IO, @nospecialize(x); onlyhtml::Bool=false)::MIME
     mime = Iterators.filter(m -> Base.invokelatest(showable, m, x), allmimes) |> first
-    println("mime: ", mime)
     t = typeof(x)
 
     # types that have no specialized show methods (their fallback is text/plain) are displayed using Pluto's interactive tree viewer.


### PR DESCRIPTION
This adds support to render vega plots interactively (current vega versions only).  

To do:
- [ ] Add tests (which file should they go in? new file?
- [ ] Figure out #252 
- [ ] how to tear down plots correctly