### PR TITLE
jsdelivr for everything

### DIFF
--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -1,8 +1,22 @@
-@import url("https://fonts.googleapis.com/css?family=Roboto+Mono:400,400i,500,700&display=swap&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext");
-@import url("https://fonts.googleapis.com/css?family=Vollkorn:600,600i,700,700i,900,900i&display=swap&subset=cyrillic,cyrillic-ext,greek,latin-ext,vietnamese");
-@import url("https://fonts.googleapis.com/css?family=Alegreya+Sans:400,400i,500,500i,700,700i&display=swap&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese");
+/* @import url("https://fonts.googleapis.com/css?family=Roboto+Mono:400,400i,500,700&display=swap&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext"); */
+@import url("https://cdn.jsdelivr.net/npm/fontsource-roboto-mono@3.0.3/400.css");
+@import url("https://cdn.jsdelivr.net/npm/fontsource-roboto-mono@3.0.3/500-normal.css");
+@import url("https://cdn.jsdelivr.net/npm/fontsource-roboto-mono@3.0.3/700-normal.css");
+
+/* @import url("https://fonts.googleapis.com/css?family=Vollkorn:600,600i,700,700i,900,900i&display=swap&subset=cyrillic,cyrillic-ext,greek,latin-ext,vietnamese"); */
+@import url("https://cdn.jsdelivr.net/npm/fontsource-vollkorn@3.0.3/600.css");
+@import url("https://cdn.jsdelivr.net/npm/fontsource-vollkorn@3.0.3/700.css");
+@import url("https://cdn.jsdelivr.net/npm/fontsource-vollkorn@3.0.3/900.css");
+
+/* @import url("https://fonts.googleapis.com/css?family=Alegreya+Sans:400,400i,500,500i,700,700i&display=swap&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese"); */
+@import url("https://cdn.jsdelivr.net/npm/fontsource-alegreya-sans@3.0.10/400.css");
+@import url("https://cdn.jsdelivr.net/npm/fontsource-alegreya-sans@3.0.10/500.css");
+@import url("https://cdn.jsdelivr.net/npm/fontsource-alegreya-sans@3.0.10/700.css");
+
 @import url("juliamono.css");
-@import url("https://fonts.googleapis.com/css2?family=Lato&display=swap");
+
+/* @import url("https://fonts.googleapis.com/css2?family=Lato&display=swap"); */
+@import url("https://cdn.jsdelivr.net/npm/fontsource-lato@3.0.9/400.css");
 
 /* VARIABLES */
 

--- a/frontend/editor.html
+++ b/frontend/editor.html
@@ -37,8 +37,8 @@
     <link rel="stylesheet" href="treeview.css" type="text/css" />
     <link rel="stylesheet" href="hide-ui.css" type="text/css" media="print" />
     <!-- The instant feedback form at the bottom of the page uses Google Firestore to save feedback and statistics. We DO NOT use Google Analytics, and NO DATA is sent except for data entered in the feedback form and anonymous statistics. See /statistics-info for more details. -->
-    <script src="https://www.gstatic.com/firebasejs/7.13.1/firebase-app.js" defer></script>
-    <script src="https://www.gstatic.com/firebasejs/7.13.1/firebase-firestore.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/firebase@7.13.1/firebase-app.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/firebase@7.13.1/firebase-firestore.js" defer></script>
 
     <script src="editor.js" type="module" defer></script>
     <script src="warn_old_browsers.js"></script>

--- a/frontend/treeview.css
+++ b/frontend/treeview.css
@@ -1,4 +1,7 @@
-@import url("https://fonts.googleapis.com/css2?family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap");
+/* @import url("https://fonts.googleapis.com/css2?family=Space+Mono:ital,wght@0,400;0,700;1,400;1,700&display=swap"); */
+@import url("https://cdn.jsdelivr.net/npm/fontsource-roboto-mono@3.0.3/400.css");
+@import url("https://cdn.jsdelivr.net/npm/fontsource-roboto-mono@3.0.3/700.css");
+
 @import url("juliamono.css");
 
 /*  */

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -332,12 +332,15 @@ function show_richest(io::IO, @nospecialize(x); onlyhtml::Bool=false)::MIME
 
     # types that have no specialized show methods (their fallback is text/plain) are displayed using Pluto's interactive tree viewer. 
     # this is how we check whether this display method is appropriate:
-    isstruct = 
+    isstruct = try
         mime isa MIME"text/plain" && 
         t isa DataType &&
         # there are two ways to override the plaintext show method: 
         which(show, (IO, MIME"text/plain", t)) === struct_showmethod_mime &&
         which(show, (IO, t)) === struct_showmethod
+    catch
+        false
+    end
     
     if isstruct
         show_struct(io, x)


### PR DESCRIPTION
We use these, because they host woff2 and subset fontfaces and stuff. It seems like this should get very close to the google fonts API performance.

They publish each font as an npm package, which we get using jsdelivr

https://github.com/fontsource/fontsource/tree/master/packages/vollkorn