### PR TITLE
add checks to bind macro

### DIFF
--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -1060,7 +1060,8 @@ The first cell will show a slider as the cell's output, ranging from 0 until 100
 The second cell will show the square of `x`, and is updated in real-time as the slider is moved.
 """
 macro bind(def, element)
-	if def isa Symbol
+    is_element_valid = element isa Symbol || (element isa Expr && element.head ∉ [:(=), :(::)])
+	if def isa Symbol && is_element_valid
 		quote
 			local el = $(esc(element))
             global $(esc(def)) = Core.applicable(Base.get, el) ? Base.get(el) : missing


### PR DESCRIPTION
Hello! :wave: 

This prevents executing code that could break some functions by defining new methods.

Example:
```julia
@bind a CheckBox(), default=true
```

Would throw an error before executing where it would not have
previously, redefining `CheckBox()` to `true` (see #486).

There seems to be currently no tests for `@bind` (https://github.com/fonsp/Pluto.jl/blob/master/test/runtests.jl#L23).
Should I add some ? 

Fixes #486