### PR TITLE
handle macro definitions in ExpressionExplorer.jl, closes #477

### DIFF
--- a/test/ExpressionExplorer.jl
+++ b/test/ExpressionExplorer.jl
@@ -294,6 +294,18 @@ using Test
         @test testee(:(md"a $(b = c) $(b)"), [:c], [:b], [Symbol("@md_str")], [])
         @test testee(:(md"\* $r"), [:r], [], [Symbol("@md_str")], [])
         @test testee(:(md"a \$(b = c)"), [], [], [Symbol("@md_str")], [])
+        @test testee(:(macro a() end), [], [], [], [
+            Symbol("@a") => ([], [], [], [])
+        ])
+        @test testee(:(macro a(b::Int); b end), [], [], [], [
+            Symbol("@a") => ([:Int], [], [], [])
+        ])
+        @test testee(:(macro a(b::Int=c) end), [], [], [], [
+            Symbol("@a") => ([:Int, :c], [], [], [])
+        ])
+        @test testee(:(macro a(); b = c; return b end), [], [], [], [
+            Symbol("@a") => ([:c], [], [], [])
+        ])
     end
     @testset "String interpolation & expressions" begin
         @test testee(:("a $b"), [:b], [], [], [])


### PR DESCRIPTION
This adds the handling of macro definitions almost like functions. The only difference is that it changes the macro name to be `Symbol("@name")` instead of just `:name` because calls to the macro will refer to `Symbol("@name")`.

#### Note
I am wondering if you can define macro with a name more complex than a single symbol :thinking: In this case, I need to consider a more robust solution.

Closes #477 