### PR TITLE
Fix anonymous function declaration

### DIFF
--- a/src/analysis/ExpressionExplorer.jl
+++ b/src/analysis/ExpressionExplorer.jl
@@ -856,7 +856,7 @@ function canonalize(ex::Expr)
 		Expr(:where, canonalize(ex.args[1]), ex.args[2:end]...)
 	elseif ex.head == :call || ex.head == :tuple
 		skip_index = ex.head == :call ? 2 : 1
-		ex.args[1] # if ex.head == :call this is the function name, we dont want it
+		# ex.args[1], if ex.head == :call this is the function name, we dont want it
 
 		interesting = filter(ex.args[skip_index:end]) do arg
 			!(arg isa Expr && arg.head == :parameters)

--- a/test/ExpressionExplorer.jl
+++ b/test/ExpressionExplorer.jl
@@ -223,7 +223,7 @@ Some of these @test_broken lines are commented out to prevent printing to the te
         #     :anon => ([:y], [], [], [])
         # ])
         @test testee(:(f = function (a, b) a + b * n end), [:n], [:f], [:+, :*], [])
-        # @test_broken testee(:(f = function () a + b end), [:a, :b], [:f], [:+], [])
+        @test testee(:(f = function () a + b end), [:a, :b], [:f], [:+], [])
 
         @test testee(:(func(a)), [:a], [], [:func], [])
         @test testee(:(func(a; b=c)), [:a, :c], [], [:func], [])


### PR DESCRIPTION
Another small fix :wave: 

Removes a no-op instruction which was accessing the first element of
the expression's args, crashing for anonymous functions with no
parameters like `function() x end`.

Fixes #776