### PR TITLE
Handle filters in generators, closes #824

### DIFF
--- a/src/analysis/ExpressionExplorer.jl
+++ b/src/analysis/ExpressionExplorer.jl
@@ -357,6 +357,9 @@ function explore!(ex::Expr, scopestate::ScopeState)::SymbolsState
     elseif ex.head == :let || ex.head == :for || ex.head == :while
         # Creates local scope
         return explore_inner_scoped(ex, scopestate)
+    elseif ex.head == :filter
+        # In a filter, the assignment is the second expression, the condition the first
+        return mapfoldr(a -> explore!(a, scopestate), union!, ex.args, init=SymbolsState())
     elseif ex.head == :generator
         # Creates local scope
 

--- a/test/ExpressionExplorer.jl
+++ b/test/ExpressionExplorer.jl
@@ -119,6 +119,9 @@ using Test
         @test testee(:([sqrt(s) for s in 1:n]), [:n], [], [:sqrt, :(:)], [])
         @test testee(:([sqrt(s + r) for s in 1:n, r in k]), [:n, :k], [], [:sqrt, :(:), :+], [])
         @test testee(:([s + j + r + m for s in 1:3 for j in 4:5 for (r, l) in [(1, 2)]]), [:m], [], [:+, :(:)], [])
+        @test testee(:([a for a in b if a != 2]), [:b], [], [:(!=)], [])
+        @test testee(:([a for a in f() if g(a)]), [], [], [:f, :g], [])
+        @test testee(:([c(a) for a in f() if g(a)]), [], [], [:c, :f, :g], [])
 
         @test testee(:([a for a in a]), [:a], [], [], [])
         @test testee(:(for a in a; a; end), [:a], [], [], [])


### PR DESCRIPTION
Hi! 

Here is a small fix for issue #824:
The expression in the `:filter` are reversed so we need to use `mapfoldr` instead of `mapfoldl`.

Fixes #824 