### PR TITLE
PLJ-613 Import Vollkorn from fonsp repo & enable features

### DIFF
--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -3,18 +3,13 @@
 @import url("https://cdn.jsdelivr.net/npm/fontsource-roboto-mono@3.0.3/500-normal.css");
 @import url("https://cdn.jsdelivr.net/npm/fontsource-roboto-mono@3.0.3/700-normal.css");
 
-/* @import url("https://fonts.googleapis.com/css?family=Vollkorn:600,600i,700,700i,900,900i&display=swap&subset=cyrillic,cyrillic-ext,greek,latin-ext,vietnamese"); */
-@import url("https://cdn.jsdelivr.net/npm/fontsource-vollkorn@3.0.3/600.css");
-@import url("https://cdn.jsdelivr.net/npm/fontsource-vollkorn@3.0.3/700.css");
-@import url("https://cdn.jsdelivr.net/npm/fontsource-vollkorn@3.0.3/900.css");
-
 /* @import url("https://fonts.googleapis.com/css?family=Alegreya+Sans:400,400i,500,500i,700,700i&display=swap&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese"); */
 @import url("https://cdn.jsdelivr.net/npm/fontsource-alegreya-sans@3.0.10/400.css");
 @import url("https://cdn.jsdelivr.net/npm/fontsource-alegreya-sans@3.0.10/500.css");
 @import url("https://cdn.jsdelivr.net/npm/fontsource-alegreya-sans@3.0.10/700.css");
 
 @import url("juliamono.css");
-
+@import url("vollkorn.css");
 /* @import url("https://fonts.googleapis.com/css2?family=Lato&display=swap"); */
 @import url("https://cdn.jsdelivr.net/npm/fontsource-lato@3.0.9/400.css");
 
@@ -97,6 +92,7 @@ pluto-output h4,
 pluto-output h5,
 pluto-output h6 {
     font-family: "Vollkorn", serif;
+    font-feature-settings: "lnum", "pnum";
     font-weight: 600;
     color: hsl(0, 0%, 12%);
     margin-block-start: 1rem;
@@ -244,6 +240,7 @@ pluto-output div.admonition {
 }
 pluto-output div.admonition .admonition-title {
     font-family: "Vollkorn", sans-serif;
+    font-feature-settings: "lnum", "pnum";
     color: white;
     font-weight: 600;
     margin-block-end: 0px;
@@ -450,6 +447,7 @@ div.export_title {
 a.export_card header {
     margin-block: 0px;
     font-family: "Vollkorn", sans;
+    font-feature-settings: "lnum", "pnum";
     font-size: 1rem;
 }
 a.export_card section {

--- a/frontend/vollkorn.css
+++ b/frontend/vollkorn.css
@@ -1,0 +1,44 @@
+@font-face {
+    font-family: Vollkorn;
+    src: url("https://cdn.jsdelivr.net/gh/fonsp/Vollkorn-Typeface@1/fonts/woff2/Vollkorn-SemiBold.woff2") format("woff2");
+    font-display: swap;
+    font-weight: 600;
+}
+
+@font-face {
+    font-family: Vollkorn;
+    font-style: italic;
+    src: url("https://cdn.jsdelivr.net/gh/fonsp/Vollkorn-Typeface@1/fonts/woff2/Vollkorn-SemiBoldItalic.woff2") format("woff2");
+    font-display: swap;
+    font-weight: 600;
+}
+
+@font-face {
+    font-family: Vollkorn;
+    src: url("https://cdn.jsdelivr.net/gh/fonsp/Vollkorn-Typeface@1/fonts/woff2/Vollkorn-Bold.woff2") format("woff2");
+    font-display: swap;
+    font-weight: 700;
+}
+
+@font-face {
+    font-family: Vollkorn;
+    font-style: italic;
+    src: url("https://cdn.jsdelivr.net/gh/fonsp/Vollkorn-Typeface@1/fonts/woff2/Vollkorn-BoldItalic.woff2") format("woff2");
+    font-display: swap;
+    font-weight: 700;
+}
+
+@font-face {
+    font-family: Vollkorn;
+    src: url("https://cdn.jsdelivr.net/gh/fonsp/Vollkorn-Typeface@1/fonts/woff2/Vollkorn-Black.woff2") format("woff2");
+    font-display: swap;
+    font-weight: 900;
+}
+
+@font-face {
+    font-family: Vollkorn;
+    font-style: italic;
+    src: url("https://cdn.jsdelivr.net/gh/fonsp/Vollkorn-Typeface@1/fonts/woff2/Vollkorn-BlackItalic.woff2") format("woff2");
+    font-display: swap;
+    font-weight: 900;
+}


### PR DESCRIPTION
Addresses #613

Define vollkorn as in the previously imported [file](https://cdn.jsdelivr.net/npm/fontsource-vollkorn@3.0.3/900.css)

600 - SemiBold
700 - Bold
900 - Black

*and* respective italics 

enables `font-feature-settings: 'lnum', 'pnum';`

Image after:
![image](https://user-images.githubusercontent.com/8681967/99068306-f1713000-25b4-11eb-846b-2583c7c589ee.png)

Also tested greek (polytonic not that supported!): 
![image](https://user-images.githubusercontent.com/8681967/99068791-d652f000-25b5-11eb-9ea6-e03cd4faf3b7.png)
