### PR TITLE
fix anonymous function canonalization, fixes #654

### DIFF
--- a/src/analysis/ExpressionExplorer.jl
+++ b/src/analysis/ExpressionExplorer.jl
@@ -819,10 +819,11 @@ canonalize(e1) == canonalize(e2)
 function canonalize(ex::Expr)
 	if ex.head == :where
 		Expr(:where, canonalize(ex.args[1]), ex.args[2:end]...)
-	elseif ex.head == :call
-		ex.args[1] # is the function name, we dont want it
+	elseif ex.head == :call || ex.head == :tuple
+		skip_index = ex.head == :call ? 2 : 1
+		ex.args[1] # if ex.head == :call this is the function name, we dont want it
 
-		interesting = filter(ex.args[2:end]) do arg
+		interesting = filter(ex.args[skip_index:end]) do arg
 			!(arg isa Expr && arg.head == :parameters)
 		end
 		

--- a/test/ExpressionExplorer.jl
+++ b/test/ExpressionExplorer.jl
@@ -193,6 +193,7 @@ using Test
         @test testee(:((((a, b), c), (d, e)) -> a * b * c * d * e * f), [], [], [], [
             :anon => ([:f], [], [:*], [])
         ])
+        @test testee(:(f = function(a, b) a + b * n end), [:n], [:f], [:+, :*], [])
 
         @test testee(:(func(a)), [:a], [], [:func], [])
         @test testee(:(func(a; b=c)), [:a, :c], [], [:func], [])


### PR DESCRIPTION
Hi ! :wave: 

This fixes #654 

However this method will not work with the current duplicate methods detection but an assignment cannot declare a new method and only override the variable :thinking:

```julia
julia> f = function() end
#7 (generic function with 1 method)

julia> f = function(a::Int) a end
#9 (generic function with 1 method)

julia> methods(f)
# 1 method for generic function "#9":
[1] (::getfield(Main, Symbol("##9#10")))(a::Int32) in Main at REPL[11]:1
```
 