### PR TITLE
Replace Array{T,1} with Vector{T}

### DIFF
--- a/sample/Tower of Hanoi.jl
+++ b/sample/Tower of Hanoi.jl
@@ -165,7 +165,7 @@ This is where we can check a solution. We start with a function that takes our r
 function run_solution(solver::Function, start = starting_stacks)
 	moves = solver(deepcopy(start)) #apply the solver
 	
-	all_states = Array{Any,1}(undef, length(moves) + 1)
+	all_states = Vector{Any}(undef, length(moves) + 1)
 	all_states[1] = starting_stacks
 	
 	for (i, m) in enumerate(moves)

--- a/src/analysis/ExpressionExplorer.jl
+++ b/src/analysis/ExpressionExplorer.jl
@@ -10,7 +10,7 @@ import Base: union, union!, ==, push!
 ###
 
 # TODO: use GlobalRef instead
-FunctionName = Array{Symbol,1}
+FunctionName = Vector{Symbol}
 
 struct FunctionNameSignaturePair
     name::FunctionName
@@ -133,7 +133,7 @@ function will_assign_global(assignee::Symbol, scopestate::ScopeState)::Bool
     (scopestate.inglobalscope || assignee ∈ scopestate.exposedglobals) && (assignee ∉ scopestate.hiddenglobals || assignee ∈ scopestate.definedfuncs)
 end
 
-function will_assign_global(assignee::Array{Symbol,1}, scopestate::ScopeState)::Bool
+function will_assign_global(assignee::Vector{Symbol}, scopestate::ScopeState)::Bool
     if length(assignee) == 0
         false
     elseif length(assignee) > 1

