### PR TITLE
Actually show the event that errored in the alert box

### DIFF
--- a/frontend/common/PlutoConnection.js
+++ b/frontend/common/PlutoConnection.js
@@ -131,7 +131,7 @@ const create_ws_connection = (address, { on_message, on_socket_close }, timeout_
                     console.log(event)
 
                     alert(
-                        `Something went wrong!\n\nPlease open an issue on https://github.com/fonsp/Pluto.jl with this info:\n\nFailed to process update\n${ex}\n\n${event}`
+                        `Something went wrong!\n\nPlease open an issue on https://github.com/fonsp/Pluto.jl with this info:\n\nFailed to process update\n${ex}\n\n${JSON.stringify(event)}`
                     )
                 }
             })


### PR DESCRIPTION
JavaScript is not very smart at stringifying objects, so we get things like in #593 (which isn't that helpful). but `JSON.stringify`'ing the object does display it!