### PR TITLE
Reduce #title's margin-top

### DIFF
--- a/frontend/index.css
+++ b/frontend/index.css
@@ -4,7 +4,7 @@
     /* position: absolute; */
     /* left: 0; */
     /* right: 0; */
-    margin-top: 34vh;
+    margin-top: 20vh;
     /* bottom: 0; */
     /* margin: auto; */
     display: block;


### PR DESCRIPTION
Before:
![Annotation 2020-08-13 154713](https://user-images.githubusercontent.com/2725611/90142154-5762d700-dd7c-11ea-8450-4d4a9058d14f.png)

After:
![Annotation 2020-08-13 154642](https://user-images.githubusercontent.com/2725611/90142153-56ca4080-dd7c-11ea-80be-47fae31df917.png)

With a smaller margin the scrollbar disappears (which looks better IMO). Screenshots from 1920x1080 screen.