### PR TITLE
WIP reshow all cells #326

### DIFF
--- a/src/evaluation/Run.jl
+++ b/src/evaluation/Run.jl
@@ -80,6 +80,13 @@ function run_reactive!(session::ServerSession, notebook::Notebook, old_topology:
 		putnotebookupdates!(session, notebook, clientupdate_cell_output(notebook, cell))
 	end
 
+	# reformat outputs if a show method is (re)defined
+	# WIP: just reformat every time.
+	for cell in new_order.runnable
+		format_single!(notebook, cell)
+		putnotebookupdates!(session, notebook, clientupdate_cell_output(notebook, cell))
+	end
+
 	# allow other `run_reactive!` calls to be executed
 	put!(notebook.executetoken)
 	return new_order
@@ -93,6 +100,15 @@ function run_single!(notebook::Union{Notebook,WorkspaceManager.Workspace}, cell:
 	cell.output_repr = run.output_formatted[1]
 	cell.repr_mime = run.output_formatted[2]
 	cell.errored = run.errored
+
+	return run
+end
+
+function format_single!(notebook::Union{Notebook,WorkspaceManager.Workspace}, cell::Cell)
+	run = WorkspaceManager.format_fetch_in_workspace(notebook, cell.cell_id, ends_with_semicolon(cell.code))
+
+	cell.output_repr = run.output_formatted[1]
+	cell.repr_mime = run.output_formatted[2]
 
 	return run
 end

--- a/test/React.jl
+++ b/test/React.jl
@@ -752,6 +752,26 @@ withenv("PLUTO_WORKSPACE_USE_DISTRIBUTED" => "false") do
 
             WorkspaceManager.unmake_workspace(notebook)
         end
+
+        @testset "#326 update display when `show()` methods defined" begin
+            notebook = Notebook([
+                Cell("1"),
+                Cell("""Base.show(io::IO, x::Int) = print(io, "Wat")"""),
+            ])
+            fakeclient.connected_notebook = notebook
+
+            update_run!(🍭, notebook, notebook.cells[1])
+            @test notebook.cells[1].output_repr == "1"
+
+            update_run!(🍭, notebook, notebook.cells[2])
+            @test notebook.cells[1].output_repr == "Wat"
+
+            setcode(notebook.cells[2], "")
+            update_run!(🍭, notebook, notebook.cells[2])
+            @test notebook.cells[1].output_repr == "1"
+
+            WorkspaceManager.unmake_workspace(notebook)
+        end
     end
 
 end


### PR DESCRIPTION
Work in progress notes.

Tests don't pass yet. And missing a test for `showerror`.

At the moment, reformatting cells that have experienced errors clears the error message and I haven't worked out why. The first test error is on line 118 in test/React.jl.

Line 117 consistently causes cell 3 to have an empty output string:

```
update_run!(🍭, notebook, notebook.cells[3:end])
```

If you run just cell 3 on its own then it gets the correct output string:

```
update_run!(🍭, notebook, notebook.cells[3])
```

I gave up for a bit after experiencing that error.

I saw a few minor code quality things, like unused variables. I could just fix them in separate commits in this branch if you're happy to merge them with this (when its done), or I can leave them.

Here's my workbook for reproducing the error:

```julia
using Test
import Pluto: Notebook, ServerSession, ClientSession, update_run!, Cell, WorkspaceManager
import Distributed

using Pluto: Pluto
function occursinerror(needle, haystack::Pluto.Cell)
    return haystack.errored && occursin(needle, haystack.output_repr)
end

ENV["PLUTO_WORKSPACE_USE_DISTRIBUTED"] = "false"

session = ServerSession()
fakeclient = ClientSession(:fake, nothing)
session.connected_clients[fakeclient.id] = fakeclient

escape_me = "16 \\ \" ' / \b \f \n \r \t 💩 \$"
notebook = Notebook([
    Cell("a\\"),
    Cell("1 = 2"),
    
    Cell("b = 3.0\nb = 3"),
    Cell("\n# uhm\n\nc = 4\n\n# wowie \n\n"),
    Cell("d = 5;"),
    Cell("e = 6; f = 6"),
    Cell("g = 7; h = 7;"),
    Cell("\n\n0 + 8; 0 + 8;\n\n\n"),
    Cell("0 + 9; 9;\n\n\n"),
    Cell("0 + 10;\n10;"),
    Cell("0 + 11;\n11"),
    
    Cell("sqrt(-12)"),
    Cell("\n\nsqrt(-13)"),
    Cell("\"Something very exciting!\"\nfunction w(x)\n\tsqrt(x)\nend"),
    Cell("w(-15)"),
    Cell("error(" * sprint(Base.print_quoted, escape_me) * ")")
])
fakeclient.connected_notebook = notebook

# @testset "Strange code"  begin
    update_run!(session, notebook, notebook.cells[1])
    update_run!(session, notebook, notebook.cells[2])
    @test notebook.cells[1].errored == true
    @test notebook.cells[2].errored == true

# end
# @testset "Mutliple expressions & semicolon"  begin

    update_run!(session, notebook, notebook.cells[3:end])
# This errors:
    @test occursinerror("syntax: extra token after", notebook.cells[3])
# end

# If you just run the lines again, it succeeds. `update_run!` does different things on each run.
    update_run!(session, notebook, notebook.cells[3:end])
    @test occursinerror("syntax: extra token after", notebook.cells[3])

# Trying to isolate the error (unsuccessfully, so far):

Pluto.update_caches!(notebook, [notebook.cells[3]])
Pluto.run_single!(notebook, notebook.cells[3])
notebook.cells[3]
Pluto.format_single!(notebook, notebook.cells[3])
notebook.cells[3]
```