### PR TITLE
 Dralbase state managment: Fix front-end tests

### DIFF
--- a/test/frontend/__tests__/autocomplete_test.js
+++ b/test/frontend/__tests__/autocomplete_test.js
@@ -28,6 +28,7 @@ describe("PlutoAutocomplete", () => {
         // Type the partial input
         lastPlutoCellId = lastElement(await getCellIds(page))
         await writeSingleLineInPlutoInput(page, `pluto-cell[id="${lastPlutoCellId}"] pluto-input`, "my_su")
+        await page.waitFor(500)
 
         // Trigger autocomplete suggestions
         await page.keyboard.press("Tab")

--- a/test/frontend/__tests__/new_notebook_test.js
+++ b/test/frontend/__tests__/new_notebook_test.js
@@ -2,7 +2,8 @@ import { waitForContent,
     lastElement, 
     dismissBeforeUnloadDialogs,
     saveScreenshot,
-    getTestScreenshotPath
+    getTestScreenshotPath,
+    waitForContentToBecome
 } from '../helpers/common'
 import {
     createNewNotebook,
@@ -72,8 +73,10 @@ describe('PlutoNewNotebook', () => {
             'a + b + c'
         ]
         const plutoCellIds = await manuallyEnterCells(page, cells)
-        await page.click('.runallchanged')
-        const content = await waitForCellOutput(page, lastElement(plutoCellIds))
+        await page.waitForSelector(`.runallchanged`, {visible: true, polling: 200, timeout: 0})
+        await page.click(`.runallchanged`)
+        await page.waitForSelector(`body:not(.update_is_ongoing)`, {polling: 100})
+        const content = await waitForContentToBecome(page, `pluto-cell[id="${plutoCellIds[3]}"] pluto-output`, '6')
         expect(content).toBe('6')
     })
 
@@ -85,8 +88,10 @@ describe('PlutoNewNotebook', () => {
             'a + b + c'
         ]
         const plutoCellIds = await manuallyEnterCells(page, cells)
-        await page.click('.runallchanged')
-        const initialLastCellContent = await waitForCellOutput(page, lastElement(plutoCellIds))
+        await page.waitForSelector(`.runallchanged`, {visible: true, polling: 200, timeout: 0})
+        await page.click(`.runallchanged`)
+        await page.waitForSelector(`body:not(.update_is_ongoing)`, {polling: 100})
+        const initialLastCellContent = await waitForContentToBecome(page, `pluto-cell[id="${plutoCellIds[3]}"] pluto-output`, "6")
         expect(initialLastCellContent).toBe('6')
 
         // Change second cell
@@ -98,8 +103,8 @@ describe('PlutoNewNotebook', () => {
         // Enter 10
         await writeSingleLineInPlutoInput(page, secondCellInputSelector, '10')
 
-        // Re-evaluate
-        await page.click('.runallchanged')
+        await page.click(`pluto-cell[id="${plutoCellIds[1]}"] .runcell`)
+
         const reactiveLastCellContent = await waitForCellOutputToChange(page, lastElement(plutoCellIds), '6')
 
         expect(reactiveLastCellContent).toBe('14')

--- a/test/frontend/helpers/common.js
+++ b/test/frontend/helpers/common.js
@@ -9,7 +9,7 @@ export const waitForContent = async (page, selector) => {
     await page.waitFor((selector) => {
         const element = document.querySelector(selector)
         return element !== null && element.textContent.length > 0
-    }, {}, selector)
+    }, {polling: 100}, selector)
     return getTextContent(selector)
 }
 
@@ -18,7 +18,16 @@ export const waitForContentToChange = async (page, selector, currentContent) => 
     await page.waitFor((selector, currentContent) => {
         const element = document.querySelector(selector)
         return element !== null && element.textContent !== currentContent
-    }, {}, selector, currentContent)
+    }, {polling: 100}, selector, currentContent)
+    return getTextContent(selector)
+}
+
+export const waitForContentToBecome = async (page, selector, targetContent) => {
+    await page.waitForSelector(selector, { visible: true })
+    await page.waitFor((selector, targetContent) => {
+        const element = document.querySelector(selector)
+        return element !== null && element.textContent === targetContent
+    }, {polling: 100}, selector, targetContent)
     return getTextContent(selector)
 }
 

--- a/test/frontend/helpers/pluto.js
+++ b/test/frontend/helpers/pluto.js
@@ -59,7 +59,7 @@ export const writeSingleLineInPlutoInput = async (page, plutoInputSelector, text
     return page.waitFor((plutoInputSelector, text) => {
         const codeMirrorLine = document.querySelector(`${plutoInputSelector} .CodeMirror-line`)
         return codeMirrorLine !== null && codeMirrorLine.textContent.endsWith(text)
-    }, {}, plutoInputSelector, text)
+    }, {polling: 100}, plutoInputSelector, text)
 }
 
 export const keyboardPressInPlutoInput = async (page, plutoInputSelector, key) => {
@@ -67,6 +67,7 @@ export const keyboardPressInPlutoInput = async (page, plutoInputSelector, key) =
     await page.focus(`${plutoInputSelector} textarea`)
     await page.waitFor(500)
     await page.keyboard.press(key)
+    await page.waitFor(500)
     // Wait for CodeMirror to process the input and display the text
     return waitForContentToChange(page, `${plutoInputSelector} .CodeMirror-line`, currentLineText)
 }


### PR DESCRIPTION
Content in front-end changes multiple times, as patches are sent
to the backend. It's not reliable to wait for the first change,
which is sometimes an undefined error (@dralletje??!!)
so we wait until the result stabilizes to the value we expect.

To the user that's transparent (hopefully). We've also added
a counter to keep track of pending backend requests, and add a
class to the document.body (that doesn't do anything else).