### PR TITLE
🖨 Fix #413 - consistent styles for hide-ui.css

### DIFF
--- a/frontend/hide-ui.css
+++ b/frontend/hide-ui.css
@@ -2,10 +2,6 @@ main {
     margin-top: 20px;
 }
 
-body {
-    font-size: 14px;
-}
-
 body > header,
 preamble > button,
 pluto-cell > button,
@@ -15,11 +11,4 @@ footer,
 pluto-runarea,
 #helpbox-wrapper {
     display: none !important;
-}
-
-pluto-output img {
-    max-width: 80%;
-    display: block;
-    margin: 0 auto;
-    margin-block-end: 1rem;
 }


### PR DESCRIPTION
This fixes #413 by making the export format consistent with the appearance of the original notebook. Note that the changes will not be shown immediately because exported HTML loads styles from CDN.

### Original Notebook
![image](https://user-images.githubusercontent.com/7550632/92957284-ecb1c380-f42d-11ea-8931-c17a76b47b7e.png)

### Exported HTML (Before)

![image](https://user-images.githubusercontent.com/7550632/92957408-1a970800-f42e-11ea-8fc5-be8d6cd7556d.png)

### Exported HTML (After, simulated by manually changing to the new version in DevTools)

![image](https://user-images.githubusercontent.com/7550632/92957440-2682ca00-f42e-11ea-8f7a-55833df0545c.png)
