### PR TITLE
Changed button opacity for pointer:coarse to be 0.25 permanently

### DIFF
--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -934,9 +934,14 @@ pluto-input > button > span {
 
 @media screen and (any-pointer: coarse) {
     pluto-cell > button,
+    pluto-cell > pluto-runarea
+    {
+        opacity: 0;
+        /* to make it feel smooth: */
+        transition: opacity 0.25s ease-in-out;
+    }
     pluto-input > button,
-    pluto-shoulder > button,
-    pluto-cell > pluto-runarea {
+    pluto-shoulder > button {
         opacity: 0.25;
     }
     pluto-cell:focus-within > button,

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -937,9 +937,7 @@ pluto-input > button > span {
     pluto-input > button,
     pluto-shoulder > button,
     pluto-cell > pluto-runarea {
-        opacity: 0;
-        /* to make it feel smooth: */
-        transition: opacity 0.25s ease-in-out;
+        opacity: 0.25;
     }
     pluto-cell:focus-within > button,
     pluto-cell:focus-within > pluto-input > button,


### PR DESCRIPTION
This PR fixes #348. 

Modified CSS `opacity` for `@media screen and (any-pointer: coarse)`. On `coarse`, all buttons will always be displayed.

![image](https://user-images.githubusercontent.com/54331348/92354197-7b0d0900-f0ff-11ea-9a69-1419241d709d.png)
