### PR TITLE
Use powershell instead of cmd to launch browser on Windows/WSL

### DIFF
--- a/src/webserver/WebServer.jl
+++ b/src/webserver/WebServer.jl
@@ -36,7 +36,7 @@ function open_in_default_browser(url::AbstractString)::Bool
             Base.run(`open $url`)
             true
         elseif Sys.iswindows() || detectwsl()
-            Base.run(`cmd.exe /s /c start "" /b $url`)
+            Base.run(`powershell.exe Start $url`)
             true
         elseif Sys.islinux()
             Base.run(`xdg-open $url`)


### PR DESCRIPTION
`cmd` cannot deal with UNC paths when executed from WSL:

![wsl_error](https://user-images.githubusercontent.com/4435990/94839446-4dbe2d00-0417-11eb-839c-354d70cd4621.jpg)

But `powershell` can! Since it ships with every Windows version >= Windows 7 SP1 || Windows server 2008, I'd say it's a safe replacement.