### PR TITLE
Rename callable struct definitions

### DIFF
--- a/src/analysis/ExpressionExplorer.jl
+++ b/src/analysis/ExpressionExplorer.jl
@@ -685,8 +685,16 @@ end
 Is also used for `struct` and `abstract`."
 function explore_funcdef!(ex::Expr, scopestate::ScopeState)::Tuple{FunctionName,SymbolsState}
     if ex.head == :call
+        # Handle struct as callables, `(obj::MyType)(a, b) = ...`
+        # or `function (obj::MyType)(a, b) ...; end` by rewriting it as:
+        # function MyType(obj, a, b) ...; end
+        funcroot = ex.args[1]
+        if funcroot isa Expr && funcroot.head == :(::)
+            return explore_funcdef!(Expr(:call, reverse(funcroot.args)..., ex.args[2:end]...), scopestate)
+        end
+
         # get the function name
-        name, symstate = explore_funcdef!(ex.args[1], scopestate)
+        name, symstate = explore_funcdef!(funcroot, scopestate)
         # and explore the function arguments
         return mapfoldl(a -> explore_funcdef!(a, scopestate), union!, ex.args[2:end], init=(name, symstate))
 

--- a/test/ExpressionExplorer.jl
+++ b/test/ExpressionExplorer.jl
@@ -278,9 +278,27 @@ Some of these @test_broken lines are commented out to prevent printing to the te
             :f => ([:A, :B, :C], [], [:+], [])
         ])
 
-        @test_broken testee(:((obj::MyType)(x,y) = x + z), [:z], [:MyType], [:+], [], verbose=false)
-        @test_broken testee(:((obj::MyType)() = 1), [], [:MyType], [], [], verbose=false)
-        @test_broken testee(:((obj::MyType)(x, args...; kwargs...) = [x, y, args..., kwargs...]), [:y], [:MyType], [], [], verbose=false)
+        @test testee(:((obj::MyType)(x,y) = x + z), [], [], [], [
+            :MyType => ([:z], [], [:+], [])
+        ])
+        @test testee(:((obj::MyType)() = 1), [], [], [], [
+            :MyType => ([], [], [], [])
+        ])
+        @test testee(:((obj::MyType)(x, args...; kwargs...) = [x, y, args..., kwargs...]), [], [], [], [
+            :MyType => ([:y], [], [], [])
+        ])
+        @test testee(:(function (obj::MyType)(x, y) x + z end), [], [], [], [
+            :MyType => ([:z], [], [:+], [])
+        ])
+        @test testee(:(begin struct MyType x::String end; (obj::MyType)(y) = obj.x + y; end), [], [:MyType], [], [
+            :MyType => ([:String], [], [:+], [])
+        ])
+        @test testee(:(begin struct MyType x::String end; function(obj::MyType)(y) obj.x + y; end; end), [], [:MyType], [], [
+            :MyType => ([:String], [], [:+], [])
+        ])
+        @test testee(:((::MyType)(x,y) = x + y), [], [], [], [
+            :MyType => ([], [], [:+], [])
+        ])
     end
     @testset "Scope modifiers" begin
         @test testee(:(let global a, b = 1, 2 end), [], [:a, :b], [], [])


### PR DESCRIPTION
Handle struct as callables, `(obj::MyType)(a, b) = ...`
or `function (obj::MyType)(a, b) ...; end` by rewriting it as:
`function MyType(obj, a, b) ...; end`

More information in issue #288 

Closes #288