### PR TITLE
📝 Add Ctr+M shortcut for toggling Markdown mode

### DIFF
--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -108,6 +108,42 @@ export const CellInput = ({
                 cm.execCommand("selectAll")
             }
         }
+        keys[mac_keyboard ? "Cmd-M" : "Ctrl-M"] = () => {
+            const value = cm.getValue()
+            const trimmed = value.trim()
+            const offset = value.length - value.trimStart().length
+            if (trimmed.startsWith('md"') && trimmed.endsWith('"')) {
+                // Markdown cell, change to code
+                let start, end
+                if (trimmed.startsWith('md"""') && trimmed.endsWith('"""')) {
+                    // Block markdown
+                    start = 5
+                    end = trimmed.length - 3
+                } else {
+                    // Inline markdown
+                    start = 3
+                    end = trimmed.length - 1
+                }
+                if (start >= end || trimmed.substring(start, end).trim() == "") {
+                    // Corner case: block is empty after removing markdown
+                    cm.setValue("")
+                } else {
+                    while (/\s/.test(trimmed[start])) {
+                        ++start
+                    }
+                    while (/\s/.test(trimmed[end - 1])) {
+                        --end
+                    }
+                    // Keep the selection from [start, end) while maintaining cursor position
+                    cm.replaceRange("", cm.posFromIndex(end + offset), { line: cm.lineCount() })
+                    cm.replaceRange("", { line: 0, ch: 0 }, cm.posFromIndex(start + offset))
+                }
+            } else {
+                // Code cell, change to markdown
+                cm.replaceRange(`\n"""`, { line: cm.lineCount() })
+                cm.replaceRange('md"""\n', { line: 0, ch: 0 })
+            }
+        }
         const swap = (a, i, j) => {
             ;[a[i], a[j]] = [a[j], a[i]]
         }


### PR DESCRIPTION
Hey there, thanks for making this awesome project! This notebook server has been really useful to me.

One thing I noticed is that it gets repetitive to keep typing `md"` every time I want to start a Markdown block. This PR aims to try to make this easier by adding a keyboard shortcut to do the same. Right now I picked Ctrl+M/Cmd+M, but feel free to change this if you prefer.

Hope this aligns with the direction you're taking the project!

### Changes

- Added a shortcut (Ctrl+M/Cmd+M) to change a code cell to Markdown, or a Markdown cell to code
- Robust to leading/trailing whitespace
- Retains your cursor position in the cell

### GIF Demo

![](https://i.imgur.com/UQ0NOCY.gif)