### PR TITLE
Tables Interactive viewer - Sticky Headers

### DIFF
--- a/frontend/components/CellOutput.js
+++ b/frontend/components/CellOutput.js
@@ -124,15 +124,13 @@ export const OutputBody = ({ mime, body, cell_id, all_completed_promise, request
             </div>`
             break
         case "application/vnd.pluto.table+object":
-            return html`<div>
-                <${TableView}
-                    cell_id=${cell_id}
-                    body=${body}
-                    all_completed_promise=${all_completed_promise}
-                    requests=${requests}
-                    persist_js_state=${persist_js_state}
-                />
-            </div>`
+            return html` <${TableView}
+                cell_id=${cell_id}
+                body=${body}
+                all_completed_promise=${all_completed_promise}
+                requests=${requests}
+                persist_js_state=${persist_js_state}
+            />`
             break
         case "application/vnd.pluto.stacktrace+object":
             return html`<div><${ErrorMessage} cell_id=${cell_id} requests=${requests} ...${body} /></div>`

--- a/frontend/components/TreeView.js
+++ b/frontend/components/TreeView.js
@@ -159,7 +159,7 @@ export const TableView = ({ mime, body, cell_id, all_completed_promise, requests
             (row) =>
                 html`<tr>
                     ${row === "more"
-                        ? html`<td colspan="999">${more(1)}</td>`
+                        ? html`<td class="jlmore-td" colspan="999">${more(1)}</td>`
                         : html`<th>${row[0]}</th>
                               ${row[1].map((x) => html`<td>${x === "more" ? null : mimepair_output(x)}</td>`)}`}
                 </tr>`

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -330,6 +330,12 @@ pluto-output div.footnote p:last-child {
     padding-bottom: 0px;
 }
 
+pluto-output.scroll_y {
+    max-height: 80vh;
+    max-height: 400px;
+    overflow: auto;
+}
+
 pluto-output table {
     border-collapse: collapse;
     border: 2px solid rgba(0, 0, 0, 0.2);

--- a/frontend/treeview.css
+++ b/frontend/treeview.css
@@ -128,6 +128,7 @@ jlmore {
     cursor: pointer;
     /* this only affects jlmore inside a table */
     width: 100%;
+    white-space: nowrap;
 }
 
 jlmore::before {

--- a/frontend/treeview.css
+++ b/frontend/treeview.css
@@ -275,15 +275,15 @@ table.pluto-table tbody th:first-child {
     top: 2rem;
 }
 
-table.pluto-table td[colspan="999"] {
+table.pluto-table .jlmore-td {
     text-align: left;
     overflow: unset;
 }
 
-table.pluto-table td[colspan="999"] jlmore {
+table.pluto-table .jlmore-td jlmore {
     overflow: unset;
     position: sticky;
     left: 0;
     top: 2rem;
-    max-width: 200px;
+    max-width: 650px;
 }

--- a/frontend/treeview.css
+++ b/frontend/treeview.css
@@ -238,6 +238,15 @@ table.pluto-table .schema-types {
     opacity: 0;
 }
 
+table.pluto-table .schema-types th {
+    border-bottom: 1px solid rgba(0, 0, 0, 0.2);
+    background-color: white;
+    position: sticky;
+    top: calc(2.25rem - var(--pluto-cell-spacing));
+    height: 2rem;
+    z-index: 1;
+}
+
 table.pluto-table thead:hover .schema-types {
     opacity: 1;
 }
@@ -247,6 +256,34 @@ table.pluto-table .schema-names {
     transition: transform 0.1s ease-in-out;
 }
 
+table.pluto-table .schema-names th {
+    background-color: white;
+    position: sticky;
+    top: calc(0.25rem - var(--pluto-cell-spacing));
+    height: 2rem;
+    z-index: 1;
+}
+
 table.pluto-table thead:hover .schema-names {
     transform: translate(0, 0);
+}
+
+table.pluto-table tbody th:first-child {
+    background-color: white;
+    position: sticky;
+    left: -10px; /* padding-left of pluto-output*/
+    top: 2rem;
+}
+
+table.pluto-table td[colspan="999"] {
+    text-align: left;
+    overflow: unset;
+}
+
+table.pluto-table td[colspan="999"] jlmore {
+    overflow: unset;
+    position: sticky;
+    left: 0;
+    top: 2rem;
+    max-width: 200px;
 }


### PR DESCRIPTION
Builds upon #646 
- Removed `div` wrapper around Table view (was that needed?)
- add `sticky` on two first rows (types & names)
- add `sticky` (left, top) on first column's `th` 
- make `jlmore` sticky when on a row (needs `max-width`)
