### PR TITLE
Initialize global IOContext instance with proper displaysize

### DIFF
--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -195,7 +195,11 @@ function html(io::IO, x::LaTeX)
 end
 
 "The `IOContext` used for converting arbitrary objects to pretty strings."
-iocontext = IOContext(stdout, :color => false, :compact => false, :limit => true, :displaysize => displaysize())
+iocontext = let
+    width = get(ENV, "COLUMNS", 88)
+    height = get(ENV, "LINES", 18)
+    IOContext(stdout, :color => false, :compact => false, :limit => true, :displaysize => (height, width))
+end
 iocontext_compact = IOContext(iocontext, :compact => true)
 
 const imagemimes = [MIME"image/svg+xml"(), MIME"image/png"(), MIME"image/jpg"(), MIME"image/jpeg"(), MIME"image/bmp"(), MIME"image/gif"()]

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -196,8 +196,19 @@ end
 
 "The `IOContext` used for converting arbitrary objects to pretty strings."
 iocontext = let
-    width = get(ENV, "COLUMNS", 88)
-    height = get(ENV, "LINES", 18)
+
+    width = try
+        parse(Int, get(ENV, "COLUMNS", "88"))
+    catch
+        88
+    end
+
+    height = try
+        parse(Int, get(ENV, "LINES", "18"))
+    catch
+        18
+    end
+
     IOContext(stdout, :color => false, :compact => false, :limit => true, :displaysize => (height, width))
 end
 iocontext_compact = IOContext(iocontext, :compact => true)

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -196,20 +196,8 @@ end
 
 "The `IOContext` used for converting arbitrary objects to pretty strings."
 iocontext = let
-
-    width = try
-        parse(Int, get(ENV, "COLUMNS", "88"))
-    catch
-        88
-    end
-
-    height = try
-        parse(Int, get(ENV, "LINES", "18"))
-    catch
-        18
-    end
-
-    IOContext(stdout, :color => false, :compact => false, :limit => true, :displaysize => (height, width))
+    displaysz = (parse(Int, get(ENV, "LINES", "18")), parse(Int, get(ENV, "COLUMNS", "88")))::Tuple{Int, Int}
+    IOContext(stdout, :color => false, :compact => false, :limit => true, :displaysize => displaysz)
 end
 iocontext_compact = IOContext(iocontext, :compact => true)
 

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -195,7 +195,7 @@ function html(io::IO, x::LaTeX)
 end
 
 "The `IOContext` used for converting arbitrary objects to pretty strings."
-iocontext = IOContext(stdout, :color => false, :compact => false, :limit => true, :displaysize => (18, 120))
+iocontext = IOContext(stdout, :color => false, :compact => false, :limit => true, :displaysize => displaysize())
 iocontext_compact = IOContext(iocontext, :compact => true)
 
 const imagemimes = [MIME"image/svg+xml"(), MIME"image/png"(), MIME"image/jpg"(), MIME"image/jpeg"(), MIME"image/bmp"(), MIME"image/gif"()]

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -29,9 +29,15 @@ current_module = Main
 
 function set_current_module(newname)
     global current_module = getfield(Main, newname)
-    global iocontext = IOContext(iocontext, :module => current_module)
+    global iocontext = IOContext(iocontext, :module => current_module, :displaysize => current_displaysize())
     global iocontext_compact = IOContext(iocontext_compact, :module => current_module)
 end
+
+const default_displaysize = ("18", "88")
+current_displaysize() :: Tuple{Int, Int} = (
+    parse(Int, get(ENV, "LINES", default_displaysize[1])),
+    parse(Int, get(ENV, "COLUMNS", default_displaysize[2]))
+)
 
 const cell_results = Dict{UUID, WeakRef}()
 
@@ -195,10 +201,7 @@ function html(io::IO, x::LaTeX)
 end
 
 "The `IOContext` used for converting arbitrary objects to pretty strings."
-iocontext = let
-    displaysz = (parse(Int, get(ENV, "LINES", "18")), parse(Int, get(ENV, "COLUMNS", "88")))::Tuple{Int, Int}
-    IOContext(stdout, :color => false, :compact => false, :limit => true, :displaysize => displaysz)
-end
+iocontext = IOContext(stdout, :color => false, :compact => false, :limit => true, :displaysize => current_displaysize())
 iocontext_compact = IOContext(iocontext, :compact => true)
 
 const imagemimes = [MIME"image/svg+xml"(), MIME"image/png"(), MIME"image/jpg"(), MIME"image/jpeg"(), MIME"image/bmp"(), MIME"image/gif"()]


### PR DESCRIPTION
Make output respect the environment variables `LINES` and `COLUMNS`. 

Fixes #292 