### PR TITLE
PJL-631 translateY keyframe animation

### DIFF
--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -879,6 +879,8 @@ pluto-cell.code_folded > pluto-shoulder > button > span::after {
 /* TRAFFIC LIGHT */
 
 pluto-trafficlight {
+    /* This is derived from the pattern length (16px) div sin(45deg) = 16px * sqrt(2)  */
+    --patternHeight: 22.62741699797px;
     box-sizing: content-box;
     margin-right: -1px; /* fix a visual glitch of imperfect alignment */
     width: 4px;
@@ -891,6 +893,17 @@ pluto-trafficlight {
     border-bottom-left-radius: 4px;
     border-left-color: rgba(0, 0, 0, 0.1);
     background: rgba(0, 0, 0, 0.1);
+    overflow: hidden;
+}
+/* 1. Unit
+ */
+pluto-trafficlight::after {
+    content: "";
+    top: calc(0px - var(--patternHeight) - var(--patternHeight));
+    left: 0;
+    width: 100%;
+    height: calc(100% + 2 * var(--patternHeight));
+    position: absolute;
 }
 
 /* in ascending order of severity: */
@@ -932,21 +945,21 @@ pluto-cell.errored > pluto-trafficlight {
     background-clip: content-box;
 }
 
-pluto-cell.queued > pluto-trafficlight {
+pluto-cell.queued > pluto-trafficlight::after {
     background: repeating-linear-gradient(-45deg, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0) 8px, rgba(0, 0, 0, 0.1) 8px, rgba(0, 0, 0, 0.1) 16px);
     background-clip: content-box;
-    animation: 1000s linear 0s infinite running scrollbackground;
-    background-size: 4px 22.62741699797px; /* 16 * sqrt(2) */
+    animation: 1s linear 0s infinite running scrollbackground;
+    background-size: 4px var(--patternHeight);
 }
 
-pluto-cell.running > pluto-trafficlight {
+pluto-cell.running > pluto-trafficlight::after {
     background: repeating-linear-gradient(-45deg, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.1) 8px, rgba(0, 0, 0, 0.2) 8px, rgba(0, 0, 0, 0.2) 16px);
     background-clip: content-box;
-    animation: 1000s linear 0s infinite running scrollbackground;
-    background-size: 4px 22.62741699797px; /* 16 * sqrt(2) */
+    animation: 1s linear 0s infinite running scrollbackground;
+    background-size: 4px var(--patternHeight);
 }
 
-pluto-cell.queued.errored > pluto-trafficlight {
+pluto-cell.queued.errored > pluto-trafficlight::after {
     background: repeating-linear-gradient(
         -45deg,
         hsla(0, 70%, 80%, 0.7),
@@ -955,24 +968,23 @@ pluto-cell.queued.errored > pluto-trafficlight {
         hsla(0, 70%, 80%, 0.05) 16px
     );
     background-clip: content-box;
-    animation: 1000s linear 0s infinite running scrollbackground;
-    background-size: 4px 22.62741699797px; /* 16 * sqrt(2) */
+    animation: 1s linear 0s infinite running scrollbackground;
+    background-size: 4px var(--patternHeight); /* 16 * sqrt(2) */
 }
 
-pluto-cell.running.errored > pluto-trafficlight {
+pluto-cell.running.errored > pluto-trafficlight::after {
     background: repeating-linear-gradient(-45deg, hsla(0, 100%, 80%, 1), hsla(0, 100%, 80%, 1) 8px, hsla(0, 70%, 80%, 0.7) 8px, hsla(0, 70%, 80%, 0.7) 16px);
     background-clip: content-box;
-    animation: 1000s linear 0s infinite running scrollbackground;
-    background-size: 4px 22.62741699797px; /* 16 * sqrt(2) */
+    animation: 1s linear 0s infinite running scrollbackground;
+    background-size: 4px var(--patternHeight); /* 16 * sqrt(2) */
 }
 
 @keyframes scrollbackground {
     0% {
-        background-position-y: 0px;
+        transform: translateY(0px);
     }
     100% {
-        background-position-y: 22627.41699797px;
-        /* 16 * sqrt(2) */
+        transform: translateY(calc(var(--patternHeight)));
     }
 }
 

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -879,7 +879,7 @@ pluto-cell.code_folded > pluto-shoulder > button > span::after {
 /* TRAFFIC LIGHT */
 
 pluto-trafficlight {
-    /* This is derived from the pattern length (16px) div sin(45deg) = 16px * sqrt(2)  */
+    /* --patternHeight is derived from the pattern length (16px) div sin(45deg) = 16px * sqrt(2)  */
     --patternHeight: 22.62741699797px;
     box-sizing: content-box;
     margin-right: -1px; /* fix a visual glitch of imperfect alignment */
@@ -895,11 +895,11 @@ pluto-trafficlight {
     background: rgba(0, 0, 0, 0.1);
     overflow: hidden;
 }
-/* 1. Unit
- */
+
 pluto-trafficlight::after {
     content: "";
-    top: calc(0px - var(--patternHeight) - var(--patternHeight));
+    /* Calc needs units everywhere to work */
+    top: calc(0px - 2 * var(--patternHeight));
     left: 0;
     width: 100%;
     height: calc(100% + 2 * var(--patternHeight));
@@ -979,6 +979,7 @@ pluto-cell.running.errored > pluto-trafficlight::after {
     background-size: 4px var(--patternHeight); /* 16 * sqrt(2) */
 }
 
+/* Define --patternHeight for this keyframes animation to work! */
 @keyframes scrollbackground {
     0% {
         transform: translateY(0px);


### PR DESCRIPTION
This pull request addresses [Issue 631](https://github.com/fonsp/Pluto.jl/issues/631) about High CPU Load with CSS animations.

- Use a variable to define the logic of `--patternHeight: 22.62741699797px`
- Set overflow of traffic-light to hidden
- Use a pseudo-element to render background image. Height of pseudo-element is `100% + 2 * patternHeight`
- Move element with animation, over the course of 1 second to 1 `patternHeight` lower.

Note: in order to run the animation, a parent of the element must have the `--patternHeight` variable set. That is if the animation is to be used elsewhere (this change makes the animation really reusable, because it _can_ be used in different settings with different pattern heights).

Result: In my computer (Chrome / Firefox on Windows 10) the cpu load drops from 60-70% to around 20%.

Let me know of your thoughts,

Thanks,
Panagiotis