### PR TITLE
Add missing wait()

### DIFF
--- a/src/webserver/WebServer.jl
+++ b/src/webserver/WebServer.jl
@@ -246,7 +246,7 @@ function run(session::ServerSession)
         end
         empty!(session.connected_clients)
         for (notebook_id, ws) in WorkspaceManager.workspaces
-            @async WorkspaceManager.unmake_workspace(ws)
+            @async WorkspaceManager.unmake_workspace(wait(ws))
         end
     end
 


### PR DESCRIPTION
The kill-server function passed a `Promise` to `unmake_workspace` without waiting on it, resulting in a MethodError being thrown at shutdown.