### PR TITLE
Implement duplicate line

### DIFF
--- a/frontend/common/KeyboardShortcuts.js
+++ b/frontend/common/KeyboardShortcuts.js
@@ -1,6 +1,7 @@
 export let is_mac_keyboard = /Mac/.test(navigator.platform)
 
-export let ctrl_or_cmd_name = is_mac_keyboard ? "Cmd" : "Ctrl"
+export let ctrl_or_cmd_name = is_mac_keyboard ? "⌘" : "Ctrl"
+export let alt_or_option_name = is_mac_keyboard ? "⌥" : "Alt"
 
 export let has_ctrl_or_cmd_pressed = (event) => event.ctrlKey || (is_mac_keyboard && event.metaKey)
 

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -153,6 +153,23 @@ export const CellInput = ({
                     cm.setSelections(new_selections)
                 }
             }
+            keys["Ctrl-Alt-Down"] = () => {
+                console.log("K");
+                // based on https://stackoverflow.com/a/53865581/633083
+                var current_cursor = cm.doc.getCursor();
+                cm.execCommand("goLineEnd")
+                cm.execCommand("goLineStart");
+                var start_cursor = cm.doc.getCursor();
+                var start = {'line': start_cursor.line, 'ch': start_cursor.ch};
+                cm.execCommand("goLineEnd")
+                var end_cursor = cm.doc.getCursor();
+                var end = {'line': end_cursor.line, 'ch': end_cursor.ch};
+                var line_content = cm.doc.getRange(start, end);
+                cm.execCommand("newLineAndIndent")
+                cm.doc.replaceSelection("\n");
+                cm.doc.replaceSelection(line_content);
+                cm.doc.setCursor(current_cursor.line + 1, current_cursor.ch);
+            }
             const swap = (a, i, j) => {
                 ;[a[i], a[j]] = [a[j], a[i]]
             }

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -1048,7 +1048,7 @@ export class Editor extends Component {
                         </td>
                         <td>
                         <form id="feedback" action="#" method="post">
-                            <label for="opinion">How can we make <a href="https://github.com/fonsp/Pluto.jl">Pluto.jl</a> better?</label>
+                            <label for="opinion">How can we make <a href="https://github.com/fonsp/Pluto.jl" target="_blank">Pluto.jl</a> better?</label>
                             <input type="text" name="opinion" id="opinion" autocomplete="off" placeholder="Instant feedback..." />
                             <button>Send</button>
                         </form>

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -19,7 +19,7 @@ import { empty_cell_data, code_differs } from "./Cell.js"
 
 import { offline_html } from "../common/OfflineHTMLExport.js"
 import { slice_utf8, length_utf8 } from "../common/UnicodeTools.js"
-import { has_ctrl_or_cmd_pressed, ctrl_or_cmd_name, is_mac_keyboard, in_textarea_or_input } from "../common/KeyboardShortcuts.js"
+import { has_ctrl_or_cmd_pressed, ctrl_or_cmd_name, alt_or_option_name, is_mac_keyboard, in_textarea_or_input } from "../common/KeyboardShortcuts.js"
 import { handle_log } from "../common/Logging.js"
 
 const default_path = "..."
@@ -806,6 +806,7 @@ export class Editor extends Component {
                 // On mac "cmd+shift+?" is used by chrome, so that is why this needs to be ctrl as well on mac
                 // Also pressing "ctrl+shift" on mac causes the key to show up as "/", this madness
                 // I hope we can find a better solution for this later - Dral
+                var mac_or_pc_join = is_mac_keyboard ? "" : "+"
                 alert(
                     `Shortcuts 🎹
 
@@ -815,13 +816,14 @@ export class Editor extends Component {
 
     PageUp or fn+Up:   select cell above
     PageDown or fn+Down:   select cell below
+    ${ctrl_or_cmd_name}${mac_or_pc_join}${alt_or_option_name}+Down:   duplicate line
 
-    ${ctrl_or_cmd_name}+Q:   interrupt notebook
-    ${ctrl_or_cmd_name}+S:   submit all changes
+    ${ctrl_or_cmd_name}${mac_or_pc_join}Q:   interrupt notebook
+    ${ctrl_or_cmd_name}${mac_or_pc_join}S:   submit all changes
 
-    ${ctrl_or_cmd_name}+C:   copy selected cells
-    ${ctrl_or_cmd_name}+X:   cut selected cells
-    ${ctrl_or_cmd_name}+V:   paste selected cells
+    ${ctrl_or_cmd_name}${mac_or_pc_join}C:   copy selected cells
+    ${ctrl_or_cmd_name}${mac_or_pc_join}X:   cut selected cells
+    ${ctrl_or_cmd_name}${mac_or_pc_join}V:   paste selected cells
 
     The notebook file saves every time you run`
                 )

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -1040,25 +1040,15 @@ export class Editor extends Component {
             />
             <${SlideControls} />
             <footer>
-                <div id="info">
-                <table width="100%">
-                    <tr>
-                        <td>
-                        🙋 <a href="https://github.com/fonsp/Pluto.jl/wiki" target="_blank" alignment="left">FAQ</a>
-                        </td>
-                        <td>
+                    <div id="faq">🙋 <a href="https://github.com/fonsp/Pluto.jl/wiki" target="_blank" alignment="left">FAQ</a></div>
+                    <div id="feedback">
                         <form id="feedback" action="#" method="post">
                             <label for="opinion">How can we make <a href="https://github.com/fonsp/Pluto.jl" target="_blank">Pluto.jl</a> better?</label>
                             <input type="text" name="opinion" id="opinion" autocomplete="off" placeholder="Instant feedback..." />
                             <button>Send</button>
                         </form>
-                        </td>
-                        <td>
-                        📈 <a id="statistics-info" href="statistics-info" alignment="left">Statistics</a>
-                        </td>
-                    </tr>
-                </table>
-                </div>
+                    </div>
+                    <div id="statistics">📈 <a id="statistics-info" href="statistics-info" alignment="left">Statistics</a></div>
             </footer>
         `
     }

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -1041,12 +1041,23 @@ export class Editor extends Component {
             <${SlideControls} />
             <footer>
                 <div id="info">
-                    <form id="feedback" action="#" method="post">
-                        <a id="statistics-info" href="statistics-info">Statistics</a>
-                        <label for="opinion">🙋 How can we make <a href="https://github.com/fonsp/Pluto.jl">Pluto.jl</a> better?</label>
-                        <input type="text" name="opinion" id="opinion" autocomplete="off" placeholder="Instant feedback..." />
-                        <button>Send</button>
-                    </form>
+                <table width="100%">
+                    <tr>
+                        <td>
+                        🙋 <a href="https://github.com/fonsp/Pluto.jl/wiki" target="_blank" alignment="left">FAQ</a>
+                        </td>
+                        <td>
+                        <form id="feedback" action="#" method="post">
+                            <label for="opinion">How can we make <a href="https://github.com/fonsp/Pluto.jl">Pluto.jl</a> better?</label>
+                            <input type="text" name="opinion" id="opinion" autocomplete="off" placeholder="Instant feedback..." />
+                            <button>Send</button>
+                        </form>
+                        </td>
+                        <td>
+                        📈 <a id="statistics-info" href="statistics-info" alignment="left">Statistics</a>
+                        </td>
+                    </tr>
+                </table>
                 </div>
             </footer>
         `

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -1289,19 +1289,59 @@ pluto-helpbox > section hr {
 
 footer {
     width: 100%;
-    height: 3.5rem;
+    /* height: 3.5rem; */
+    padding-top: 0.2rem;
+    padding-bottom: 0.5rem;
     font-family: "Roboto Mono", monospace;
     font-size: 0.75rem;
     background-color: #d7dcd3;
     color: #333333;
     z-index: 7;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+}
+
+footer #feedback {
+    flex-grow: 1;
+    flex-shrink: 0;
 }
 
 footer form {
     height: 1.5rem;
+    flex-grow: 1;
     display: flex;
     flex-direction: row;
-    justify-content: flex-end;
+    justify-content: center;
+    padding-left: 0.2rem;
+    padding-right: 0.2rem;
+    /* flex-wrap: wrap; */
+}
+
+footer form > label {
+    flex: 0 1 auto;
+    text-align: right;
+    /* width: 50%; */
+}
+
+footer form > input {
+    flex: 0 0 auto;
+    width: 50%;
+    padding-right: 0.5rem;
+}
+
+footer form > button {
+    padding-left: 0.5rem;
+}
+
+footer #faq {
+    flex: 0 0 auto;
+    margin-left: 2%;
+}
+
+footer #statistics {
+    flex: 0 0 auto;
+    margin-right: 2%;
 }
 
 footer form > * {


### PR DESCRIPTION
Was difficult to find an unused shortcut, maybe worsened by (possibly mistaken here) not being able to use `Ctrl` for keybindings on Mac as they all get converted to `Cmd`. I don't have a Windows machine so I'm not sure if what I chose, which is `Ctrl+Alt+Down`, is available on PC.

![Oct-21-2020 15-44-56](https://user-images.githubusercontent.com/231346/96796134-743b0c80-13b4-11eb-9a07-cae65492f427.gif)

<img width="453" alt="image" src="https://user-images.githubusercontent.com/231346/96796359-81f09200-13b4-11eb-8383-63c6aac21282.png">
