### PR TITLE
Disable automatic word wrap for MethodErrors

### DIFF
--- a/frontend/components/ErrorMessage.js
+++ b/frontend/components/ErrorMessage.js
@@ -61,6 +61,10 @@ export const ErrorMessage = ({ msg, stacktrace, cell_id, requests }) => {
                     <p>In the future, <code>include</code> will be deprecated, and this will be the default.</p>`,
         },
         {
+            pattern: /MethodError: no method matching .*\nClosest candidates are:/,
+            display: (x) => x.split("\n").map((line) => html`<p style="white-space: nowrap;">${line}</p>`),
+        },
+        {
             pattern: /.?/,
             display: (x) => x.split("\n").map((line) => html`<p>${line}</p>`),
         },


### PR DESCRIPTION
This makes the method candidates displayed in `MethodError`s more readable by displaying each of them in one line that can be scrolled horizontally.

See also #122 
Before:
![before](https://user-images.githubusercontent.com/64231/89435027-92458900-d744-11ea-847c-b47ae3a60cac.png)

And after:
![after](https://user-images.githubusercontent.com/64231/89435045-9d001e00-d744-11ea-9195-b04a21687459.png)
