### PR TITLE
Ligatures

### DIFF
--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -1622,4 +1622,3 @@ pluto-input:focus-within .cm-s-default .CodeMirror-matchingbracket {
     color: rgba(0, 0, 0, 0.2);
     font-style: italic;
 }
-}

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -65,15 +65,6 @@ pluto-notebook {
     display: block;
 }
 
-pluto-notebook .CodeMirror pre.CodeMirror-line,
-pluto-notebook .CodeMirror pre.CodeMirror-line-like {
-  font-variant-ligatures: none;
-}
-
-.cm-operator {
-    font-variant-ligatures: var(--pluto-operator-ligatures);
-}
-
 /* STANDARD HTML ELEMENTS */
 
 /* (can be overriden by custom style) */
@@ -1616,6 +1607,15 @@ pluto-input:focus-within .cm-s-default .CodeMirror-matchingbracket {
     font-weight: 700;
     background-color: #1b4bbb21;
     border-radius: 2px;
+}
+
+pluto-notebook .CodeMirror pre.CodeMirror-line,
+pluto-notebook .CodeMirror pre.CodeMirror-line-like {
+  font-variant-ligatures: none;
+}
+
+.cm-operator {
+    font-variant-ligatures: var(--pluto-operator-ligatures);
 }
 
 .cm-s-default.CodeMirror-empty {

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -8,12 +8,9 @@
 
 :root {
     --pluto-cell-spacing: 17px;
-    /* use the value "contextual" to enable contextual ligatures
-        for julia mono see here: https://cormullion.github.io/pages/2020-07-26-JuliaMono/#contextual_and_stylistic_alternates_and_ligatures
-    */
-    --font-variant-ligatures: none;
-    /* e.g. "zero", "ss05"; Also see link above for options */
-    --font-feature-settings: off;
+    /* use the value "contextual" to enable contextual ligatures `document.documentElement.style.setProperty('--pluto-operator-ligatures', 'contextual');`
+        for julia mono see here: https://cormullion.github.io/pages/2020-07-26-JuliaMono/#contextual_and_stylistic_alternates_and_ligatures */
+    --pluto-operator-ligatures: none;
 }
 
 /* GENERAL PAGE LAYOUT */
@@ -70,9 +67,11 @@ pluto-notebook {
 
 pluto-notebook .CodeMirror pre.CodeMirror-line,
 pluto-notebook .CodeMirror pre.CodeMirror-line-like {
+  font-variant-ligatures: none;
+}
 
-  font-variant-ligatures: var(--font-variant-ligatures);
-  font-feature-settings: var(--font-feature-settings);
+.cm-operator {
+    font-variant-ligatures: var(--pluto-operator-ligatures);
 }
 
 /* STANDARD HTML ELEMENTS */

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -8,6 +8,12 @@
 
 :root {
     --pluto-cell-spacing: 17px;
+    /* use the value "contextual" to enable contextual ligatures
+        for julia mono see here: https://cormullion.github.io/pages/2020-07-26-JuliaMono/#contextual_and_stylistic_alternates_and_ligatures
+    */
+    --font-variant-ligatures: none;
+    /* e.g. "zero", "ss05"; Also see link above for options */
+    --font-feature-settings: off;
 }
 
 /* GENERAL PAGE LAYOUT */
@@ -60,6 +66,13 @@ main {
 
 pluto-notebook {
     display: block;
+}
+
+pluto-notebook .CodeMirror pre.CodeMirror-line,
+pluto-notebook .CodeMirror pre.CodeMirror-line-like {
+
+  font-variant-ligatures: var(--font-variant-ligatures);
+  font-feature-settings: var(--font-feature-settings);
 }
 
 /* STANDARD HTML ELEMENTS */
@@ -1609,4 +1622,5 @@ pluto-input:focus-within .cm-s-default .CodeMirror-matchingbracket {
 .cm-s-default.CodeMirror-empty {
     color: rgba(0, 0, 0, 0.2);
     font-style: italic;
+}
 }

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -1472,6 +1472,11 @@ ul.CodeMirror-hints {
     color: #41323f;
 }
 
+.cm-s-default.CodeMirror pre.CodeMirror-line,
+.cm-s-default.CodeMirror pre.CodeMirror-line-like {
+    font-variant-ligatures: none;
+}
+
 .cm-s-default div.CodeMirror-selected {
     background: #d9dfef;
 }
@@ -1558,6 +1563,10 @@ pluto-cell.code_differs .cm-s-default .CodeMirror-gutters {
     color: #ce7d0a;
 }
 
+.cm-s-default span.cm-operator {
+    font-variant-ligatures: var(--pluto-operator-ligatures);
+}
+
 pluto-output > assignee,
 .cm-s-default span.cm-variable {
     color: #5668a4;
@@ -1607,15 +1616,6 @@ pluto-input:focus-within .cm-s-default .CodeMirror-matchingbracket {
     font-weight: 700;
     background-color: #1b4bbb21;
     border-radius: 2px;
-}
-
-pluto-notebook .CodeMirror pre.CodeMirror-line,
-pluto-notebook .CodeMirror pre.CodeMirror-line-like {
-  font-variant-ligatures: none;
-}
-
-.cm-operator {
-    font-variant-ligatures: var(--pluto-operator-ligatures);
 }
 
 .cm-s-default.CodeMirror-empty {

--- a/frontend/juliamono.css
+++ b/frontend/juliamono.css
@@ -1,12 +1,5 @@
 @font-face {
     font-family: JuliaMono;
-    src: url("https://cdn.jsdelivr.net/gh/cormullion/juliamono@0.017/webfonts/JuliaMono-Regular.woff2") format("woff2");
-    font-display: swap;
-    font-weight: 400;
-}
-
-@font-face {
-    font-family: JuliaMono;
     src: url("https://cdn.jsdelivr.net/gh/cormullion/juliamono@0.017/webfonts/JuliaMono-RegularLatin.woff2") format("woff2");
     font-display: swap;
     font-weight: 400;
@@ -15,15 +8,22 @@
 
 @font-face {
     font-family: JuliaMono;
-    src: url("https://cdn.jsdelivr.net/gh/cormullion/juliamono@0.017/webfonts/JuliaMono-Bold.woff2") format("woff2");
-    font-display: swap;
-    font-weight: 700;
-}
-
-@font-face {
-    font-family: JuliaMono;
     src: url("https://cdn.jsdelivr.net/gh/cormullion/juliamono@0.017/webfonts/JuliaMono-BoldLatin.woff2") format("woff2");
     font-display: swap;
     font-weight: 700;
     unicode-range: U+00-7F; /* Basic Latin characters */
+}
+
+@font-face {
+    font-family: JuliaMono;
+    src: url("https://cdn.jsdelivr.net/gh/cormullion/juliamono@0.017/webfonts/JuliaMono-Regular.woff2") format("woff2");
+    font-display: swap;
+    font-weight: 400;
+}
+
+@font-face {
+    font-family: JuliaMono;
+    src: url("https://cdn.jsdelivr.net/gh/cormullion/juliamono@0.017/webfonts/JuliaMono-Bold.woff2") format("woff2");
+    font-display: swap;
+    font-weight: 700;
 }


### PR DESCRIPTION
This is a fix for [Pluto frontend doesn't display ligature fonts despite using JuliaMono #584
](https://github.com/fonsp/Pluto.jl/issues/584)

The font loading order load the main font first, then loads the minifed (latin only) font that seems to override the first one (that has the ligatures).

First off, reading the css, I understand the _intent_ of the code is to prodive ligatures, since `.Codemirror.css`'s setting of `font-variant-ligatures: contextual;` is not overriden. 

Both the [author ](https://cormullion.github.io/pages/2020-07-26-JuliaMono/#fnref:nottheonlyone) of the font and [this guy](https://practicaltypography.com/ligatures-in-programming-fonts-hell-no.html) disagree with ligatures in general.

This fix enables the contextual ligatures
![image](https://user-images.githubusercontent.com/8681967/96506007-9707dc80-125f-11eb-8f09-f046b1064841.png)

but not the alternative ligatures
![image](https://user-images.githubusercontent.com/8681967/96506088-b30b7e00-125f-11eb-9c6c-1094bb256313.png)
as it just fixes the loading order.

Personal opinion, the slashed zero and the simple star look really cool.
It can be enabed with the `font-feature-settings: "zero", "ss05";` property (which is not part of this PR)