### PR TITLE
[Frontend] Fix Alt-Down code shift bug

### DIFF
--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -181,7 +181,7 @@ export const CellInput = ({
             const final_line_number = delta === 1 ? cm.lineCount() - 1 : 0
             if (!selected_lines.has(final_line_number)) {
                 Array.from(selected_lines)
-                    .sort((a, b) => delta * a < delta * b)
+                    .sort((a, b) => delta * a < delta * b ? 1 : -1)
                     .forEach((line_number) => {
                         const lines = cm.getValue().split("\n")
                         swap(lines, line_number, line_number + delta)


### PR DESCRIPTION
closes #665 

The bug was caused by the sort function used. The return type of the sort function ```(a, b) => delta * a < delta * b``` is boolean however sort function requires a number, i.e. -1 or +1. Hence ```(a, b) => delta * a < delta * b ? 1 : -1``` fixed the problem.

![altfix](https://user-images.githubusercontent.com/28949397/98848268-77875c80-2477-11eb-8ff3-0bb1beeb81b0.gif)
