### PR TITLE
FAQ link location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+<h1><img alt="Pluto.jl" src="https://raw.githubusercontent.com/fonsp/Pluto.jl/master/frontend/img/logo.svg" width=300 height=74 ></h1>
+
+The **Pluto.jl** [Julia](https://julialang.org) package allows you to create and share Pluto _notebooks_: documents that contain live Julia code, equations, plots, visualizations and narrative text. Pluto notebooks are **_reactive_**, **_lightweight_**, and **_simple_**. <!-- borrowing a bit from text at https://jupyter.org.. -->
+
+
+[![FAQ](https://img.shields.io/badge/docs-latest-blue.svg)](https://github.com/fonsp/Pluto.jl/wiki) <!-- | -->
+
 > _Interested in learning Julia, Pluto and applied maths?_ Join the **open MIT course** taught by **Alan Edelman**, **David P. Sanders**, Grant Sanderson (**3blue1brown**) & James Schloss (**LeiosOS**) (_and a bit of me_): [Introduction to Computational Thinking](https://mitmath.github.io/18S191/Fall20/), fall 2020.
 > <br>
 
@@ -5,10 +12,6 @@
 
 <br>
 <br>
-
-<h1><img alt="Pluto.jl" src="https://raw.githubusercontent.com/fonsp/Pluto.jl/master/frontend/img/logo.svg" width=300 height=74 ></h1>
-
-Questions? Have a look at the [FAQ](https://github.com/fonsp/Pluto.jl/wiki).
 
 _Writing a notebook is not just about writing the final document — Pluto empowers the experiments and discoveries that are essential to getting there._
 
@@ -101,6 +104,8 @@ julia> Pluto.run()
 ```
 
 Pluto will open in your browser, and you can get started!
+
+Questions? Have a look at the [FAQ](https://github.com/fonsp/Pluto.jl/wiki).
 
 ### To developers
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 <h1><img alt="Pluto.jl" src="https://raw.githubusercontent.com/fonsp/Pluto.jl/master/frontend/img/logo.svg" width=300 height=74 ></h1>
 
+Questions? Have a look at the [FAQ](https://github.com/fonsp/Pluto.jl/wiki).
+
 _Writing a notebook is not just about writing the final document — Pluto empowers the experiments and discoveries that are essential to getting there._
 
 **Explore models and share results** in a notebook that is
@@ -138,6 +140,5 @@ The Pluto project is an ambition to [_rethink what a programming environment sho
 
 <img alt="feedback screencap" src="https://user-images.githubusercontent.com/6933510/84502876-6f08db00-acb9-11ea-84c3-f5daaba29273.png" width="100%">
 
-Questions? Have a look at the [FAQ](https://github.com/fonsp/Pluto.jl/wiki).
 
 _Created by [**Fons van der Plas**](https://github.com/fonsp) and [**Mikołaj Bochenski**](https://github.com/malyvsen). Inspired by [Observable](https://observablehq.com/)._

--- a/README.md
+++ b/README.md
@@ -1,10 +1,3 @@
-<h1><img alt="Pluto.jl" src="https://raw.githubusercontent.com/fonsp/Pluto.jl/master/frontend/img/logo.svg" width=300 height=74 ></h1>
-
-The **Pluto.jl** [Julia](https://julialang.org) package allows you to create and share Pluto _notebooks_: documents that contain live Julia code, equations, plots, visualizations and narrative text. Pluto notebooks are **_reactive_**, **_lightweight_**, and **_simple_**. <!-- borrowing a bit from text at https://jupyter.org.. -->
-
-
-[![FAQ](https://img.shields.io/badge/docs-latest-blue.svg)](https://github.com/fonsp/Pluto.jl/wiki) <!-- | -->
-
 > _Interested in learning Julia, Pluto and applied maths?_ Join the **open MIT course** taught by **Alan Edelman**, **David P. Sanders**, Grant Sanderson (**3blue1brown**) & James Schloss (**LeiosOS**) (_and a bit of me_): [Introduction to Computational Thinking](https://mitmath.github.io/18S191/Fall20/), fall 2020.
 > <br>
 
@@ -12,6 +5,10 @@ The **Pluto.jl** [Julia](https://julialang.org) package allows you to create and
 
 <br>
 <br>
+
+<h1><img alt="Pluto.jl" src="https://raw.githubusercontent.com/fonsp/Pluto.jl/master/frontend/img/logo.svg" width=300 height=74 ></h1>
+
+Questions? Have a look at the [FAQ](https://github.com/fonsp/Pluto.jl/wiki).
 
 _Writing a notebook is not just about writing the final document — Pluto empowers the experiments and discoveries that are essential to getting there._
 
@@ -104,8 +101,6 @@ julia> Pluto.run()
 ```
 
 Pluto will open in your browser, and you can get started!
-
-Questions? Have a look at the [FAQ](https://github.com/fonsp/Pluto.jl/wiki).
 
 ### To developers
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 
 <h1><img alt="Pluto.jl" src="https://raw.githubusercontent.com/fonsp/Pluto.jl/master/frontend/img/logo.svg" width=300 height=74 ></h1>
 
-Questions? Have a look at the [FAQ](https://github.com/fonsp/Pluto.jl/wiki).
-
 _Writing a notebook is not just about writing the final document — Pluto empowers the experiments and discoveries that are essential to getting there._
 
 **Explore models and share results** in a notebook that is
@@ -102,6 +100,8 @@ julia> Pluto.run()
 
 Pluto will open in your browser, and you can get started!
 
+Questions? Have a look at the [FAQ](https://github.com/fonsp/Pluto.jl/wiki).
+
 ### To developers
 
 Follow [these instructions](https://github.com/fonsp/Pluto.jl/blob/master/CONTRIBUTING.md) to start working on the package.
@@ -140,5 +140,6 @@ The Pluto project is an ambition to [_rethink what a programming environment sho
 
 <img alt="feedback screencap" src="https://user-images.githubusercontent.com/6933510/84502876-6f08db00-acb9-11ea-84c3-f5daaba29273.png" width="100%">
 
+Questions? Have a look at the [FAQ](https://github.com/fonsp/Pluto.jl/wiki).
 
 _Created by [**Fons van der Plas**](https://github.com/fonsp) and [**Mikołaj Bochenski**](https://github.com/malyvsen). Inspired by [Observable](https://observablehq.com/)._


### PR DESCRIPTION
Move the FAQ link up "above the fold" where it is easier to find, consistent with where one would usually find a documentation badge.