### PR TITLE
🧸 Open your own files as samples

### DIFF
--- a/src/notebook/PathHelpers.jl
+++ b/src/notebook/PathHelpers.jl
@@ -58,6 +58,19 @@ function new_notebooks_directory()
     end
 end
 
+function without_dotjl(path)
+	extension = let
+		parts = split(basename(path), '.')
+		length(parts) == 1 ? "" : last(parts)
+	end
+
+	if startswith(extension, "jl")
+		path[1:end-length(extension)-1]
+	else
+		path
+	end
+end
+
 """
 Return `base` * `suffix` if the file does not exist yet.
 

--- a/src/webserver/Static.jl
+++ b/src/webserver/Static.jl
@@ -155,16 +155,17 @@ function http_router_for(session::ServerSession)
         try
             uri = HTTP.URI(request.target)
             query = HTTP.queryparams(uri)
+            as_sample = haskey(query, "as_sample")
             if haskey(query, "path")
                 path = tamepath(query["path"])
                 if isfile(path)
-                    return try_launch_notebook_response(SessionActions.open, path, title="Failed to load notebook", advice="The file <code>$(htmlesc(path))</code> could not be loaded. Please <a href='https://github.com/fonsp/Pluto.jl/issues'>report this error</a>!")
+                    return try_launch_notebook_response(SessionActions.open, path; as_sample=as_sample, title="Failed to load notebook", advice="The file <code>$(htmlesc(path))</code> could not be loaded. Please <a href='https://github.com/fonsp/Pluto.jl/issues'>report this error</a>!")
                 else
                     return error_response(404, "Can't find a file here", "Please check whether <code>$(htmlesc(path))</code> exists.")
                 end
             elseif haskey(query, "url")
                 url = query["url"]
-                return try_launch_notebook_response(SessionActions.open_url, url, title="Failed to load notebook", advice="The notebook from <code>$(htmlesc(url))</code> could not be loaded. Please <a href='https://github.com/fonsp/Pluto.jl/issues'>report this error</a>!")
+                return try_launch_notebook_response(SessionActions.open_url, url; as_sample=as_sample, title="Failed to load notebook", advice="The notebook from <code>$(htmlesc(url))</code> could not be loaded. Please <a href='https://github.com/fonsp/Pluto.jl/issues'>report this error</a>!")
             else
                 error("Empty request")
             end

--- a/src/webserver/Static.jl
+++ b/src/webserver/Static.jl
@@ -127,9 +127,9 @@ function http_router_for(session::ServerSession)
     HTTP.@register(router, "GET", "/ping", r -> HTTP.Response(200, "OK!"))
     HTTP.@register(router, "GET", "/possible_binder_token_please", r -> session.binder_token === nothing ? HTTP.Response(404,"") : HTTP.Response(200, session.binder_token))
     
-    function try_launch_notebook_response(action::Function, path_or_url::AbstractString; title="", advice="", home_url="./")
+    function try_launch_notebook_response(action::Function, path_or_url::AbstractString; title="", advice="", home_url="./", action_kwargs...)
         try
-            nb = action(session, path_or_url)
+            nb = action(session, path_or_url; action_kwargs...)
             notebook_redirect_response(nb; home_url=home_url)
         catch e
             if e isa SessionActions.NotebookIsRunningException
@@ -180,13 +180,10 @@ function http_router_for(session::ServerSession)
         security.require_secret_for_open_links
     ) do request::HTTP.Request
         uri = HTTP.URI(request.target)
-        sample_path = split(HTTP.unescapeuri(uri.path), "sample/")[2]
-        sample_path_without_dotjl = "sample " * sample_path[1:end - 3]
+        sample_filename = split(HTTP.unescapeuri(uri.path), "sample/")[2]
+        sample_path = project_relative_path("sample", sample_filename)
         
-        path = numbered_until_new(joinpath(new_notebooks_directory(), sample_path_without_dotjl))
-        readwrite(project_relative_path("sample", sample_path), path)
-        
-        try_launch_notebook_response(SessionActions.open, path, home_url="../", title="Failed to load sample", advice="Please <a href='https://github.com/fonsp/Pluto.jl/issues'>report this error</a>!")
+        try_launch_notebook_response(SessionActions.open, sample_path, home_url="../", title="Failed to load sample", advice="Please <a href='https://github.com/fonsp/Pluto.jl/issues'>report this error</a>!", as_sample=true)
     end
     HTTP.@register(router, "GET", "/sample/*", serve_sample)
 


### PR DESCRIPTION
If you put `as_sample=yes` in the URL search parameters, the path/URL will be opened as a sample notebook:

Example open link:

`http://localhost:1234/open?path=%2FUsers%2Ffons%2F.julia%2Fpluto_notebooks%2Fsample+Interactivity+2.jl`

as sample:

`http://localhost:1234/open?path=%2FUsers%2Ffons%2F.julia%2Fpluto_notebooks%2Fsample+Interactivity+2.jl&as_sample=yesplease`

@GiggleLiu 