### PR TITLE
When text is selected and either (, [ or { is pressed wrap selection in (), [], {} instead of replacing it.

### DIFF
--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -291,10 +291,14 @@ export const CellInput = ({
                 return CodeMirror.Pass
             }
         })
-        const open_close_selection = (opening_char, closing_char) => (cm_) => {
-            for (const selection of cm_.getSelections())
-                if (selection?.length) cm_.replaceSelection(`${opening_char}${selection}${closing_char}`)
-                else cm_.replaceSelection(opening_char)
+        const open_close_selection = (opening_char, closing_char) => () => {
+            if (cm.somethingSelected()) {
+                for (const selection of cm.getSelections()) {
+                    cm.replaceSelection(`${opening_char}${selection}${closing_char}`, "around")
+                }
+            } else {
+                return CodeMirror.Pass
+            }
         }
 
         ;["()", "{}", "[]"].forEach((pair) => {

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -291,9 +291,18 @@ export const CellInput = ({
                 return CodeMirror.Pass
             }
         })
+        const open_close_selection = (opening_char, closing_char) => (cm_) => {
+            for (const selection of cm_.getSelections())
+                if (selection?.length) cm_.replaceSelection(`${opening_char}${selection}${closing_char}`)
+                else cm_.replaceSelection(opening_char)
+        }
+
+        ;["()", "{}", "[]"].forEach((pair) => {
+            const [opening_char, closing_char] = pair.split("")
+            keys[`'${opening_char}'`] = open_close_selection(opening_char, closing_char)
+        })
 
         cm.setOption("extraKeys", map_cmd_to_ctrl_on_mac(keys))
-        cm.setOption("autoCloseBrackets", true)
 
         let is_good_token = (token) => {
             if (token.type == null && token.string === "]") {


### PR DESCRIPTION
This PR adds key bindings to codemirror in order to handle the press of `(`, `[` or `{` more intuitively (citation needed).

When user has done a text selection and presses `(`, `[` or `{`, the character _replaces_ the text.

With this PR, the behaviour changes to wrap the selection in brackets.

Note that the cursor is moved after the text  `(selected-text)<HERE>` vs for example VSCode that goes to `(selected-text<HERE>)`.

Also remove the line that activates ''autoCloseBrackets" (because it doesn't!)