### PR TITLE
Prevent leaking the secret to cross origins

### DIFF
--- a/src/webserver/WebServer.jl
+++ b/src/webserver/WebServer.jl
@@ -210,6 +210,7 @@ function run(session::ServerSession)
             request.response::HTTP.Response = response_body
             request.response.request = request
             try
+                HTTP.setheader(http, "Referrer-Policy" => "origin-when-cross-origin")
                 HTTP.startwrite(http)
                 write(http, request.response.body)
                 HTTP.closewrite(http)


### PR DESCRIPTION
Currently the secret is exposed to third parties (CDN , Google) through the referrer sent for the linked asset requests. _"Referrer : http://pluto-server:1234/?secret=XXXX"_

This is a quick-fix proposal to set a Referrer-Policy on each http request. The header instructs browsers to send only the origin part of the url as referrer on cross origin requests. 

For a better fix (and better offline support #241 )  i would suggest removing the external dependencies altogether.  This could either be done via "vendorizing" them by keeping a local copy (lowest initial maintenance impact) or switching to a build script for the front end (requires build step). Let me know if you want me to contribute something.