--- a/src/analysis/Parse.jl
+++ b/src/analysis/Parse.jl
@@ -81,7 +81,7 @@ fix_linenumbernodes!(::Any, actual_filename) = nothing
 `expression_boundaries("sqrt(1)\n\n123") == [ncodeunits("sqrt(1)\n\n") + 1, ncodeunits("sqrt(1)\n\n123") + 1]`
 
 """
-function expression_boundaries(code::String, start=1)::Array{<:Integer,1}
+function expression_boundaries(code::String, start=1)::Vector{<:Integer}
     expr, next = Meta.parse(code, start, raise=false)
     if next <= ncodeunits(code)
         [next, expression_boundaries(code, next)...]

--- a/src/analysis/Topology.jl
+++ b/src/analysis/Topology.jl
@@ -3,13 +3,13 @@ import .ExpressionExplorer: SymbolsState, FunctionName
 "Information container about the cells to run in a reactive call and any cells that will err."
 struct TopologicalOrder
 	"Cells that form a directed acyclic graph, in topological order."
-	runnable::Array{Cell,1}
+	runnable::Vector{Cell}
 	"Cells that are in a directed cycle, with corresponding `ReactivityError`s."
 	errable::Dict{Cell,ReactivityError}
 end
 
 "Return a `TopologicalOrder` that lists the cells to be evaluated in a single reactive run, in topological order. Includes the given roots."
-function topological_order(notebook::Notebook, topology::NotebookTopology, roots::Array{Cell,1}; allow_multiple_defs=false)::TopologicalOrder
+function topological_order(notebook::Notebook, topology::NotebookTopology, roots::Vector{Cell}; allow_multiple_defs=false)::TopologicalOrder
 	entries = Cell[]
 	exits = Cell[]
 	errable = Dict{Cell,ReactivityError}()
@@ -61,19 +61,19 @@ function disjoint(a::Set, b::Set)
 end
 
 "Return the cells that reference any of the symbols defined by the given cell. Non-recursive: only direct dependencies are found."
-function where_referenced(notebook::Notebook, topology::NotebookTopology, myself::Cell)::Array{Cell,1}
+function where_referenced(notebook::Notebook, topology::NotebookTopology, myself::Cell)::Vector{Cell}
 	to_compare = union(topology[myself].definitions, topology[myself].funcdefs_without_signatures)
 	where_referenced(notebook, topology, to_compare)
 end
 "Return the cells that reference any of the given symbols. Non-recursive: only direct dependencies are found."
-function where_referenced(notebook::Notebook, topology::NotebookTopology, to_compare::Set{Symbol})::Array{Cell,1}
+function where_referenced(notebook::Notebook, topology::NotebookTopology, to_compare::Set{Symbol})::Vector{Cell}
 	return filter(notebook.cells) do cell
 		!disjoint(to_compare, topology[cell].references)
 	end
 end
 
 "Return the cells that also assign to any variable or method defined by the given cell. If more than one cell is returned (besides the given cell), then all of them should throw a `MultipleDefinitionsError`. Non-recursive: only direct dependencies are found."
-function where_assigned(notebook::Notebook, topology::NotebookTopology, myself::Cell)::Array{Cell,1}
+function where_assigned(notebook::Notebook, topology::NotebookTopology, myself::Cell)::Vector{Cell}
 	self = topology[myself]
 	return filter(notebook.cells) do cell
 		other = topology[cell]

--- a/src/evaluation/Run.jl
+++ b/src/evaluation/Run.jl
@@ -21,7 +21,7 @@ macro asynclog(expr)
 end
 
 "Run given cells and all the cells that depend on them, based on the topology information before and after the changes."
-function run_reactive!(session::ServerSession, notebook::Notebook, old_topology::NotebookTopology, new_topology::NotebookTopology, cells::Array{Cell,1}; deletion_hook::Function=WorkspaceManager.delete_vars, persist_js_state::Bool=false)::TopologicalOrder
+function run_reactive!(session::ServerSession, notebook::Notebook, old_topology::NotebookTopology, new_topology::NotebookTopology, cells::Vector{Cell}; deletion_hook::Function=WorkspaceManager.delete_vars, persist_js_state::Bool=false)::TopologicalOrder
 	# make sure that we're the only `run_reactive!` being executed - like a semaphor
 	take!(notebook.executetoken)
 
@@ -34,7 +34,7 @@ function run_reactive!(session::ServerSession, notebook::Notebook, old_topology:
 
 	# get the new topological order
 	new_order = topological_order(notebook, new_topology, union(cells, keys(old_order.errable)))
-	to_run = setdiff(union(new_order.runnable, old_order.runnable), keys(new_order.errable))::Array{Cell,1} # TODO: think if old error cell order matters
+	to_run = setdiff(union(new_order.runnable, old_order.runnable), keys(new_order.errable))::Vector{Cell} # TODO: think if old error cell order matters
 
 	# change the bar on the sides of cells to "queued"
 	local listeners = ClientSession[]
@@ -123,7 +123,7 @@ end
 ###
 
 "Do all the things!"
-function update_save_run!(session::ServerSession, notebook::Notebook, cells::Array{Cell,1}; save::Bool=true, run_async::Bool=false, prerender_text::Bool=false, kwargs...)
+function update_save_run!(session::ServerSession, notebook::Notebook, cells::Vector{Cell}; save::Bool=true, run_async::Bool=false, prerender_text::Bool=false, kwargs...)
 	update_caches!(notebook, cells)
 	old = notebook.topology
 	new = notebook.topology = updated_topology(old, notebook, cells)

--- a/src/notebook/Notebook.jl
+++ b/src/notebook/Notebook.jl
@@ -17,7 +17,7 @@ end
 "Like a [`Diary`](@ref) but more serious. 📓"
 mutable struct Notebook
     "Cells are ordered in a `Notebook`, and this order can be changed by the user. Cells will always have a constant UUID."
-    cells::Array{Cell,1}
+    cells::Vector{Cell}
     
     # i still don't really know what an AbstractString is but it makes this package look more professional
     path::AbstractString
@@ -35,10 +35,10 @@ mutable struct Notebook
 end
 # We can keep 128 updates pending. After this, any put! calls (i.e. calls that push an update to the notebook) will simply block, which is fine.
 # This does mean that the Notebook can't be used if nothing is clearing the update channel.
-Notebook(cells::Array{Cell,1}, path::AbstractString, notebook_id::UUID) = 
+Notebook(cells::Vector{Cell}, path::AbstractString, notebook_id::UUID) = 
     Notebook(cells, path, notebook_id, NotebookTopology(), Channel(1024), Token(), nothing)
 
-Notebook(cells::Array{Cell,1}, path::AbstractString=numbered_until_new(joinpath(new_notebooks_directory(), cutename()))) = Notebook(cells, path, uuid1())
+Notebook(cells::Vector{Cell}, path::AbstractString=numbered_until_new(joinpath(new_notebooks_directory(), cutename()))) = Notebook(cells, path, uuid1())
 
 function cell_index_from_id(notebook::Notebook, cell_id::UUID)::Union{Int,Nothing}
     findfirst(c -> c.cell_id == cell_id, notebook.cells)

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -618,7 +618,7 @@ pluto_showable(m::MIME, @nospecialize(x))::Bool = Base.invokelatest(showable, m,
 
 
 # We invent our own MIME _because we can_ but don't use it somewhere else because it might change :)
-pluto_showable(::MIME"application/vnd.pluto.tree+object", ::AbstractArray{<:Any,1}) = true
+pluto_showable(::MIME"application/vnd.pluto.tree+object", ::AbstractVector{<:Any}) = true
 pluto_showable(::MIME"application/vnd.pluto.tree+object", ::AbstractDict{<:Any,<:Any}) = true
 pluto_showable(::MIME"application/vnd.pluto.tree+object", ::Tuple) = true
 pluto_showable(::MIME"application/vnd.pluto.tree+object", ::NamedTuple) = true
@@ -637,7 +637,7 @@ pluto_showable(::MIME"application/vnd.pluto.table+object", t::AbstractVector{<:N
 # in the next functions you see a `context` argument
 # this is really only used for the circular reference tracking
 
-function tree_data_array_elements(@nospecialize(x::AbstractArray{<:Any,1}), indices::AbstractVector{I}, context::IOContext)::Vector{Tuple{I,Any}} where {I<:Integer}
+function tree_data_array_elements(@nospecialize(x::AbstractVector{<:Any}), indices::AbstractVector{I}, context::IOContext)::Vector{Tuple{I,Any}} where {I<:Integer}
     Tuple{I,Any}[
         if isassigned(x, i)
             i, format_output_default(x[i], context)
@@ -648,7 +648,7 @@ function tree_data_array_elements(@nospecialize(x::AbstractArray{<:Any,1}), indi
     ] |> collect
 end
 
-function array_prefix(@nospecialize(x::Array{<:Any,1}))::String
+function array_prefix(@nospecialize(x::Vector{<:Any}))::String
     string(eltype(x))
 end
 function array_prefix(@nospecialize(x))::String
@@ -667,7 +667,7 @@ function get_my_display_limit(@nospecialize(x), dim::Integer, context::IOContext
     end
 end
 
-function tree_data(@nospecialize(x::AbstractArray{<:Any,1}), context::IOContext)
+function tree_data(@nospecialize(x::AbstractVector{<:Any}), context::IOContext)
     indices = eachindex(x)
     my_limit = get_my_display_limit(x, 1, context, tree_display_limit, tree_display_limit_increase)
 
@@ -830,7 +830,7 @@ function table_data(x::Any, io::IOContext)
     # not enumerate(rows) because of some silliness
     # not rows[i] because `getindex` is not guaranteed to exist
     L = truncate_rows ? my_row_limit : length(rows)
-    row_data = Array{Any,1}(undef, L)
+    row_data = Vector{Any}(undef, L)
     for (i, row) in zip(1:L,rows)
         row_data[i] = (i, row_data_for(row))
     end

--- a/src/webserver/Dynamic.jl
+++ b/src/webserver/Dynamic.jl
@@ -177,7 +177,7 @@ responses[:set_bond] = (session::ServerSession, body, notebook::Notebook; initia
         putnotebookupdates!(session, notebook, UpdateMessage(:bond_update, reponse, notebook, nothing, initiator))
         
         if !cancel_run_early
-            function custom_deletion_hook((session, notebook)::Tuple{ServerSession,Notebook}, to_delete_vars::Set{Symbol}, funcs_to_delete::Set{Tuple{UUID,FunctionName}}, to_reimport::Set{Expr}; to_run::Array{Cell,1})
+            function custom_deletion_hook((session, notebook)::Tuple{ServerSession,Notebook}, to_delete_vars::Set{Symbol}, funcs_to_delete::Set{Tuple{UUID,FunctionName}}, to_reimport::Set{Expr}; to_run::Vector{Cell})
                 push!(to_delete_vars, bound_sym) # also delete the bound symbol
                 WorkspaceManager.delete_vars((session, notebook), to_delete_vars, funcs_to_delete, to_reimport)
                 WorkspaceManager.eval_in_workspace((session, notebook), :($bound_sym = $new_val))


### PR DESCRIPTION
Hi again! I'm working on a linter, and saw that this repository  has [21 occurrences](https://lint.huijzer.xyz/github/fonsp/pluto.jl/#replace_arrayt1_with_vectort_21_hits) of using 
```
Array{T,1}
```
where this could be shortened to
```
Vector{T}
```
I know that it doesn't shorten the code too much, but I think that overall it does improve the readability, and that is why I open this PR :smile: 

Feel free to close this PR immediately if you're not interested in this small refactoring.