### PR TITLE
🍓 Support 32-bit systems

### DIFF
--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -653,7 +653,7 @@ function array_prefix(@nospecialize(x))::String
     lstrip(original, ':') * ": "
 end
 
-function get_my_display_limit(@nospecialize(x), dim::Int64, context::IOContext, a::Int64, b::Int64)::Int64
+function get_my_display_limit(@nospecialize(x), dim::Int, context::IOContext, a::Int, b::Int)::Int
     a + let
         d = get(context, :extra_items, nothing)
         if d === nothing

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -653,7 +653,7 @@ function array_prefix(@nospecialize(x))::String
     lstrip(original, ':') * ": "
 end
 
-function get_my_display_limit(@nospecialize(x), dim::Int, context::IOContext, a::Int, b::Int)::Int
+function get_my_display_limit(@nospecialize(x), dim::Integer, context::IOContext, a::Integer, b::Integer)::Int # needs to be system-dependent Int because it is used as array index
     a + let
         d = get(context, :extra_items, nothing)
         if d === nothing

--- a/test/React.jl
+++ b/test/React.jl
@@ -488,7 +488,7 @@ import Distributed
         Cell("g(a,b) = a+b"),
         Cell("g(5,6)"),
 
-        Cell("h(x::Int64) = x"),
+        Cell("h(x::Int) = x"),
         Cell("h(7)"),
         Cell("h(8.0)"),
 
@@ -500,7 +500,7 @@ import Distributed
             a(x::String) = \"🐟\"
         end"),
         Cell("using .Something"),
-        Cell("a(x::Int64) = x"),
+        Cell("a(x::Int) = x"),
         Cell("a(\"i am a \")"),
         Cell("a(15)"),
         
@@ -509,7 +509,7 @@ import Distributed
             b(x::String) = \"🐟\"
         end"),
         Cell("import .Different: b"),
-        Cell("b(x::Int64) = x"),
+        Cell("b(x::Int) = x"),
         Cell("b(\"i am a \")"),
         Cell("b(20)"),
         
@@ -519,7 +519,7 @@ import Distributed
         end"),
         Cell("begin
             import .Wow: c
-            c(x::Int64) = x
+            c(x::Int) = x
         end"),
         Cell("c(\"i am a \")"),
         Cell("c(24)"),


### PR DESCRIPTION
- This PR allows Pluto to run 32bit system e.g. RaspberryPi devices. On such devices, the default type of numeric is regarded as `Int32`. Therefore if one defines function which accepts only `Int64` (not `Int`), we will get `MethodError: no method matching f(::Int32)`. Here is my log that shows what happens.


```julia
julia
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.5.3 (2020-11-09)
 _/ |\__'_|_|_|\__'_|  |
|__/                   |

julia> versioninfo()
Julia Version 1.5.3
Commit 788b2c7* (2020-11-09 13:37 UTC)
Platform Info:
  OS: Linux (arm-linux-gnueabihf)
  CPU: ARMv7 Processor rev 3 (v7l)
  WORD_SIZE: 32
  LIBM: libopenlibm
  LLVM: libLLVM-9.0.1 (ORCJIT, cortex-a72)

julia> Sys.WORD_SIZE
32

julia> 1 |> typeof
Int32

julia> f(x::Int64) = 2x
f (generic function with 1 method)

julia> f(1)
ERROR: MethodError: no method matching f(::Int32)
Closest candidates are:
  f(::Int64) at REPL[4]:1
Stacktrace:
 [1] top-level scope at REPL[5]:1

julia> f(x::Int) = 2x
f (generic function with 2 methods)

julia> f(1)
2

```

If this PR is merged, Pluto.jl can support many devices 👍 . Below image is our future.

![image](https://user-images.githubusercontent.com/16760547/100735852-3d293380-3415-11eb-9d8c-14bb1acd6289.png)

