### PR TITLE
Make sure cells don't use top-level return

### DIFF
--- a/src/analysis/Parse.jl
+++ b/src/analysis/Parse.jl
@@ -87,7 +87,7 @@ end
 preprocess_expr(val::Any) = val
 
 "Wrap `expr` inside a timing block."
-function timed_expr(expr::Expr)::Expr
+function timed_expr(expr::Expr, id::Any=nothing)::Expr
     # @assert ExpressionExplorer.is_toplevel_expr(expr)
 
     linenumbernode = expr.args[1]
@@ -99,16 +99,29 @@ function timed_expr(expr::Expr)::Expr
         linenumbernode,
         :(local result = $root),
         :(elapsed_ns = time_ns() - elapsed_ns),
-        :((result, elapsed_ns)),
+        :((result, elapsed_ns, $id)),
     )
 end
 
 "Wrap `expr` inside a timing block, and then inside a try ... catch block."
 function trycatch_expr(expr::Expr, module_name::Symbol, cell_id::UUID)
+    # I use this to make sure the result from the `expr` went through `timed_expr`, as opposed to when `expr`
+    # has an explicit `return` that causes it to jump to the result of `Core.eval` directly.
+    # This seems a bit like a petty check ("I don't want people to play with Pluto!!!") but I see it more as a
+    # way to protect people from finding this obscure bug in some way - DRAL
+    return_check = []
+
     quote
         ans, runtime = try
             # We eval `expr` in the global scope of the workspace module:
-            Core.eval($(module_name), $(timed_expr(expr) |> QuoteNode))
+            local invocation = Core.eval($(module_name), $(timed_expr(expr, return_check) |> QuoteNode))
+
+            if !isa(invocation, Tuple{Any, Number, Any}) || invocation[3] !== $(return_check)
+                throw("Pluto: You can't use the return keyword in the top level of your cell")
+            else
+                local ans, runtime = invocation
+                (ans, runtime)
+            end
         catch ex
             bt = stacktrace(catch_backtrace())
             (CapturedException(ex, bt), missing)

--- a/src/analysis/Parse.jl
+++ b/src/analysis/Parse.jl
@@ -87,7 +87,7 @@ end
 preprocess_expr(val::Any) = val
 
 "Wrap `expr` inside a timing block."
-function timed_expr(expr::Expr, id::Any=nothing)::Expr
+function timed_expr(expr::Expr, return_proof::Any=nothing)::Expr
     # @assert ExpressionExplorer.is_toplevel_expr(expr)
 
     linenumbernode = expr.args[1]
@@ -99,7 +99,7 @@ function timed_expr(expr::Expr, id::Any=nothing)::Expr
         linenumbernode,
         :(local result = $root),
         :(elapsed_ns = time_ns() - elapsed_ns),
-        :((result, elapsed_ns, $id)),
+        :((result, elapsed_ns, $return_proof)),
     )
 end
 
@@ -107,19 +107,19 @@ end
 function trycatch_expr(expr::Expr, module_name::Symbol, cell_id::UUID)
     # I use this to make sure the result from the `expr` went through `timed_expr`, as opposed to when `expr`
     # has an explicit `return` that causes it to jump to the result of `Core.eval` directly.
+    return_proof = Ref(123)
     # This seems a bit like a petty check ("I don't want people to play with Pluto!!!") but I see it more as a
     # way to protect people from finding this obscure bug in some way - DRAL
-    return_check = []
 
     quote
         ans, runtime = try
             # We eval `expr` in the global scope of the workspace module:
-            local invocation = Core.eval($(module_name), $(timed_expr(expr, return_check) |> QuoteNode))
+            local invocation = Core.eval($(module_name), $(timed_expr(expr, return_proof) |> QuoteNode))
 
-            if !isa(invocation, Tuple{Any, Number, Any}) || invocation[3] !== $(return_check)
-                throw("Pluto: You can't use the return keyword in the top level of your cell")
+            if !isa(invocation, Tuple{Any,Number,Any}) || invocation[3] !== $(return_proof)
+                throw("Pluto: You can only use return inside a function.")
             else
-                local ans, runtime = invocation
+                local ans, runtime, _ = invocation
                 (ans, runtime)
             end
         catch ex

--- a/test/Dynamic.jl
+++ b/test/Dynamic.jl
@@ -42,7 +42,6 @@ stringify_keys(x::Any) = x
         c(cell) = cell.cell_id |> string
 
         @test_nowarn send(:connect, Dict(), Dict(:notebook_id => n))
-        @test_nowarn send(:get_version, Dict(), Dict())
 
         @test_nowarn send(:add_cell, Dict(:index => 0), Dict(:notebook_id => n))
         send(:add_cell, Dict(:index => 0), Dict(:notebook_id => n))

--- a/test/React.jl
+++ b/test/React.jl
@@ -673,6 +673,27 @@ import JSON
         WorkspaceManager.unmake_workspace((🍭, notebook))
     end
 
+    @testset "No top level return" begin
+        notebook = Notebook([
+            Cell("return 10"),
+            Cell("return (0, 0)"),
+            Cell("return (0, 0, 0)"),
+            Cell("begin return \"a string\" end"),
+            Cell("""
+                let
+                    return []
+                end
+            """),
+        ])
+
+        for cell in notebook.cells
+            update_run!(🍭, notebook, cell)
+            @test occursinerror("can't use the return keyword in the top level", cell)
+        end
+
+        WorkspaceManager.unmake_workspace((🍭, notebook))
+    end
+
     @testset "Run multiple" begin
         notebook = Notebook([
             Cell("x = []"),

--- a/test/React.jl
+++ b/test/React.jl
@@ -688,7 +688,7 @@ import JSON
 
         for cell in notebook.cells
             update_run!(🍭, notebook, cell)
-            @test occursinerror("can't use the return keyword in the top level", cell)
+            @test occursinerror("You can only use return inside a function.", cell)
         end
 
         WorkspaceManager.unmake_workspace((🍭, notebook))


### PR DESCRIPTION
A tiny wrapper in the timed_expr/trycatch_expr - wanted to make it more sound logicy (separate functions composed) but that felt like it was going to make it more complex.
So I find this suffices for now :D 