### PR TITLE
swap Shift/Ctrl Enter to match VS Code?

### DIFF
--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -66,8 +66,8 @@ export const CellInput = ({
 
         const keys = {}
 
-        keys["Shift-Enter"] = () => on_submit(cm.getValue())
-        keys["Ctrl-Enter"] = () => {
+        keys["Ctrl-Enter"] = () => on_submit(cm.getValue())
+        keys["Shift-Enter"] = () => {
             on_add_after()
 
             const new_value = cm.getValue()

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -688,8 +688,8 @@ export class Editor extends Component {
                     alert(
                         `Shortcuts 🎹
         
-        Shift+Enter:   run cell
-        Ctrl+Enter:   run cell and add cell below
+        Ctrl+Enter:   run cell
+        Shift+Enter:   run cell and add cell below
         Delete or Backspace:   delete empty cell
 
         PageUp or fn+Up:   select cell above


### PR DESCRIPTION
As mentioned by @tbenst [here](https://github.com/fonsp/Pluto.jl/issues/65#issuecomment-675109492), currently Ctrl+Enter and Shift+Enter are backwards compared to the suggestion by @fonsp [here](https://github.com/fonsp/Pluto.jl/issues/56#issuecomment-608520571), which means they are unfortunately also backwards to Jupyter/Juno. 

Since I'm guessing many of us are coming from Jupyter in particular and I don't see any great reason to swap them, this puts them back. 