### PR TITLE
📜 Logging tweaks and fixes

### DIFF
--- a/frontend/common/Logging.js
+++ b/frontend/common/Logging.js
@@ -6,7 +6,7 @@ const log_functions = {
 }
 
 export const handle_log = ({ level, msg, file, line, kwargs }, filename) => {
-    const f = log_functions[level]
+    const f = log_functions[level] || console.log
     const args = [`%c┌ ${level}:\n`, `font-weight: bold`, msg]
     if (Object.keys(kwargs).length !== 0) {
         args.push(kwargs)

--- a/frontend/common/Logging.js
+++ b/frontend/common/Logging.js
@@ -11,21 +11,11 @@ export const handle_log = ({ level, msg, file, line, kwargs }, filename) => {
     if (Object.keys(kwargs).length !== 0) {
         args.push(kwargs)
     }
-
     if (file.startsWith(filename)) {
         const cell_id = file.substring(file.indexOf("#==#") + 4)
         const cell_node = document.getElementById(cell_id)
 
-        // hacky hackkkkkk
-        const cm_internal_node = cell_node.querySelector(".CodeMirror-code")
-        const origin_line = cm_internal_node.children[line - 1]
-
-        args.push(`\n\nfrom`)
-        if (origin_line == null) {
-            args.push(cell_node)
-        } else {
-            args.push(origin_line)
-        }
+        args.push(`\n\nfrom`, cell_node)
     }
     f(...args)
 }

--- a/src/evaluation/WorkspaceManager.jl
+++ b/src/evaluation/WorkspaceManager.jl
@@ -69,6 +69,9 @@ function start_relaying_logs((session, notebook)::Tuple{ServerSession, Notebook}
             next_log = take!(log_channel)
             putnotebookupdates!(session, notebook, UpdateMessage(:log, next_log, notebook))
         catch e
+            if !isopen(log_channel)
+                break
+            end
             @error "Failed to relay log" exception=(e, catch_backtrace())
         end
     end

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -704,7 +704,12 @@ const old_logger = Ref{Any}(nothing)
 
 struct PlutoLogger <: Logging.AbstractLogger end
 
-Logging.shouldlog(::PlutoLogger, args...) = true
+function Logging.shouldlog(::PlutoLogger, level, _module, _...)
+    # Accept logs
+    # - From the user's workspace module
+    # - Info level and above for other modules
+    _module === current_module || convert(Logging.LogLevel, level) >= Logging.Info
+end
 Logging.min_enabled_level(::PlutoLogger) = Logging.Debug
 Logging.catch_exceptions(::PlutoLogger) = false
 function Logging.handle_message(::PlutoLogger, level, msg, _module, group, id, file, line; kwargs...)


### PR DESCRIPTION
* Prevent frontend from crashing with unknown log levels
  (eg ProgressLogging.@-progress)
* Avoid spamming the user with infinite log relay errors once the remote
  log channel is closed
* Only relay info-and-above-level logs from third party modules, to
  prevent excessive debug level log spam.

Fixes a few problems I found while testing #496 