### PR TITLE
add unamed parameter type to references, fixes #423

### DIFF
--- a/test/ExpressionExplorer.jl
+++ b/test/ExpressionExplorer.jl
@@ -23,8 +23,10 @@ using Test
     @testset "Lists and structs" begin
         @test testee(:(1:3), [], [], [:(:)], [])
         @test testee(:(a[1:3,4]), [:a], [], [:(:)], [])
+        @test testee(:(a[b]), [:a, :b], [], [], [])
         @test testee(:([a[1:3,4]; b[5]]), [:b, :a], [], [:(:)], [])
-        @test testee(:(a.property), [:a], [], [], []) # `a` can also be a module
+        @test testee(:(a.someproperty), [:a], [], [], []) # `a` can also be a module
+        @test testee(:([a..., b]), [:a, :b], [], [], [])
         @test testee(:(struct a; b; c; end), [], [], [], [
             :a => ([], [], [], [])
             ])

--- a/test/ExpressionExplorer.jl
+++ b/test/ExpressionExplorer.jl
@@ -213,6 +213,9 @@ using Test
         @test testee(:(a(a::AbstractArray{T,R}) where {T,S} = a + b), [], [], [], [
             :a => ([:AbstractArray, :b, :R], [], [:+], [])
         ])
+        @test testee(:(f(::A) = 1), [], [], [], [
+            :f => ([:A], [], [], [])
+        ])
     end
     @testset "Scope modifiers" begin
         @test testee(:(let global a, b = 1, 2 end), [], [:a, :b], [], [])

--- a/test/ExpressionExplorer.jl
+++ b/test/ExpressionExplorer.jl
@@ -216,6 +216,12 @@ using Test
         @test testee(:(f(::A) = 1), [], [], [], [
             :f => ([:A], [], [], [])
         ])
+        @test testee(:(f(::A, ::B) = 1), [], [], [], [
+            :f => ([:A, :B], [], [], [])
+        ])
+        @test testee(:(f(a::A, ::B, c::C...) = a + c), [], [], [], [
+            :f => ([:A, :B, :C], [], [:+], [])
+        ])
     end
     @testset "Scope modifiers" begin
         @test testee(:(let global a, b = 1, 2 end), [], [:a, :b], [], [])


### PR DESCRIPTION
Hi,

This is a fix for issue #423 where methods with unnamed arguments where not added as referencers to the parameters' type. I fixed it by adding a special case in the `explore_funcdef` function.

This is my first try at touching a serious julia codebase so I will be happy to fix any comments

Thanks :balloon: 