### PR TITLE
Bugfix: Delete button not working on feedback field etc. (inputs)

### DIFF
--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -677,6 +677,7 @@ export class Editor extends Component {
             const selected = this.state.notebook.cells.filter((c) => c.selected)
             if (selected.length > 0) {
                 this.requests.confirm_delete_multiple(verb, selected)
+                return true
             }
         }
 
@@ -695,7 +696,9 @@ export class Editor extends Component {
                 }
                 e.preventDefault()
             } else if (e.key === "Backspace" || e.key === "Delete") {
-                this.delete_selected("Delete")
+                if(this.delete_selected("Delete")){
+                  e.preventDefault()
+                }
 
             } else if ((e.key === "?" && has_ctrl_or_cmd_pressed(e)) || e.key === "F1") {
                 // On mac "cmd+shift+?" is used by chrome, so that is why this needs to be ctrl as well on mac
@@ -703,7 +706,7 @@ export class Editor extends Component {
                 // I hope we can find a better solution for this later - Dral
                 alert(
                     `Shortcuts 🎹
-    
+
     Shift+Enter:   run cell
     ${ctrl_or_cmd_name}+Enter:   run cell and add cell below
     Delete or Backspace:   delete empty cell

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -696,7 +696,7 @@ export class Editor extends Component {
                 e.preventDefault()
             } else if (e.key === "Backspace" || e.key === "Delete") {
                 this.delete_selected("Delete")
-                e.preventDefault()
+
             } else if ((e.key === "?" && has_ctrl_or_cmd_pressed(e)) || e.key === "F1") {
                 // On mac "cmd+shift+?" is used by chrome, so that is why this needs to be ctrl as well on mac
                 // Also pressing "ctrl+shift" on mac causes the key to show up as "/", this madness


### PR DESCRIPTION
Hi,

I've noticed that due to a recent commit the backspace/delete key would not delete text in html-inputs (e.g. instant feedback). I removed the ```e.preventDefault()```that caused this.

Commit that caused it: https://github.com/fonsp/Pluto.jl/commit/1180226ff997001105200cad151f4cdb18795cdf by @ekzhang @fonsp.

My solution is possibly not the best way to do this, but at least it would fix the bug for now.

Do we need the ```preventDefault```altogether?

Greetings ☺️