### PR TITLE
Adding macro for activating parent git repo environment

### DIFF
--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -14,8 +14,9 @@ import Base64
 import REPL.REPLCompletions: completions, complete_path, completion_text
 import Base: show, istextmime
 import UUIDs: UUID
+import Pkg
 
-export @bind
+export @bind, @activate_repo_env
 
 MimedOutput = Tuple{Union{String,Vector{UInt8}}, MIME}
 
@@ -660,5 +661,30 @@ const fake_bind = """macro bind(def, element)
         el
     end
 end"""
+
+###
+# ENVIRONMENT
+###
+
+"""
+    `@activate_repo_env`
+
+A macro which searches for the parent Git repository (if one exists), 
+and activates the project environment at the top level of the repository.
+
+"""
+macro activate_repo_env() 
+    quote
+        let 
+            local repo_path = nothing
+            try
+                repo_path = read(`git rev-parse --show-toplevel`, String)
+                Pkg.activate(convert(String, strip(repo_path,['\n'])))
+            catch
+                error("@activate_repo_env call failed.\nThings to try:\n\tIs `git` in your path?\n\tDoes .git/ exist in a parent directory of your notebook?")
+            end
+        end
+    end
+end
 
 end


### PR DESCRIPTION
This is a macro for code I use at the top of my notebooks. It searches for a Git repository in a directory above the notebook working directory. If one is found, then it runs `Pkg.activate` on that top-level path.

It partially addresses one non-default Pluto use case - storing notebooks in Git repositories. This has been discussed in [#142].

The usage is simply `@activate_repo_env`.

Despite Pluto not fully understanding macros (#196), I think this macro should work. It doesn't use any outside variables, and all variables in the macro are locally scoped within a `let` block.

I don't think this is an ideal fix - maybe a better solution would be to add arguments for SVN, Git, or the current working directory? Or maybe switch this from a macro to a function, or put it in a `Pluto.run` argument?