### PR TITLE
Shortcut for toggle word wrap

### DIFF
--- a/frontend/common/KeyboardShortcuts.js
+++ b/frontend/common/KeyboardShortcuts.js
@@ -1,6 +1,7 @@
 export let is_mac_keyboard = /Mac/.test(navigator.platform)
 
-export let ctrl_or_cmd_name = is_mac_keyboard ? "Cmd" : "Ctrl"
+export let ctrl_or_cmd_name = is_mac_keyboard ? "⌘" : "Ctrl"
+export let alt_or_option_name = is_mac_keyboard ? "⌥" : "Alt"
 
 export let has_ctrl_or_cmd_pressed = (event) => event.ctrlKey || (is_mac_keyboard && event.metaKey)
 

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -153,6 +153,9 @@ export const CellInput = ({
                     cm.setSelections(new_selections)
                 }
             }
+            keys["Alt-Z"]  = () => {
+                cm.setOption("lineWrapping", !cm.getOption("lineWrapping"));
+            }
             const swap = (a, i, j) => {
                 ;[a[i], a[j]] = [a[j], a[i]]
             }

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -19,7 +19,7 @@ import { empty_cell_data, code_differs } from "./Cell.js"
 
 import { offline_html } from "../common/OfflineHTMLExport.js"
 import { slice_utf8, length_utf8 } from "../common/UnicodeTools.js"
-import { has_ctrl_or_cmd_pressed, ctrl_or_cmd_name, is_mac_keyboard, in_textarea_or_input } from "../common/KeyboardShortcuts.js"
+import { has_ctrl_or_cmd_pressed, ctrl_or_cmd_name, alt_or_option_name, is_mac_keyboard, in_textarea_or_input } from "../common/KeyboardShortcuts.js"
 import { handle_log } from "../common/Logging.js"
 
 const default_path = "..."
@@ -806,22 +806,24 @@ export class Editor extends Component {
                 // On mac "cmd+shift+?" is used by chrome, so that is why this needs to be ctrl as well on mac
                 // Also pressing "ctrl+shift" on mac causes the key to show up as "/", this madness
                 // I hope we can find a better solution for this later - Dral
+                var mac_or_pc_join = is_mac_keyboard ? "" : "+"
                 alert(
                     `Shortcuts 🎹
 
     Shift+Enter:   run cell
-    ${ctrl_or_cmd_name}+Enter:   run cell and add cell below
+    ${ctrl_or_cmd_name}${mac_or_pc_join}Enter:   run cell and add cell below
     Delete or Backspace:   delete empty cell
 
     PageUp or fn+Up:   select cell above
     PageDown or fn+Down:   select cell below
 
-    ${ctrl_or_cmd_name}+Q:   interrupt notebook
-    ${ctrl_or_cmd_name}+S:   submit all changes
+    Ctrl+Q:   interrupt notebook
+    ${ctrl_or_cmd_name}${mac_or_pc_join}S:   submit all changes
+    ${alt_or_option_name}${mac_or_pc_join}Z:   toggle word wrap
 
-    ${ctrl_or_cmd_name}+C:   copy selected cells
-    ${ctrl_or_cmd_name}+X:   cut selected cells
-    ${ctrl_or_cmd_name}+V:   paste selected cells
+    ${ctrl_or_cmd_name}${mac_or_pc_join}C:   copy selected cells
+    ${ctrl_or_cmd_name}${mac_or_pc_join}X:   cut selected cells
+    ${ctrl_or_cmd_name}${mac_or_pc_join}V:   paste selected cells
 
     The notebook file saves every time you run`
                 )


### PR DESCRIPTION
Implement toggle word wrap, include on shortcuts popup, clean up the popup a bit.

Wrap on (default):
<img width="915" alt="image" src="https://user-images.githubusercontent.com/231346/96932907-76fd3680-1474-11eb-9364-abdbd944ab9b.png">
Wrap off:
<img width="914" alt="image" src="https://user-images.githubusercontent.com/231346/96932944-81b7cb80-1474-11eb-80c6-f44240069a01.png">

<img width="456" alt="image" src="https://user-images.githubusercontent.com/231346/96932974-8c726080-1474-11eb-9dde-170cedbe43f9.png">
