### PR TITLE
Add CompatHelper

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,0 +1,15 @@
+name: CompatHelper
+on:
+  schedule:
+    - cron: '00 00 * * *'
+  workflow_dispatch:
+jobs:
+  CompatHelper:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Pkg.add("CompatHelper")
+        run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
+      - name: CompatHelper.main()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: julia -e 'using CompatHelper; CompatHelper.main()'

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -1,6 +1,7 @@
 name: CompatHelper
 on:
   schedule:
+    # Every day at 00:00.
     - cron: '00 00 * * *'
   workflow_dispatch:
 jobs:


### PR DESCRIPTION
I noticed that Pluto was raising compatibility errors when I tried to get the newest HTTP. This led me to see https://github.com/fonsp/Pluto.jl/pull/761. With this PR, I propose to add [CompatHelper](https://github.com/JuliaRegistries/CompatHelper.jl), which should work straight away. It will automatically create PRs for updated packages.