### PR TITLE
fix undef showing

### DIFF
--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -375,6 +375,19 @@ function show_array_row(io::IO, pair::Tuple)
     print(io, "</v></r>")
 end
 
+function show_array_row(io::IO, idxs::AbstractVector{<:Integer}, ary::AbstractArray{<:Any, 1})
+    for i in idxs
+        if isassigned(ary, i)
+            show_array_row(io, (i, ary[i]))
+        else
+            # such that #undef is not confused with "#undef"
+            print(io, "<r><k>", i, "</k><v>")
+            print(io, Base.undef_ref_str)
+            print(io, "</v></r>")
+        end
+    end
+end
+
 function show_dict_row(io::IO, pair::Union{Pair,Tuple})
     k, el = pair
     print(io, "<r><k>")
@@ -393,19 +406,22 @@ istextmime(::MIME"application/vnd.pluto.tree+xml") = true
 
 function show(io::IO, ::MIME"application/vnd.pluto.tree+xml", x::AbstractArray{<:Any, 1})
     print(io, """<jltree class="collapsed" onclick="onjltreeclick(this, event)">""")
-    print(io, eltype(x) |> trynameof)
+    summary(io, x)
     print(io, "<jlarray>")
+    idxs = eachindex(x)
+
     if length(x) <= tree_display_limit
-        show_array_row.([io], zip(eachindex(x), x))
+        show_array_row(io, idxs, x)
     else
-        from_end = tree_display_limit > 20 ? 10 : 1
         firsti = firstindex(x)
-        show_array_row.([io], zip(eachindex(x)[firsti:firsti-1+tree_display_limit-from_end], x[firsti:firsti-1+tree_display_limit-from_end]))
+        from_end = tree_display_limit > 20 ? 10 : 1
+
+        show_array_row(io, idxs[firsti:firsti-1+tree_display_limit-from_end], @view x[firsti:firsti-1+tree_display_limit-from_end])
         
         print(io, "<r><more></more></r>")
         
         indices = 1+length(x)-from_end:length(x)
-        show_array_row.([io], zip(eachindex(x)[end+1-from_end:end], x[end+1-from_end:end]))
+        show_array_row(io, idxs[end+1-from_end:end], @view x[end+1-from_end:end])
     end
     
     print(io, "</jlarray>")

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -369,16 +369,16 @@ end
 const tree_display_limit = 50
 
 function show_array_row(io::IO, pair::Tuple)
-    i, el = pair
+    i, element = pair
     print(io, "<r><k>", i, "</k><v>")
-    show_richest(io, el; onlyhtml=true)
+    show_richest(io, element; onlyhtml=true)
     print(io, "</v></r>")
 end
 
-function show_array_els(io::IO, idxs::AbstractVector{<:Integer}, ary::AbstractArray{<:Any, 1})
-    for i in idxs
-        if isassigned(ary, i)
-            show_array_row(io, (i, ary[i]))
+function show_array_elements(io::IO, indices::AbstractVector{<:Integer}, x::AbstractArray{<:Any, 1})
+    for i in indices
+        if isassigned(x, i)
+            show_array_row(io, (i, x[i]))
         else
             show_array_row(io, (i, Text(Base.undef_ref_str)))
         end
