### PR TITLE
fix running nothing

### DIFF
--- a/src/evaluation/Run.jl
+++ b/src/evaluation/Run.jl
@@ -72,7 +72,7 @@ function run_reactive!(session::ServerSession, notebook::Notebook, old_topology:
 
 		if any_interrupted
 			relay_reactivity_error!(cell, InterruptException())
-		else
+		elseif cell.parsedcode !== nothing
 			run = run_single!((session, notebook), cell)
 			any_interrupted |= run.interrupted
 		end


### PR DESCRIPTION
`nothing` is a valid expression will freeze Pluto in some cases. Because `eval_format_fetch_in_workspace` does not handle it.

```julia
MethodError: no method matching eval_format_fetch_in_workspace(::Tuple{Pluto.ServerSession,Pluto.Notebook}, ::Nothing, ::Base.UUID, ::Bool)
Closest candidates are:
  eval_format_fetch_in_workspace(::Union{Tuple{Pluto.ServerSession,Pluto.Notebook}, Pluto.WorkspaceManager.Workspace}, ::Expr, ::Base.UUID, ::Bool) at /home/leo/.julia/dev/Pluto/src/evaluation/WorkspaceManager.jl:195
  eval_format_fetch_in_workspace(::Union{Tuple{Pluto.ServerSession,Pluto.Notebook}, Pluto.WorkspaceManager.Workspace}, ::Expr, ::Base.UUID) at /home/leo/.julia/dev/Pluto/src/evaluation/WorkspaceManager.jl:195
Stacktrace:
 [1] run_single!(::Tuple{Pluto.ServerSession,Pluto.Notebook}, ::Pluto.Cell) at /home/leo/.julia/dev/Pluto/src/evaluation/Run.jl:91
 [2] run_reactive!(::Pluto.ServerSession, ::Pluto.Notebook, ::Pluto.NotebookTopology, ::Pluto.NotebookTopology, ::Array{Pluto.Cell,1}; deletion_hook::Function) at /home/leo/.julia/dev/Pluto/src/evaluation/Run.jl:76
 [3] macro expansion at /home/leo/.julia/dev/Pluto/src/evaluation/Run.jl:12 [inlined]
 [4] (::Pluto.var"#71#73"{Base.Iterators.Pairs{Symbol,Pluto.var"#custom_deletion_hook#185"{Pluto.var"#custom_deletion_hook#183#186"{Symbol,String}},Tuple{Symbol},NamedTuple{(:deletion_hook,),Tuple{Pluto.var"#custom_deletion_hook#185"{Pluto.var"#custom_deletion_hook#183#186"{Symbol,String}}}}},Pluto.ServerSession,Pluto.Notebook,Pluto.NotebookTopology,Pluto.NotebookTopology,Array{Pluto.Cell,1}})() at ./task.jl:356
```

@fonsp Since numbers and strings are also valid expressions, do you know how to handle it better?