### PR TITLE
handle try catch in different scopes, closes #464

### DIFF
--- a/src/analysis/ExpressionExplorer.jl
+++ b/src/analysis/ExpressionExplorer.jl
@@ -112,6 +112,14 @@ Base.push!(x::Set) = x
 # HELPER FUNCTIONS
 ###
 
+function explore_inner_scoped(ex::Expr, scopestate::ScopeState)::SymbolsState
+    # Because we are entering a new scope, we create a copy of the current scope state, and run it through the expressions.
+    innerscopestate = deepcopy(scopestate)
+    innerscopestate.inglobalscope = false
+
+    return mapfoldl(a -> explore!(a, innerscopestate), union!, ex.args, init=SymbolsState())
+end
+
 # from the source code: https://github.com/JuliaLang/julia/blob/master/src/julia-parser.scm#L9
 const modifiers = [:(+=), :(-=), :(*=), :(/=), :(//=), :(^=), :(÷=), :(%=), :(<<=), :(>>=), :(>>>=), :(&=), :(⊻=), :(≔), :(⩴), :(≕)]
 const modifiers_dotprefixed = [Symbol('.' * String(m)) for m in modifiers]
@@ -310,12 +318,7 @@ function explore!(ex::Expr, scopestate::ScopeState)::SymbolsState
         return explore!(expanded_expr, scopestate)
     elseif ex.head == :let || ex.head == :for || ex.head == :while
         # Creates local scope
-
-        # Because we are entering a new scope, we create a copy of the current scope state, and run it through the expressions.
-        innerscopestate = deepcopy(scopestate)
-        innerscopestate.inglobalscope = false
-
-        return mapfoldl(a -> explore!(a, innerscopestate), union!, ex.args, init=SymbolsState())
+        return explore_inner_scoped(ex, scopestate)
     elseif ex.head == :macrocall
         # Does not create sccope
         
@@ -410,6 +413,27 @@ function explore!(ex::Expr, scopestate::ScopeState)::SymbolsState
 
             # so we insert the function's inner symbol state here, as if it was a `let` block.
             symstate = innersymstate
+        end
+
+        return symstate
+    elseif ex.head == :try
+        symstate = SymbolsState()
+
+        # Handle catch first
+        if ex.args[3] != false
+            union!(symstate, explore_inner_scoped(ex.args[3], scopestate))
+            # If we catch a symbol, it could shadow a global reference, remove it
+            if ex.args[2] != false
+                setdiff!(symstate.references, Symbol[ex.args[2]])
+            end
+        end
+
+        # Handle the try block
+        union!(symstate, explore_inner_scoped(ex.args[1], scopestate))
+
+        # Finally, handle finally
+        if length(ex.args) == 4
+            union!(symstate, explore_inner_scoped(ex.args[4], scopestate))
         end
 
         return symstate

--- a/test/ExpressionExplorer.jl
+++ b/test/ExpressionExplorer.jl
@@ -101,6 +101,14 @@ using Test
         @test testee(:(for k in 1:2, r in 3:4; global z = k + r; end), [], [:z], [:+, :(:)], [])
         @test testee(:(while k < 2; r = w; global z = k + r; end), [:k, :w], [:z], [:+, :(<)], [])
     end
+    @testset "`try` & `catch`" begin
+        @test testee(:(try a = b + 1 catch; end), [:b], [], [:+], [])
+        @test testee(:(try a() catch e; e end), [], [], [:a], [])
+        @test testee(:(try a() catch; e end), [:e], [], [:a], [])
+        @test testee(:(try a + 1 catch a; a end), [:a], [], [:+], [])
+        @test testee(:(try 1 catch e; e finally a end), [:a], [], [], [])
+        @test testee(:(try 1 finally a end), [:a], [], [], [])
+    end
     @testset "Comprehensions" begin
         @test testee(:([sqrt(s) for s in 1:n]), [:n], [], [:sqrt, :(:)], [])
         @test testee(:([sqrt(s + r) for s in 1:n, r in k]), [:n, :k], [], [:sqrt, :(:), :+], [])


### PR DESCRIPTION
Hi,

I added a case to handle `try`/`catch` expressions as two blocks with their own scopes. This prevents the error happening in #464.

We start by exploring the `catch` block to deal with the case where a global reference could be shadowed with the symbol for the catched error:
```julia
a = 1
```
```julia
try
   do_something()
catch a
   report(a)
end
```

We then explore the `try` block as usual.