### PR TITLE
Open a pluto notebook directly

### DIFF
--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -15,6 +15,7 @@ Base.@kwdef mutable struct ServerOptions
     launch_browser::Bool = true
     show_file_system::Bool = true
     notebook_path_suggestion::String = notebook_path_suggestion()
+    notebook::String = ""
 end
 
 """

--- a/src/webserver/WebServer.jl
+++ b/src/webserver/WebServer.jl
@@ -10,6 +10,8 @@ function endswith(vec::Vector{T}, suffix::Vector{T}) where T
     liv >= lis && (view(vec, (liv - lis + 1):liv) == suffix)
 end
 
+isurl(s::String) = startswith(s, "http://") || startswith(s, "https://")
+
 include("./WebSocketFix.jl")
 
 
@@ -230,11 +232,15 @@ function run(session::ServerSession)
 
         Sys.set_process_title("Pluto server - $root")
 
-        if session.options.security.require_secret_for_access
-            root * "?secret=$(session.secret)"
-        else
-            root
+        qargs = Dict{String, String}()
+        session.options.security.require_secret_for_access && (qargs["secret"]="$(session.secret)")
+        nbfile = session.options.server.notebook
+        if !isempty(nbfile)
+            nb = (isurl(nbfile) ? SessionActions.open_url : SessionActions.open)(session, nbfile; compiler_options=session.options.compiler)
+            root *= "edit"
+            qargs["id"] = "$(nb.notebook_id)"
         end
+        root * "?" * join(["$k=$v" for (k, v) in qargs], "&")
     end
 
     println()


### PR DESCRIPTION
@fonsp I know you do not want to get the project harder and harder to maintain
(https://github.com/fonsp/Pluto.jl/issues/435). But I think this feature is nessessary and related issues can not be circumvented.
When I wrote an appplication/tutorial and want to convey it to users. Now I need to tell people
1. read Pluto README to know how to install and run Pluto and then you see a Pluto web page in your browser.
2. `]dev MyPackage`
3. find the notebook in .julia/dev/MyPackage  and paste the path to your Pluto web page.

User can easily feel frustrated to find a file in a hidden folder. I wish a user can
```julia
pkg> dev MyPackage
julia> using MyPackage && MyPackage.run_notebook()
```
I don't know how it is doable without the API to open a specific notebook.

It will not increase the complexity of this project much. :P

### Example
```julia
julia> using Pluto

julia> Pluto.run(notebook="https://gist.githubusercontent.com/GiggleLiu/7ab57094475d0a496112807d3235b8f5/raw/7afd487c356f9dff6ccb0ef99a2fbb23538e2f09/stateful_pluto.jl")
```

The notebook can also be a file path.