### PR TITLE
allow up/down arrow between cells

### DIFF
--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -78,10 +78,10 @@ export const CellInput = ({
         // these should be fn+Up and fn+Down on recent apple keyboards
         // please confirm and change this comment <3
         keys["PageUp"] = () => {
-            on_focus_neighbor(cell_id, -1)
+            on_focus_neighbor(cell_id, -1, 0, 0)
         }
         keys["PageDown"] = () => {
-            on_focus_neighbor(cell_id, +1)
+            on_focus_neighbor(cell_id, +1, 0, 0)
         }
         keys["Shift-Tab"] = "indentLess"
         keys["Tab"] = on_tab_key
@@ -187,7 +187,7 @@ export const CellInput = ({
 
         keys["Backspace"] = keys[mac_keyboard ? "Cmd-Backspace" : "Ctrl-Backspace"] = () => {
             if (cm.lineCount() === 1 && cm.getValue() === "") {
-                on_focus_neighbor(cell_id, -1)
+                on_focus_neighbor(cell_id, -1, Infinity, Infinity)
                 on_delete()
                 console.log("backspace!")
             }
@@ -195,11 +195,25 @@ export const CellInput = ({
         }
         keys["Delete"] = keys[mac_keyboard ? "Cmd-Delete" : "Ctrl-Delete"] = () => {
             if (cm.lineCount() === 1 && cm.getValue() === "") {
-                on_focus_neighbor(cell_id, +1)
+                on_focus_neighbor(cell_id, +1, 0, 0)
                 on_delete()
                 console.log("delete!")
             }
             return window.CodeMirror.Pass
+        }
+        keys["Up"] = () => {
+            if (cm.getCursor().line == 0) {
+                on_focus_neighbor(cell_id, -1, Infinity, cm.getCursor().ch)
+            } else {
+                return window.CodeMirror.Pass
+            }
+        }
+        keys["Down"] = () => {
+            if (cm.getCursor().line == cm.lastLine()) {
+                on_focus_neighbor(cell_id, 1, 0, cm.getCursor().ch)
+            } else {
+                return window.CodeMirror.Pass
+            }
         }
 
         cm.setOption("extraKeys", keys)
@@ -262,6 +276,7 @@ export const CellInput = ({
             clear_selection(cm_ref.current)
         } else {
             cm_ref.current.focus()
+            cm_forced_focus = cm_forced_focus.map(x => (x.line == Infinity) ? {...x, line: cm_ref.current.lastLine()} : x)
             cm_ref.current.setSelection(...cm_forced_focus)
         }
     }, [cm_forced_focus])

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -844,7 +844,7 @@ export class Editor extends Component {
                             },
                         })
                     }}
-                    on_focus_neighbor=${(cell_id, delta) => {
+                    on_focus_neighbor=${(cell_id, delta, line, ch) => {
                         const i = this.state.notebook.cells.findIndex((c) => c.cell_id === cell_id)
                         const new_i = i + delta
                         if (new_i >= 0 && new_i < this.state.notebook.cells.length) {
@@ -852,7 +852,8 @@ export class Editor extends Component {
                                 new CustomEvent("cell_focus", {
                                     detail: {
                                         cell_id: this.state.notebook.cells[new_i].cell_id,
-                                        line: delta === -1 ? Infinity : -1,
+                                        line: line,
+                                        ch: ch
                                     },
                                 })
                             )


### PR DESCRIPTION
Two things here: 

* When you're at the top/bottom of a cell, if you hit up/down it takes you to the previous/next cell, at the same column, exactly as if the whole notebook was just one single big document. This is basically the current behavior of Del/Backspace, so I think this fits nicely into that mental model, and also pretty convenient for keyboard-only use.

* Moving up/down by a cell using Pg Up/Down is switched to always putting the cursor at the top of the new cell. This was already the PgDown behavior, but PgUp used to put it at the end of the last line. I think the current behavior is better since it actually scrolls the top of the cell into view and if you're browsing across many cells, which I think is a fair assumption if you've moved your hand to Pg Up/Down, you are probably looking to read them from the beginning.

