### PR TITLE
Handle parametric type assignments, closes #517

### DIFF
--- a/src/analysis/ExpressionExplorer.jl
+++ b/src/analysis/ExpressionExplorer.jl
@@ -282,12 +282,19 @@ function explore!(ex::Expr, scopestate::ScopeState)::SymbolsState
             # function f(x, y) x + y end
             return explore!(Expr(:function, ex.args...), scopestate)
         end
-        assignees = get_assignees(ex.args[1])
+
         val = ex.args[2]
+        # Handle generic types assignments A{B} = C{B, Int}
+        if ex.args[1] isa Expr && ex.args[1].head == :curly
+            assignees, symstate = explore_funcdef!(ex.args[1], scopestate)
+            innersymstate = union!(symstate, explore!(val, scopestate))
+        else
+            assignees = get_assignees(ex.args[1])
+            symstate = innersymstate = explore!(val, scopestate)
+        end
 
         global_assignees = get_global_assignees(assignees, scopestate)
-        
-        symstate = innersymstate = explore!(val, scopestate)
+
         # If we are _not_ assigning a global variable, then this symbol hides any global definition with that name
         push!(scopestate.hiddenglobals, setdiff(assignees, global_assignees)...)
         assigneesymstate = explore!(ex.args[1], scopestate)

--- a/test/ExpressionExplorer.jl
+++ b/test/ExpressionExplorer.jl
@@ -40,6 +40,9 @@ using Test
         @test testee(:(Foo[]), [:Foo], [], [], [])
         @test testee(:(x isa Foo), [:x, :Foo], [], [:isa], [])
 
+        @test testee(:(A{B} = B), [], [:A], [], [])
+        @test testee(:(A{T} = Union{T, Int}), [:Int, :Union], [:A], [], [])
+
         @test testee(:(abstract type a end), [], [], [], [:a => ([], [], [], [])])
         @test testee(:(abstract type a <: b end), [], [], [], [:a => ([:b], [], [], [])])
         @test testee(:(abstract type a <: b{C} end), [], [], [], [:a => ([:b, :C], [], [], [])])


### PR DESCRIPTION
Hi! This PR fixes the assignments of parametric types as disclosed in #517. For these, I did two things:
 1. The warning was fixed by handling these types of assignments and by constructing the references (https://github.com/Pangoraw/Pluto.jl/commit/d29df8d3f2271e5745cdbe0cba35296c4da05aba)
 2. The error was due to the fact that `julia` is trying to use the generic type as a normal type when we use an expression like this: `local result = $(expr)` as in Pluto's runner. The solution was to wrap the assignment in a `const` (a `begin` would also work) expression (https://github.com/Pangoraw/Pluto.jl/commit/fab4715b0abfc8ff99986c28f775d51fff3b4a5d).
###### Without `const`
```julia
julia> local result = (Nullable{T} = Union{T, Nothing})
ERROR: UndefVarError: T not defined
Stacktrace:
 [1] top-level scope at REPL[1]:1
 [2] run_repl(::REPL.AbstractREPL, ::Any) at /build/julia/src/julia-1.5.1/usr/share/julia/stdlib/v1.5/REPL/src/REPL.jl:288
```
###### With `const`
```julia
julia> local result = (const Nullable{T} = Union{T, Nothing})
Union{Nothing, T} where T
```
