### PR TITLE
add closebrackets CodeMirror addon

### DIFF
--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -167,6 +167,7 @@ export const CellInput = ({
         }
 
         cm.setOption("extraKeys", keys)
+        cm.setOption("autoCloseBrackets", true)
 
         cm.on("cursorActivity", () => {
             if (cm.somethingSelected()) {

--- a/frontend/editor.html
+++ b/frontend/editor.html
@@ -24,6 +24,7 @@
     <script src="https://cdn.jsdelivr.net/npm/codemirror@5.57.0/addon/hint/show-hint.min.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/codemirror@5.57.0/addon/display/placeholder.min.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/codemirror@5.57.0/addon/edit/matchbrackets.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/codemirror@5.57.0/addon/edit/closebrackets.min.js" defer></script>
     <!-- <script src="https://cdn.jsdelivr.net/npm/codemirror@5.57.0/addon/search/searchcursor.min.js" defer></script> -->
     <script src="https://cdn.jsdelivr.net/npm/codemirror@5.57.0/addon/comment/comment.min.js" defer></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/codemirror@5.57.0/lib/codemirror.min.css">


### PR DESCRIPTION
This (or its equivalent) are enabled by default in Jupyter/Juno/VSCode from what I can tell. It always surprised me when I select some text and hit `(` expecting to wrap the current selection in parenthesis and it doesn't work in Pluto. This fixes that.

(sorry for the barrage of simple-ish PRs, just trying to share some things that have improved my productivity, always happy to discuss)