@@ -386,7 +386,7 @@ function show_array_els(io::IO, idxs::AbstractVector{<:Integer}, ary::AbstractAr
 end
 
 function show_dict_row(io::IO, pair::Union{Pair,Tuple})
-    k, el = pair
+    k, element = pair
     print(io, "<r><k>")
     if pair isa Pair
         show_richest(io, k; onlyhtml=true)
@@ -395,7 +395,7 @@ function show_dict_row(io::IO, pair::Union{Pair,Tuple})
         print(io, k)
     end
     print(io, "</k><v>")
-    show_richest(io, el; onlyhtml=true)
+    show_richest(io, element; onlyhtml=true)
     print(io, "</v></r>")
 end
 
@@ -405,20 +405,19 @@ function show(io::IO, ::MIME"application/vnd.pluto.tree+xml", x::AbstractArray{<
     print(io, """<jltree class="collapsed" onclick="onjltreeclick(this, event)">""")
     summary(io, x)
     print(io, "<jlarray>")
-    idxs = eachindex(x)
+    indices = eachindex(x)
 
     if length(x) <= tree_display_limit
-        show_array_els(io, idxs, x)
+        show_array_elements(io, indices, x)
     else
         firsti = firstindex(x)
         from_end = tree_display_limit > 20 ? 10 : 1
 
-        show_array_els(io, idxs[firsti:firsti-1+tree_display_limit-from_end], @view x[firsti:firsti-1+tree_display_limit-from_end])
+        show_array_elements(io, indices[firsti:firsti-1+tree_display_limit-from_end], @view x[firsti:firsti-1+tree_display_limit-from_end])
         
         print(io, "<r><more></more></r>")
         
-        indices = 1+length(x)-from_end:length(x)
-        show_array_els(io, idxs[end+1-from_end:end], @view x[end+1-from_end:end])
+        show_array_elements(io, indices[end+1-from_end:end], @view x[end+1-from_end:end])
     end
     
     print(io, "</jlarray>")

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -375,15 +375,12 @@ function show_array_row(io::IO, pair::Tuple)
     print(io, "</v></r>")
 end
 
-function show_array_row(io::IO, idxs::AbstractVector{<:Integer}, ary::AbstractArray{<:Any, 1})
+function show_array_els(io::IO, idxs::AbstractVector{<:Integer}, ary::AbstractArray{<:Any, 1})
     for i in idxs
         if isassigned(ary, i)
             show_array_row(io, (i, ary[i]))
         else
-            # such that #undef is not confused with "#undef"
-            print(io, "<r><k>", i, "</k><v>")
-            print(io, Base.undef_ref_str)
-            print(io, "</v></r>")
+            show_array_row(io, (i, Text(Base.undef_ref_str)))
         end
     end
 end
@@ -411,17 +408,17 @@ function show(io::IO, ::MIME"application/vnd.pluto.tree+xml", x::AbstractArray{<
     idxs = eachindex(x)
 
     if length(x) <= tree_display_limit
-        show_array_row(io, idxs, x)
+        show_array_els(io, idxs, x)
     else
         firsti = firstindex(x)
         from_end = tree_display_limit > 20 ? 10 : 1
 
-        show_array_row(io, idxs[firsti:firsti-1+tree_display_limit-from_end], @view x[firsti:firsti-1+tree_display_limit-from_end])
+        show_array_els(io, idxs[firsti:firsti-1+tree_display_limit-from_end], @view x[firsti:firsti-1+tree_display_limit-from_end])
         
         print(io, "<r><more></more></r>")
         
         indices = 1+length(x)-from_end:length(x)
-        show_array_row(io, idxs[end+1-from_end:end], @view x[end+1-from_end:end])
+        show_array_els(io, idxs[end+1-from_end:end], @view x[end+1-from_end:end])
     end
     
     print(io, "</jlarray>")

--- a/test/RichOutput.jl
+++ b/test/RichOutput.jl
@@ -21,6 +21,7 @@ import Pluto: update_run!, WorkspaceManager, ClientSession, ServerSession, Noteb
                     Cell("Ref(9)"),
                     Cell("struct Ten x end"),
                     Cell("Ten(11)"),
+                    Cell("Vector(undef, 12)"),
                 ])
                 fakeclient.connected_notebook = notebook
 
@@ -37,6 +38,7 @@ import Pluto: update_run!, WorkspaceManager, ClientSession, ServerSession, Noteb
             @test notebook.cells[9].repr_mime isa MIME"application/vnd.pluto.tree+xml"
 
             @test notebook.cells[11].repr_mime isa MIME"application/vnd.pluto.tree+xml"
+            @test notebook.cells[12].repr_mime isa MIME"application/vnd.pluto.tree+xml"
             
 
             WorkspaceManager.unmake_workspace(notebook)


### PR DESCRIPTION
main issue was that error happens at assign:
https://github.com/fonsp/Pluto.jl/blob/b53d282a132752e34563593b8c7c294866042efb/src/runner/PlutoRunner.jl#L372

so instead of broadcast over `zip` of (index, elements), a specialized function for array is implemented.

Also, I think a lot can be re-used from `Base`, for example:
```
julia> Base.print_matrix(stdout, vvv)
 #undef
 #undef
 #undef
```
Maybe for the next re-factor :construction_worker:

Also I switched to `@view` when possible, since users can have huge array (maybe each element is big or something), so slicing with copy was not as good of an idea (I think).

After this patch:
![image](https://user-images.githubusercontent.com/5306213/92851820-00244680-f3bc-11ea-8d22-6884f6a81ed8.png)

