### PR TITLE
Fix 'undefineds' time unit for long running cells

### DIFF
--- a/frontend/components/RunArea.js
+++ b/frontend/components/RunArea.js
@@ -15,7 +15,7 @@ const prettytime = (time_ns) => {
     }
     const prefices = ["n", "μ", "m", ""]
     let i = 0
-    while (i < prefices.length && time_ns >= 1000.0) {
+    while (i < prefices.length - 1 && time_ns >= 1000.0) {
         i += 1
         time_ns /= 1000
     }


### PR DESCRIPTION
Hi, I found that when a cell runs for more than 1000 seconds, the displayed time unit will become 'undefineds'. (See the following screenshot)

![image](https://user-images.githubusercontent.com/18098099/93296156-367d1e00-f821-11ea-9206-944113653372.png)

It seems to be due to an index error in ` frontend/components/RunArea.js` I fixed the loop index bound so it won't further increase when already at the largest time unit (seconds)