### PR TITLE
Change error contrast ratio

### DIFF
--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -1685,7 +1685,7 @@ li.CodeMirror-hint.c_Array::before,
 
 .cm-s-default span.cm-error {
     background: #ef6155;
-    color: #776e71;
+    color: #f7f7f7;
 }
 
 .cm-s-default .CodeMirror-activeline-background {


### PR DESCRIPTION
Closes #749.

Follows this [suggestion](https://www.w3.org/WAI/WCAG21/Techniques/general/G145) for a contrast rate of at least 3:1.

![image](https://user-images.githubusercontent.com/8681967/101650233-67e24000-3a44-11eb-8267-608380614f07.png)
