### PR TITLE
Wrap LaTeXString with `text{}`

### DIFF
--- a/frontend/editor.html
+++ b/frontend/editor.html
@@ -41,7 +41,7 @@
     <script src="warn_old_browsers.js"></script>
 
     <script src="common/SetupMathJax.js"></script>
-    <script type="text/javascript" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg-full.js" async></script>
+    <script type="text/javascript" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3.1.2/es5/tex-svg-full.js" async></script>
 </head>
 
 <body class="loading no-MαθJax">

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -344,10 +344,9 @@ function show_richest(io::IO, @nospecialize(x); onlyhtml::Bool=false)::MIME
                     htmlesc(io, repr(mime, x; context=iocontext_compact))
                 end
             elseif mime isa MIME"text/latex"
-                # LaTeXStrings prints $ at the start and end.
-                # We strip those, since Markdown.LaTeX only contains the math content
+                # Wrapping with `\text{}` allows for LaTeXStrings with mixed text/math
                 texed = repr(mime, x)
-                html(io, Markdown.LaTeX(strip(texed, '$')))
+                html(io, Markdown.LaTeX("\\text{$texed}"))
             else                
                 show(io, mime, x)
             end


### PR DESCRIPTION
Wrap `LaTeXString` with `text{}` in order to preserve mixed text/math in the rendered repr using MathJax.

https://github.com/fonsp/Pluto.jl/issues/359