### PR TITLE
Comments using [ctrl-/] match the line indentation #️⃣

### DIFF
--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -97,7 +97,7 @@ export const CellInput = ({
         }
         keys["Ctrl-/"] = () => {
             const old_value = cm.getValue()
-            cm.toggleComment()
+            cm.toggleComment({indent: true})
             const new_value = cm.getValue()
             if (old_value === new_value) {
                 // the commenter failed for some reason


### PR DESCRIPTION
Instead of commenting like this:
```julia
function example()
    for i in 1:10
#       some_code = i^10
    end
end
```
we'd get this:
```julia
function example()
    for i in 1:10
        # some_code = i^10
    end
end
```

For other `toggleComment` options see: https://github.com/ficristo/codemirror-addon-toggle-comment