### PR TITLE
Changed default location to ~/.julia/pluto_notebooks BUT

### DIFF
--- a/sample/Getting started.jl
+++ b/sample/Getting started.jl
@@ -96,7 +96,7 @@ end
 HTML("""<p>To delete a cell like the one defining $scary_dog, click on the <img src="https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.0.0/src/svg/close-circle-outline.svg" style="width: 1em; height: 1em; margin-bottom: -.2em;"> on the right of its code.</p>""")
 
 # ╔═╡ fb4e471c-9551-11ea-1ab5-41bbd5de76b8
-md"Speaking of saving, this notebook is autosaved whenever you change something. The default location for new notebooks is $(tempdir()), a special directory that gets _emptied_ when you restart your computer. To change the save location to something more permanent, scroll to the top - you'll see it next to the Pluto logo."
+md"Speaking of saving, this notebook is autosaved whenever you change something. The default location for new notebooks is $(joinpath(first(DEPOT_PATH), "pluto_notebooks")), you can find it using your file explorer. To change the name or the directory of a notebook, scroll to the top - you enter the notebook's path next to the Pluto logo."
 
 # ╔═╡ 9d3af596-9554-11ea-21bd-bf427c91c424
 md"## ⚡ Pluto power ⚡

--- a/src/notebook/Notebook.jl
+++ b/src/notebook/Notebook.jl
@@ -40,7 +40,7 @@ end
 Notebook(cells::Array{Cell,1}, path::AbstractString, notebook_id::UUID) = 
     Notebook(cells, path, notebook_id, NotebookTopology(), Channel(1024), Token(), nothing)
 
-Notebook(cells::Array{Cell,1}, path::AbstractString=numbered_until_new(joinpath(tempdir(), cutename()))) = Notebook(cells, path, uuid1())
+Notebook(cells::Array{Cell,1}, path::AbstractString=numbered_until_new(joinpath(new_notebooks_directory(), cutename()))) = Notebook(cells, path, uuid1())
 
 function cell_index_from_id(notebook::Notebook, cell_id::UUID)::Union{Int,Nothing}
     findfirst(c -> c.cell_id == cell_id, notebook.cells)
@@ -64,7 +64,7 @@ Save the notebook to `io`, `file` or to `notebook.path`.
 
 In the produced file, cells are not saved in the notebook order. If `notebook.topolgy` is up-to-date, I will save cells in _topological order_. This guarantees that you can run the notebook file outside of Pluto, with `julia my_notebook.jl`.
 
-Have a look at or [JuliaCon 2020 presentation](https://youtu.be/IAF8DjrQSSk?t=1085) to learn more!
+Have a look at our [JuliaCon 2020 presentation](https://youtu.be/IAF8DjrQSSk?t=1085) to learn more!
 """
 function save_notebook(io, notebook::Notebook)
     println(io, _notebook_header)

--- a/src/notebook/PathHelpers.jl
+++ b/src/notebook/PathHelpers.jl
@@ -1,14 +1,22 @@
 const adjectives = [
 	"groundbreaking"
+	"revolutionary"
 	"important"
 	"novel"
 	"fun"
 	"interesting"
 	"fascinating"
+	"exciting"
 	"surprising"
 	"remarkable"
 	"wonderful"
 	"stunning"
+	"mini"
+	"small"
+	"tiny"
+	"cute"
+	"friendly"
+	"wild"
 ]
 
 const nouns = [
@@ -24,6 +32,11 @@ const nouns = [
 	"invention"
 	"blueprint"
 	"report"
+	"science"
+	"magic"
+	"program"
+	"notes"
+	"lecture"
 ]
 
 function cutename()

--- a/src/notebook/PathHelpers.jl
+++ b/src/notebook/PathHelpers.jl
@@ -30,6 +30,18 @@ function cutename()
     titlecase(rand(adjectives)) * " " * rand(nouns)
 end
 
+function new_notebooks_directory()
+    try
+        path = joinpath(first(DEPOT_PATH), "pluto_notebooks")
+        if !isdir(path)
+            mkdir(path)
+        end
+        path
+    catch
+        homedir()
+    end
+end
+
 """
 Return `base` * `suffix` if the file does not exist yet.
 

--- a/src/notebook/PathHelpers.jl
+++ b/src/notebook/PathHelpers.jl
@@ -37,6 +37,9 @@ const nouns = [
 	"program"
 	"notes"
 	"lecture"
+	"theory"
+	"proof"
+	"conjecture"
 ]
 
 function cutename()

--- a/src/webserver/Session.jl
+++ b/src/webserver/Session.jl
@@ -121,7 +121,7 @@ function clientupdate_notebook_list(notebooks; initiator::Union{Initiator,Missin
                 Dict(
                     :notebook_id => notebook.notebook_id,
                     :path => notebook.path,
-                    :in_temp_dir => startswith(notebook.path, tempdir()),
+                    :in_temp_dir => startswith(notebook.path, new_notebooks_directory()),
                     :shortpath => basename(notebook.path)
                 ) for notebook in values(notebooks)
             ]

--- a/src/webserver/Static.jl
+++ b/src/webserver/Static.jl
@@ -112,7 +112,7 @@ function http_router_for(session::ServerSession)
         sample_path = HTTP.URIs.unescapeuri(split(uri.path, "sample/")[2])
         sample_path_without_dotjl = "sample " * sample_path[1:end - 3]
         
-        path = numbered_until_new(joinpath(tempdir(), sample_path_without_dotjl))
+        path = numbered_until_new(joinpath(new_notebooks_directory(), sample_path_without_dotjl))
         readwrite(project_relative_path("sample", sample_path), path)
         
         return try_launch_notebook_response(SessionActions.open, path, home_url="../", title="Failed to load sample", advice="Please <a href='https://github.com/fonsp/Pluto.jl/issues'>report this error</a>!")


### PR DESCRIPTION
BUT it's secret! 

It behaves exactly like before with `/tmp`: if your notebook is stored in `~/.julia/pluto_notebooks`, then it just asks you to `Save notebook...`, and when you click, the place where you launched Pluto is suggested as the new notebook's path, never showing you the old position.

# Why secret?
The issue got kind of stuck, and I feel like this is a good way to _at least_ make sure that less work gets lost, while changing as little as possible.

Ideally, we would split the file box into **path** and **filename**, and both would have an unspecified default.

![image](https://user-images.githubusercontent.com/6933510/93944791-f0025480-fd35-11ea-8146-ea682ad5119e.png)

![image](https://user-images.githubusercontent.com/6933510/93944944-3eafee80-fd36-11ea-9cd3-b581a6f365d2.png)

Fixes #265 