### PR TITLE
Adding and removing CodeMirror instance on-demand, i.e. depending on …

### DIFF
--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -285,13 +285,6 @@ export const CellInput = ({
         }
     }, [cm_forced_focus])
 
-    // if the CodeMirror initialized/changed while it was hidden, and it suddely became unhidden, we need to refresh it to fix a layout bug where the gutter takes no horizontal space.
-    useLayoutEffect(() => {
-        if (!is_hidden) {
-            cm_ref.current && cm_ref.current.refresh()
-        }
-    }, [is_hidden])
-
     // TODO effect hook for disable_input?
 
     return html`
@@ -299,7 +292,6 @@ export const CellInput = ({
             <button onClick=${on_delete} class="delete_cell" title="Delete cell"><span></span></button>
         </pluto-input>
     `
-    // TODO: confirm delete
 }
 
 const no_autocomplete = " \t\r\n([])+-=/,;'\"!#$%^&*~`<>|"

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -34,14 +34,13 @@ export const CellInput = ({
     const remote_code_ref = useRef(null)
     const change_handler_ref = useRef(null)
     change_handler_ref.current = on_change
-    const cm_enabled = !is_hidden
 
     useEffect(() => {
         remote_code_ref.current = remote_code
     }, [remote_code])
 
     useEffect(() => {
-        if(cm_enabled){
+        if (!is_hidden) {
             const cm = (cm_ref.current = window.CodeMirror(
                 (el) => {
                     dom_node_ref.current.appendChild(el)
@@ -70,7 +69,7 @@ export const CellInput = ({
             keys["Shift-Enter"] = () => on_submit(cm.getValue())
             keys["Ctrl-Enter"] = () => {
                 on_add_after()
-    
+
                 const new_value = cm.getValue()
                 if (new_value !== remote_code_ref.current.body) {
                     on_submit(new_value)
@@ -99,7 +98,7 @@ export const CellInput = ({
             }
             keys["Ctrl-/"] = () => {
                 const old_value = cm.getValue()
-                cm.toggleComment({indent: true})
+                cm.toggleComment({ indent: true })
                 const new_value = cm.getValue()
                 if (old_value === new_value) {
                     // the commenter failed for some reason
@@ -192,7 +191,7 @@ export const CellInput = ({
             }
             keys["Alt-Up"] = () => alt_move(-1)
             keys["Alt-Down"] = () => alt_move(+1)
-    
+
             keys["Backspace"] = keys["Ctrl-Backspace"] = () => {
                 if (cm.lineCount() === 1 && cm.getValue() === "") {
                     on_focus_neighbor(cell_id, -1)
@@ -209,9 +208,9 @@ export const CellInput = ({
                 }
                 return window.CodeMirror.Pass
             }
-    
+
             cm.setOption("extraKeys", map_cmd_to_ctrl_on_mac(keys))
-    
+
             cm.on("cursorActivity", () => {
                 if (cm.somethingSelected()) {
                     const sel = cm.getSelection()
@@ -231,7 +230,7 @@ export const CellInput = ({
                     }
                 }
             })
-    
+
             cm.on("change", () => {
                 const new_value = cm.getValue()
                 if (new_value.length > 1 && new_value[0] === "?") {
@@ -239,7 +238,7 @@ export const CellInput = ({
                 }
                 change_handler_ref.current(new_value)
             })
-    
+
             cm.on("blur", () => {
                 // NOT a debounce:
                 setTimeout(() => {
@@ -249,30 +248,25 @@ export const CellInput = ({
                     }
                 }, 100)
             })
-    
+
             if (focus_after_creation) {
                 cm.focus()
             }
-    
+
             document.fonts.ready.then(() => {
                 cm.refresh()
             })
+        } else {
+            if (cm_ref.current != null) {
+                const cm_wrapper = cm_ref.current.getWrapperElement()
+                cm_wrapper.parentNode.removeChild(cm_wrapper)
+                cm_ref.current = null
+            }
         }
-        else{
-            const cm = cm_ref.current
-
-            if (!cm) return
-
-            var cm_wrapper = cm.getWrapperElement()
-
-            cm_wrapper.parentNode.removeChild(cm_wrapper)
-
-            cm_ref.current = null
-        }
-    }, [cm_enabled])
+    }, [is_hidden])
 
     useEffect(() => {
-        if(cm_enabled){
+        if (!is_hidden) {
             if (!remote_code.submitted_by_me) {
                 cm_ref.current.setValue(remote_code.body)
             }
@@ -281,7 +275,7 @@ export const CellInput = ({
     }, [remote_code.timestamp])
 
     useEffect(() => {
-        if(cm_enabled){
+        if (!is_hidden) {
             if (cm_forced_focus == null) {
                 clear_selection(cm_ref.current)
             } else {

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -34,242 +34,260 @@ export const CellInput = ({
     const remote_code_ref = useRef(null)
     const change_handler_ref = useRef(null)
     change_handler_ref.current = on_change
+    const cm_enabled = !is_hidden
 
     useEffect(() => {
         remote_code_ref.current = remote_code
     }, [remote_code])
 
     useEffect(() => {
-        const cm = (cm_ref.current = window.CodeMirror(
-            (el) => {
-                dom_node_ref.current.appendChild(el)
-            },
-            {
-                value: remote_code.body,
-                lineNumbers: true,
-                mode: "julia",
-                lineWrapping: true,
-                viewportMargin: Infinity,
-                placeholder: "Enter cell code...",
-                indentWithTabs: true,
-                indentUnit: 4,
-                hintOptions: {
-                    hint: juliahints,
-                    client: client,
-                    notebook_id: notebook_id,
-                    on_update_doc_query: on_update_doc_query,
+        if(cm_enabled){
+            const cm = (cm_ref.current = window.CodeMirror(
+                (el) => {
+                    dom_node_ref.current.appendChild(el)
                 },
-                matchBrackets: true,
-            }
-        ))
-
-        const keys = {}
-
-        keys["Shift-Enter"] = () => on_submit(cm.getValue())
-        keys["Ctrl-Enter"] = () => {
-            on_add_after()
-
-            const new_value = cm.getValue()
-            if (new_value !== remote_code_ref.current.body) {
-                on_submit(new_value)
-            }
-        }
-        // Page up and page down are fn+Up and fn+Down on recent apple keyboards
-        keys["PageUp"] = () => {
-            on_focus_neighbor(cell_id, -1)
-        }
-        keys["PageDown"] = () => {
-            on_focus_neighbor(cell_id, +1)
-        }
-        keys["Shift-Tab"] = "indentLess"
-        keys["Tab"] = on_tab_key
-        keys["Ctrl-D"] = () => {
-            if (cm.somethingSelected()) {
-                const sels = cm.getSelections()
-                if (all_equal(sels)) {
-                    // TODO
+                {
+                    value: remote_code.body,
+                    lineNumbers: true,
+                    mode: "julia",
+                    lineWrapping: true,
+                    viewportMargin: Infinity,
+                    placeholder: "Enter cell code...",
+                    indentWithTabs: true,
+                    indentUnit: 4,
+                    hintOptions: {
+                        hint: juliahints,
+                        client: client,
+                        notebook_id: notebook_id,
+                        on_update_doc_query: on_update_doc_query,
+                    },
+                    matchBrackets: true,
                 }
-            } else {
-                const cursor = cm.getCursor()
-                const token = cm.getTokenAt(cursor)
-                cm.setSelection({ line: cursor.line, ch: token.start }, { line: cursor.line, ch: token.end })
+            ))
+
+            const keys = {}
+
+            keys["Shift-Enter"] = () => on_submit(cm.getValue())
+            keys["Ctrl-Enter"] = () => {
+                on_add_after()
+    
+                const new_value = cm.getValue()
+                if (new_value !== remote_code_ref.current.body) {
+                    on_submit(new_value)
+                }
             }
-        }
-        keys["Ctrl-/"] = () => {
-            const old_value = cm.getValue()
-            cm.toggleComment({indent: true})
-            const new_value = cm.getValue()
-            if (old_value === new_value) {
-                // the commenter failed for some reason
-                // this happens when lines start with `md"`, with no indent
-                cm.setValue(cm.lineCount() === 1 ? `# ${new_value}` : `#= ${new_value} =#`)
-                cm.execCommand("selectAll")
+            // Page up and page down are fn+Up and fn+Down on recent apple keyboards
+            keys["PageUp"] = () => {
+                on_focus_neighbor(cell_id, -1)
             }
-        }
-        keys["Ctrl-M"] = () => {
-            const value = cm.getValue()
-            const trimmed = value.trim()
-            const offset = value.length - value.trimStart().length
-            if (trimmed.startsWith('md"') && trimmed.endsWith('"')) {
-                // Markdown cell, change to code
-                let start, end
-                if (trimmed.startsWith('md"""') && trimmed.endsWith('"""')) {
-                    // Block markdown
-                    start = 5
-                    end = trimmed.length - 3
+            keys["PageDown"] = () => {
+                on_focus_neighbor(cell_id, +1)
+            }
+            keys["Shift-Tab"] = "indentLess"
+            keys["Tab"] = on_tab_key
+            keys["Ctrl-D"] = () => {
+                if (cm.somethingSelected()) {
+                    const sels = cm.getSelections()
+                    if (all_equal(sels)) {
+                        // TODO
+                    }
                 } else {
-                    // Inline markdown
-                    start = 3
-                    end = trimmed.length - 1
+                    const cursor = cm.getCursor()
+                    const token = cm.getTokenAt(cursor)
+                    cm.setSelection({ line: cursor.line, ch: token.start }, { line: cursor.line, ch: token.end })
                 }
-                if (start >= end || trimmed.substring(start, end).trim() == "") {
-                    // Corner case: block is empty after removing markdown
-                    cm.setValue("")
-                } else {
-                    while (/\s/.test(trimmed[start])) {
-                        ++start
-                    }
-                    while (/\s/.test(trimmed[end - 1])) {
-                        --end
-                    }
-                    // Keep the selection from [start, end) while maintaining cursor position
-                    cm.replaceRange("", cm.posFromIndex(end + offset), { line: cm.lineCount() })
-                    cm.replaceRange("", { line: 0, ch: 0 }, cm.posFromIndex(start + offset))
-                }
-            } else {
-                // Code cell, change to markdown
-                const old_selections = cm.listSelections()
-                cm.setValue(`md"""\n${value}\n"""`)
-                // Move all selections down a line
-                const new_selections = old_selections.map(({ anchor, head }) => {
-                    return {
-                        anchor: { ...anchor, line: anchor.line + 1 },
-                        head: { ...head, line: head.line + 1 },
-                    }
-                })
-                cm.setSelections(new_selections)
             }
-        }
-        const swap = (a, i, j) => {
-            ;[a[i], a[j]] = [a[j], a[i]]
-        }
-        const range = (a, b) => {
-            const x = Math.min(a, b)
-            const y = Math.max(a, b)
-            return [...Array(y + 1 - x).keys()].map((i) => i + x)
-        }
-        const alt_move = (delta) => {
-            const selections = cm.listSelections()
-            const selected_lines = new Set([].concat(...selections.map((sel) => range(sel.anchor.line, sel.head.line))))
-            const final_line_number = delta === 1 ? cm.lineCount() - 1 : 0
-            if (!selected_lines.has(final_line_number)) {
-                Array.from(selected_lines)
-                    .sort((a, b) => delta * a < delta * b)
-                    .forEach((line_number) => {
-                        const lines = cm.getValue().split("\n")
-                        swap(lines, line_number, line_number + delta)
-                        cm.setValue(lines.join("\n"))
-                        cm.indentLine(line_number + delta, "smart")
-                        cm.indentLine(line_number, "smart")
-                    })
-                cm.setSelections(
-                    selections.map((sel) => {
+            keys["Ctrl-/"] = () => {
+                const old_value = cm.getValue()
+                cm.toggleComment({indent: true})
+                const new_value = cm.getValue()
+                if (old_value === new_value) {
+                    // the commenter failed for some reason
+                    // this happens when lines start with `md"`, with no indent
+                    cm.setValue(cm.lineCount() === 1 ? `# ${new_value}` : `#= ${new_value} =#`)
+                    cm.execCommand("selectAll")
+                }
+            }
+            keys["Ctrl-M"] = () => {
+                const value = cm.getValue()
+                const trimmed = value.trim()
+                const offset = value.length - value.trimStart().length
+                if (trimmed.startsWith('md"') && trimmed.endsWith('"')) {
+                    // Markdown cell, change to code
+                    let start, end
+                    if (trimmed.startsWith('md"""') && trimmed.endsWith('"""')) {
+                        // Block markdown
+                        start = 5
+                        end = trimmed.length - 3
+                    } else {
+                        // Inline markdown
+                        start = 3
+                        end = trimmed.length - 1
+                    }
+                    if (start >= end || trimmed.substring(start, end).trim() == "") {
+                        // Corner case: block is empty after removing markdown
+                        cm.setValue("")
+                    } else {
+                        while (/\s/.test(trimmed[start])) {
+                            ++start
+                        }
+                        while (/\s/.test(trimmed[end - 1])) {
+                            --end
+                        }
+                        // Keep the selection from [start, end) while maintaining cursor position
+                        cm.replaceRange("", cm.posFromIndex(end + offset), { line: cm.lineCount() })
+                        cm.replaceRange("", { line: 0, ch: 0 }, cm.posFromIndex(start + offset))
+                    }
+                } else {
+                    // Code cell, change to markdown
+                    const old_selections = cm.listSelections()
+                    cm.setValue(`md"""\n${value}\n"""`)
+                    // Move all selections down a line
+                    const new_selections = old_selections.map(({ anchor, head }) => {
                         return {
-                            head: {
-                                line: sel.head.line + delta,
-                                ch: sel.head.ch,
-                            },
-                            anchor: {
-                                line: sel.anchor.line + delta,
-                                ch: sel.anchor.ch,
-                            },
+                            anchor: { ...anchor, line: anchor.line + 1 },
+                            head: { ...head, line: head.line + 1 },
                         }
                     })
-                )
-            }
-        }
-        keys["Alt-Up"] = () => alt_move(-1)
-        keys["Alt-Down"] = () => alt_move(+1)
-
-        keys["Backspace"] = keys["Ctrl-Backspace"] = () => {
-            if (cm.lineCount() === 1 && cm.getValue() === "") {
-                on_focus_neighbor(cell_id, -1)
-                on_delete()
-                console.log("backspace!")
-            }
-            return window.CodeMirror.Pass
-        }
-        keys["Delete"] = keys["Ctrl-Delete"] = () => {
-            if (cm.lineCount() === 1 && cm.getValue() === "") {
-                on_focus_neighbor(cell_id, +1)
-                on_delete()
-                console.log("delete!")
-            }
-            return window.CodeMirror.Pass
-        }
-
-        cm.setOption("extraKeys", map_cmd_to_ctrl_on_mac(keys))
-
-        cm.on("cursorActivity", () => {
-            if (cm.somethingSelected()) {
-                const sel = cm.getSelection()
-                if (!/[\s]/.test(sel)) {
-                    // no whitespace
-                    on_update_doc_query(sel)
-                }
-            } else {
-                const cursor = cm.getCursor()
-                const token = cm.getTokenAt(cursor)
-                if (token.start === 0 && token.type === "operator" && token.string === "?") {
-                    // https://github.com/fonsp/Pluto.jl/issues/321
-                    const second_token = cm.getTokenAt({ ...cursor, ch: 2 })
-                    on_update_doc_query(second_token.string)
-                } else if (token.type != null && token.type !== "string") {
-                    on_update_doc_query(module_expanded_selection(cm, token.string, cursor.line, token.start))
+                    cm.setSelections(new_selections)
                 }
             }
-        })
-
-        cm.on("change", () => {
-            const new_value = cm.getValue()
-            if (new_value.length > 1 && new_value[0] === "?") {
-                window.dispatchEvent(new CustomEvent("open_live_docs"))
+            const swap = (a, i, j) => {
+                ;[a[i], a[j]] = [a[j], a[i]]
             }
-            change_handler_ref.current(new_value)
-        })
-
-        cm.on("blur", () => {
-            // NOT a debounce:
-            setTimeout(() => {
-                if (document.hasFocus()) {
-                    clear_selection(cm)
-                    set_cm_forced_focus(null)
+            const range = (a, b) => {
+                const x = Math.min(a, b)
+                const y = Math.max(a, b)
+                return [...Array(y + 1 - x).keys()].map((i) => i + x)
+            }
+            const alt_move = (delta) => {
+                const selections = cm.listSelections()
+                const selected_lines = new Set([].concat(...selections.map((sel) => range(sel.anchor.line, sel.head.line))))
+                const final_line_number = delta === 1 ? cm.lineCount() - 1 : 0
+                if (!selected_lines.has(final_line_number)) {
+                    Array.from(selected_lines)
+                        .sort((a, b) => delta * a < delta * b)
+                        .forEach((line_number) => {
+                            const lines = cm.getValue().split("\n")
+                            swap(lines, line_number, line_number + delta)
+                            cm.setValue(lines.join("\n"))
+                            cm.indentLine(line_number + delta, "smart")
+                            cm.indentLine(line_number, "smart")
+                        })
+                    cm.setSelections(
+                        selections.map((sel) => {
+                            return {
+                                head: {
+                                    line: sel.head.line + delta,
+                                    ch: sel.head.ch,
+                                },
+                                anchor: {
+                                    line: sel.anchor.line + delta,
+                                    ch: sel.anchor.ch,
+                                },
+                            }
+                        })
+                    )
                 }
-            }, 100)
-        })
-
-        if (focus_after_creation) {
-            cm.focus()
+            }
+            keys["Alt-Up"] = () => alt_move(-1)
+            keys["Alt-Down"] = () => alt_move(+1)
+    
+            keys["Backspace"] = keys["Ctrl-Backspace"] = () => {
+                if (cm.lineCount() === 1 && cm.getValue() === "") {
+                    on_focus_neighbor(cell_id, -1)
+                    on_delete()
+                    console.log("backspace!")
+                }
+                return window.CodeMirror.Pass
+            }
+            keys["Delete"] = keys["Ctrl-Delete"] = () => {
+                if (cm.lineCount() === 1 && cm.getValue() === "") {
+                    on_focus_neighbor(cell_id, +1)
+                    on_delete()
+                    console.log("delete!")
+                }
+                return window.CodeMirror.Pass
+            }
+    
+            cm.setOption("extraKeys", map_cmd_to_ctrl_on_mac(keys))
+    
+            cm.on("cursorActivity", () => {
+                if (cm.somethingSelected()) {
+                    const sel = cm.getSelection()
+                    if (!/[\s]/.test(sel)) {
+                        // no whitespace
+                        on_update_doc_query(sel)
+                    }
+                } else {
+                    const cursor = cm.getCursor()
+                    const token = cm.getTokenAt(cursor)
+                    if (token.start === 0 && token.type === "operator" && token.string === "?") {
+                        // https://github.com/fonsp/Pluto.jl/issues/321
+                        const second_token = cm.getTokenAt({ ...cursor, ch: 2 })
+                        on_update_doc_query(second_token.string)
+                    } else if (token.type != null && token.type !== "string") {
+                        on_update_doc_query(module_expanded_selection(cm, token.string, cursor.line, token.start))
+                    }
+                }
+            })
+    
+            cm.on("change", () => {
+                const new_value = cm.getValue()
+                if (new_value.length > 1 && new_value[0] === "?") {
+                    window.dispatchEvent(new CustomEvent("open_live_docs"))
+                }
+                change_handler_ref.current(new_value)
+            })
+    
+            cm.on("blur", () => {
+                // NOT a debounce:
+                setTimeout(() => {
+                    if (document.hasFocus()) {
+                        clear_selection(cm)
+                        set_cm_forced_focus(null)
+                    }
+                }, 100)
+            })
+    
+            if (focus_after_creation) {
+                cm.focus()
+            }
+    
+            document.fonts.ready.then(() => {
+                cm.refresh()
+            })
         }
+        else{
+            const cm = cm_ref.current
 
-        document.fonts.ready.then(() => {
-            cm.refresh()
-        })
-    }, [])
+            if (!cm) return
+
+            var cm_wrapper = cm.getWrapperElement()
+
+            cm_wrapper.parentNode.removeChild(cm_wrapper)
+
+            cm_ref.current = null
+        }
+    }, [cm_enabled])
 
     useEffect(() => {
-        if (!remote_code.submitted_by_me) {
-            cm_ref.current.setValue(remote_code.body)
+        if(cm_enabled){
+            if (!remote_code.submitted_by_me) {
+                cm_ref.current.setValue(remote_code.body)
+            }
+            cm_ref.current.options.disableInput = disable_input
         }
-        cm_ref.current.options.disableInput = disable_input
     }, [remote_code.timestamp])
 
     useEffect(() => {
-        if (cm_forced_focus == null) {
-            clear_selection(cm_ref.current)
-        } else {
-            cm_ref.current.focus()
-            cm_ref.current.setSelection(...cm_forced_focus)
+        if(cm_enabled){
+            if (cm_forced_focus == null) {
+                clear_selection(cm_ref.current)
+            } else {
+                cm_ref.current.focus()
+                cm_ref.current.setSelection(...cm_forced_focus)
+            }
         }
     }, [cm_forced_focus])
 


### PR DESCRIPTION
…the visibility of a cell - #291.

Hi all,

I took on the enhancement in #291 by only creating the CodeMirror instance if a cell is hidden (folded) and deleting the instance upon folding/hiding the cell. 

I introduced a new boolean called cm_enabled that is basically !is_hidden, but allows to later add more conditions (e.g. "is cell visible on screen" - that was probably meant by viewport, right?).

The general idea is then to, instead of as before running the effect hook that set up the CodeMirror only with initial values, re-run the effect hook everytime cm_enabled changes and to wrap everything else that requires the instance into an IF that checks for cm_enabled.

This is my first contribution to this project and I hope you like it - if you have any suggestions or concerns, I'd be happy to discuss. 

If this first step is done, I'd be happy to also take on the viewport-idea.