### PR TITLE
Regard `:=` in macros as einsum notation (take 2)

### DIFF
--- a/src/analysis/ExpressionExplorer.jl
+++ b/src/analysis/ExpressionExplorer.jl
@@ -261,6 +261,18 @@ end
 assign_to_kw(e::Expr) = e.head == :(=) ? Expr(:kw, e.args...) : e
 assign_to_kw(x::Any) = x
 
+"Turn `A[i] * B[j,K[l+m]]` into `A[0] * B[0,K[0+0]]` to hide loop indices"
+function strip_indexing(x, inside::Bool=false)
+    if Meta.isexpr(x, :ref)
+        Expr(:ref, strip_indexing(x.args[1]), strip_indexing.(x.args[2:end], true)...)
+    elseif Meta.isexpr(x, :call)
+        Expr(x.head, x.args[1], strip_indexing.(x.args[2:end], inside)...)
+    elseif x isa Symbol && inside
+        0
+    else
+        x
+    end
+end
 
 ###
 # MAIN RECURSIVE FUNCTION
@@ -376,9 +388,22 @@ function explore!(ex::Expr, scopestate::ScopeState)::SymbolsState
         end
 
         new_ex = if length(ex.args) > 3 && ex.args[1] != GlobalRef(Core, Symbol("@doc"))
+            # for macros like @test a ≈ b atol=1e-6, read assignment in 2nd & later arg as keywords
             Expr(:call, ex.args[1:3]..., assign_to_kw.(ex.args[4:end])...)
         else
             Expr(:call, ex.args...)
+        end
+
+	   if length(new_ex.args) >= 3 && Meta.isexpr(new_ex.args[3], :(:=))
+            # macros like @einsum C[i] := A[i,j] are assignment to C, illegal syntax without macro
+            ein = new_ex.args[3]
+            left = if Meta.isexpr(ein.args[1], :ref)
+                ein.args[1].args[1]
+            else
+                ein.args[1]  # scalar case `c := A[i,j]`
+            end
+            ein_done = Expr(:(=), left, strip_indexing.(ein.args[2:end])...)  # i,j etc. are local
+            new_ex = Expr(:call, new_ex.args[1:2]..., ein_done, strip_indexing.(new_ex.args[4:end])...)
         end
 
         return explore!(new_ex, scopestate)

--- a/src/analysis/ExpressionExplorer.jl
+++ b/src/analysis/ExpressionExplorer.jl
@@ -398,6 +398,8 @@ function explore!(ex::Expr, scopestate::ScopeState)::SymbolsState
             # macros like @einsum C[i] := A[i,j] are assignment to C, illegal syntax without macro
             ein = new_ex.args[3]
             left = if Meta.isexpr(ein.args[1], :ref)
+                # assign to the symbol, and save LHS indices as fake RHS argument
+                push!(new_ex.args, Expr(:ref, :Float64, ein.args[1].args[2:end]...))
                 ein.args[1].args[1]
             else
                 ein.args[1]  # scalar case `c := A[i,j]`

--- a/test/ExpressionExplorer.jl
+++ b/test/ExpressionExplorer.jl
@@ -303,8 +303,9 @@ using Test
 
         @test testee(:(@asdf a = x1 b = x2 c = x3), [:x1, :x2, :x3], [:a], [Symbol("@asdf")], []) # https://github.com/fonsp/Pluto.jl/issues/670
 
-        @test testee(:(@einsum a[i,j] := x[i]*y[j]), [:x, :y], [:a], [[Symbol("@einsum")], [:*]], [])
+        @test testee(:(@einsum a[i,j] := x[i]*y[j]), [:x, :y, :Float64], [:a], [[Symbol("@einsum")], [:*]], [])
         @test testee(:(@tullio a := f(x)[i+2j, k[j]] init=z), [:x, :k, :z], [:a], [[Symbol("@tullio")], [:f], [:*], [:+]], [])
+        @test testee(:(Pack.@asdf a[1,k[j]] := log(x[i]/y[j])), [:x, :y, :k, :Pack, :Float64], [:a], [[:Pack, Symbol("@asdf")], [:/], [:log]], [])
 
         @test testee(:(md"hey $(@bind a b) $(a)"), [:b], [:a], [:get, :applicable, :Bond, Symbol("@md_str"), Symbol("@bind")], [])
         @test testee(:(md"hey $(a) $(@bind a b)"), [:b, :a], [:a], [:get, :applicable, :Bond, Symbol("@md_str"), Symbol("@bind")], [])

--- a/test/ExpressionExplorer.jl
+++ b/test/ExpressionExplorer.jl
@@ -303,6 +303,9 @@ using Test
 
         @test testee(:(@asdf a = x1 b = x2 c = x3), [:x1, :x2, :x3], [:a], [Symbol("@asdf")], []) # https://github.com/fonsp/Pluto.jl/issues/670
 
+        @test testee(:(@einsum a[i,j] := x[i]*y[j]), [:x, :y], [:a], [[Symbol("@einsum")], [:*]], [])
+        @test testee(:(@tullio a := f(x)[i+2j, k[j]] init=z), [:x, :k, :z], [:a], [[Symbol("@tullio")], [:f], [:*], [:+]], [])
+
         @test testee(:(md"hey $(@bind a b) $(a)"), [:b], [:a], [:get, :applicable, :Bond, Symbol("@md_str"), Symbol("@bind")], [])
         @test testee(:(md"hey $(a) $(@bind a b)"), [:b, :a], [:a], [:get, :applicable, :Bond, Symbol("@md_str"), Symbol("@bind")], [])
         @test testee(:(html"a $(b = c)"), [], [], [Symbol("@html_str")], [])


### PR DESCRIPTION
This is another, simpler, attempt at my initial idea in #407. It interprets macro calls like `@einsum A[i] := B[i,j]` as assignment to `A`.

A small example notebook, which gives errors without this PR: 
https://gist.github.com/mcabbott/cf49093313612b084614b90d4f96af0d

The function `strip_indexing` makes this not quite the minimal version. It ensures that Pluto doesn't think the result depends on `i,j` (if these are defined elsewhere) since they are loop variables. If this is removed, it should still work without errors, but sometimes updates things unnecessarily.