### PR TITLE
Fixes Safari support (#286)

### DIFF
--- a/frontend/common/PlutoConnection.js
+++ b/frontend/common/PlutoConnection.js
@@ -101,7 +101,7 @@ export class PlutoConnection {
 
     async handle_message(event) {
         try {
-            const buffer = await event.data.arrayBuffer()
+            const buffer = await new Response(event.data).arrayBuffer()
             const buffer_sliced = buffer.slice(0, buffer.byteLength - this.MSG_DELIM.length)
             const update = unpack(new Uint8Array(buffer_sliced))
             const by_me = "initiator_id" in update && update.initiator_id == this.client_id


### PR DESCRIPTION
This PR fixes the safari support: https://github.com/fonsp/Pluto.jl/issues/286

## Problem

The reason for pluto failing in safari is `frontend/common/PlutoConnection.js:104`, specifically the usage of `Blob.arrayBuffer()`.
The support for this is still [pretty spotty](https://developer.mozilla.org/en-US/docs/Web/API/Blob/arrayBuffer).

<img width="1128" alt="Screenshot 2020-08-14 at 13 56 54" src="https://user-images.githubusercontent.com/230631/90247023-0c0cff00-de36-11ea-88b3-977f2b216bea.png">


## Solution

Instead uses `Response(blob).arrayBuffer()`, whose support is [much better](https://developer.mozilla.org/en-US/docs/Web/API/Body/arrayBuffer).
