### PR TITLE
Consider cmd key for shortcuts on mac

### DIFF
--- a/frontend/common/KeyboardShortcuts.js
+++ b/frontend/common/KeyboardShortcuts.js
@@ -1,0 +1,17 @@
+export let is_mac_keyboard = /Mac/.test(navigator.platform)
+
+export let ctrl_or_cmd_name = is_mac_keyboard ? "Cmd" : "Ctrl"
+
+export let has_ctrl_or_cmd_pressed = (event) => event.ctrlKey || (is_mac_keyboard && event.metaKey)
+
+export let map_cmd_to_ctrl_on_mac = (keymap) => {
+    if (!is_mac_keyboard) {
+        return keymap
+    }
+
+    let keymap_with_cmd = { ...keymap }
+    for (let [key, handler] of Object.entries(keymap)) {
+        keymap_with_cmd[key.replace(/Ctrl/g, "Cmd")] = handler
+    }
+    return keymap_with_cmd
+}

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -1,6 +1,7 @@
 import { html, useState, useEffect, useLayoutEffect, useRef } from "../common/Preact.js"
 
 import { utf8index_to_ut16index } from "../common/UnicodeTools.js"
+import { map_cmd_to_ctrl_on_mac } from "../common/KeyboardShortcuts.js"
 
 const clear_selection = (cm) => {
     const c = cm.getCursor()
@@ -62,8 +63,6 @@ export const CellInput = ({
             }
         ))
 
-        const mac_keyboard = /Mac/.test(navigator.platform)
-
         const keys = {}
 
         keys["Shift-Enter"] = () => on_submit(cm.getValue())
@@ -75,8 +74,7 @@ export const CellInput = ({
                 on_submit(new_value)
             }
         }
-        // these should be fn+Up and fn+Down on recent apple keyboards
-        // please confirm and change this comment <3
+        // Page up and page down are fn+Up and fn+Down on recent apple keyboards
         keys["PageUp"] = () => {
             on_focus_neighbor(cell_id, -1)
         }
@@ -85,7 +83,7 @@ export const CellInput = ({
         }
         keys["Shift-Tab"] = "indentLess"
         keys["Tab"] = on_tab_key
-        keys[mac_keyboard ? "Cmd-D" : "Ctrl-D"] = () => {
+        keys["Ctrl-D"] = () => {
             if (cm.somethingSelected()) {
                 const sels = cm.getSelections()
                 if (all_equal(sels)) {
@@ -97,7 +95,7 @@ export const CellInput = ({
                 cm.setSelection({ line: cursor.line, ch: token.start }, { line: cursor.line, ch: token.end })
             }
         }
-        keys[mac_keyboard ? "Cmd-/" : "Ctrl-/"] = () => {
+        keys["Ctrl-/"] = () => {
             const old_value = cm.getValue()
             cm.toggleComment()
             const new_value = cm.getValue()
@@ -108,7 +106,7 @@ export const CellInput = ({
                 cm.execCommand("selectAll")
             }
         }
-        keys[mac_keyboard ? "Cmd-M" : "Ctrl-M"] = () => {
+        keys["Ctrl-M"] = () => {
             const value = cm.getValue()
             const trimmed = value.trim()
             const offset = value.length - value.trimStart().length
@@ -185,7 +183,7 @@ export const CellInput = ({
         keys["Alt-Up"] = () => alt_move(-1)
         keys["Alt-Down"] = () => alt_move(+1)
 
-        keys["Backspace"] = keys[mac_keyboard ? "Cmd-Backspace" : "Ctrl-Backspace"] = () => {
+        keys["Backspace"] = keys["Ctrl-Backspace"] = () => {
             if (cm.lineCount() === 1 && cm.getValue() === "") {
                 on_focus_neighbor(cell_id, -1)
                 on_delete()
@@ -193,7 +191,7 @@ export const CellInput = ({
             }
             return window.CodeMirror.Pass
         }
-        keys["Delete"] = keys[mac_keyboard ? "Cmd-Delete" : "Ctrl-Delete"] = () => {
+        keys["Delete"] = keys["Ctrl-Delete"] = () => {
             if (cm.lineCount() === 1 && cm.getValue() === "") {
                 on_focus_neighbor(cell_id, +1)
                 on_delete()
@@ -202,7 +200,7 @@ export const CellInput = ({
             return window.CodeMirror.Pass
         }
 
-        cm.setOption("extraKeys", keys)
+        cm.setOption("extraKeys", map_cmd_to_ctrl_on_mac(keys))
 
         cm.on("cursorActivity", () => {
             if (cm.somethingSelected()) {

--- a/frontend/components/DropRuler.js
+++ b/frontend/components/DropRuler.js
@@ -1,5 +1,7 @@
 import { html, Component } from "../common/Preact.js"
 
+import { has_ctrl_or_cmd_pressed } from "../common/KeyboardShortcuts.js"
+
 export class DropRuler extends Component {
     constructor() {
         super()
@@ -185,7 +187,7 @@ export class DropRuler extends Component {
 
         // Ctrl+A to select all cells
         document.addEventListener("keydown", (e) => {
-            if (e.key === "a" && e.ctrlKey) {
+            if (e.key === "a" && has_ctrl_or_cmd_pressed(e)) {
                 // if you are not writing text somewhere else
                 if (document.activeElement === document.body && window.getSelection().isCollapsed) {
                     this.props.on_selection({

--- a/frontend/components/FilePicker.js
+++ b/frontend/components/FilePicker.js
@@ -1,6 +1,7 @@
 import { html, Component } from "../common/Preact.js"
 
 import { utf8index_to_ut16index } from "../common/UnicodeTools.js"
+import { map_cmd_to_ctrl_on_mac } from "../common/KeyboardShortcuts.js"
 
 const deselect = (cm) => {
     cm.setSelection({ line: 0, ch: Infinity }, { line: 0, ch: Infinity }, { scroll: false })
@@ -70,18 +71,21 @@ export class FilePicker extends Component {
             }
         )
 
-        this.cm.setOption("extraKeys", {
-            "Ctrl-Enter": this.on_submit,
-            "Ctrl-Shift-Enter": this.on_submit,
-            "Enter": this.on_submit,
-            "Esc": (cm) => {
-                cm.closeHint()
-                cm.setValue(this.props.value)
-                deselect(cm)
-                document.activeElement.blur()
-            },
-            "Tab": this.request_path_completions.bind(this),
-        })
+        this.cm.setOption(
+            "extraKeys",
+            map_cmd_to_ctrl_on_mac({
+                "Ctrl-Enter": this.on_submit,
+                "Ctrl-Shift-Enter": this.on_submit,
+                "Enter": this.on_submit,
+                "Esc": (cm) => {
+                    cm.closeHint()
+                    cm.setValue(this.props.value)
+                    deselect(cm)
+                    document.activeElement.blur()
+                },
+                "Tab": this.request_path_completions.bind(this),
+            })
+        )
 
         this.cm.on("change", (cm, e) => {
             if (e.origin !== "setValue") {


### PR DESCRIPTION
Keyboard shortcuts are harder than I imagined at the start actually.
Not everything just works if we change all "Ctrl" appearances to "Cmd", because of some colliding shortcuts.
So I guess it's best to allow both Ctrl **and** Cmd in shortcuts on mac 🤷‍♀️