### PR TITLE
CSS animation performance

### DIFF
--- a/frontend/components/Cell.js
+++ b/frontend/components/Cell.js
@@ -2,7 +2,7 @@ import { html, useState, useEffect, useMemo, useRef, useContext } from "../impor
 
 import { CellOutput } from "./CellOutput.js"
 import { CellInput } from "./CellInput.js"
-import { RunArea, useDebouncedTruth, useMillisSinceTruthy } from "./RunArea.js"
+import { RunArea, useDebouncedTruth } from "./RunArea.js"
 import { cl } from "../common/ClassTable.js"
 import { useDropHandler } from "./useDropHandler.js"
 import { PlutoContext } from "../common/PlutoContext.js"
@@ -37,7 +37,6 @@ export const Cell = ({
     // cm_forced_focus is null, except when a line needs to be highlighted because it is part of a stack trace
     const [cm_forced_focus, set_cm_forced_focus] = useState(null)
     const { saving_file, drag_active, handler } = useDropHandler()
-    const localTimeRunning = 10e5 * useMillisSinceTruthy(running)
     useEffect(() => {
         const focusListener = (e) => {
             if (e.detail.cell_id === cell_id) {
@@ -162,7 +161,8 @@ export const Cell = ({
                         pluto_actions.set_and_run_multiple(cell_to_run)
                     }
                 }}
-                runtime=${localTimeRunning || runtime}
+                runtime=${runtime}
+                running=${running}
             />
             <button
                 onClick=${() => {

--- a/frontend/components/Cell.js
+++ b/frontend/components/Cell.js
@@ -2,7 +2,7 @@ import { html, useState, useEffect, useMemo, useRef, useContext } from "../impor
 
 import { CellOutput } from "./CellOutput.js"
 import { CellInput } from "./CellInput.js"
-import { RunArea, useMillisSinceTruthy } from "./RunArea.js"
+import { RunArea, useDebouncedTruth, useMillisSinceTruthy } from "./RunArea.js"
 import { cl } from "../common/ClassTable.js"
 import { useDropHandler } from "./useDropHandler.js"
 import { PlutoContext } from "../common/PlutoContext.js"
@@ -65,6 +65,9 @@ export const Cell = ({
             set_waiting_to_run(false)
         }
     }, [queued, running, output?.last_run_timestamp])
+    // We activate animations instantly BUT deactivate them NSeconds later.
+    // We then toggle animation visibility using opacity. This saves a bunch of repaints.
+    const activate_animation = useDebouncedTruth(running || queued || waiting_to_run)
 
     const class_code_differs = code !== (cell_input_local?.code ?? code)
     const class_code_folded = code_folded && cm_forced_focus == null
@@ -81,6 +84,7 @@ export const Cell = ({
             class=${cl({
                 queued: queued || waiting_to_run,
                 running: running,
+                activate_animation: activate_animation,
                 errored: errored,
                 selected: selected,
                 code_differs: class_code_differs,

--- a/frontend/components/RunArea.js
+++ b/frontend/components/RunArea.js
@@ -1,11 +1,12 @@
 import { in_textarea_or_input } from "../common/KeyboardShortcuts.js"
 import { html, useEffect, useMemo, useState } from "../imports/Preact.js"
 
-export const RunArea = ({ runtime, onClick }) => {
+export const RunArea = ({ runtime, onClick, running }) => {
+    const localTimeRunning = 10e5 * useMillisSinceTruthy(running)
     return html`
         <pluto-runarea>
             <button onClick=${onClick} class="runcell" title="Run"><span></span></button>
-            <span class="runtime">${prettytime(runtime)}</span>
+            <span class="runtime">${prettytime(running ? localTimeRunning || runtime : runtime)}</span>
         </pluto-runarea>
     `
 }

--- a/frontend/components/RunArea.js
+++ b/frontend/components/RunArea.js
@@ -1,4 +1,5 @@
-import { html, useEffect, useState } from "../imports/Preact.js"
+import { in_textarea_or_input } from "../common/KeyboardShortcuts.js"
+import { html, useEffect, useMemo, useState } from "../imports/Preact.js"
 
 export const RunArea = ({ runtime, onClick }) => {
     return html`
@@ -47,4 +48,20 @@ export const useMillisSinceTruthy = (truthy) => {
         }
     }, [truthy])
     return truthy ? now - startRunning : undefined
+}
+
+const NSeconds = 5
+export const useDebouncedTruth = (truthy) => {
+    const [mytruth, setMyTruth] = useState(truthy)
+    const setMyTruthAfterNSeconds = useMemo(() => _.debounce(setMyTruth, NSeconds * 1000), [setMyTruth])
+    useEffect(() => {
+        if (truthy) {
+            setMyTruth(true)
+            setMyTruthAfterNSeconds.cancel()
+        } else {
+            setMyTruthAfterNSeconds(false)
+        }
+        return () => {}
+    }, [truthy])
+    return mytruth
 }

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -910,11 +910,13 @@ pluto-trafficlight {
 pluto-trafficlight::after {
     content: "";
     /* Calc needs units everywhere to work */
-    top: calc(0px - 2 * var(--patternHeight));
+    top: calc(0px - 10 * var(--patternHeight));
     left: 0;
     width: 100%;
-    height: calc(100% + 2 * var(--patternHeight));
+    height: calc(100% + 10 * var(--patternHeight));
     position: absolute;
+    opacity: 0;
+    animation: 10s linear 100ms infinite running scrollbackground;
 }
 
 /* in ascending order of severity: */
@@ -959,14 +961,14 @@ pluto-cell.errored > pluto-trafficlight {
 pluto-cell.queued > pluto-trafficlight::after {
     background: repeating-linear-gradient(-45deg, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0) 8px, rgba(0, 0, 0, 0.1) 8px, rgba(0, 0, 0, 0.1) 16px);
     background-clip: content-box;
-    animation: 1s linear 0s infinite running scrollbackground;
+    opacity: 0.97;
     background-size: 4px var(--patternHeight);
 }
 
 pluto-cell.running > pluto-trafficlight::after {
     background: repeating-linear-gradient(-45deg, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.1) 8px, rgba(0, 0, 0, 0.2) 8px, rgba(0, 0, 0, 0.2) 16px);
     background-clip: content-box;
-    animation: 1s linear 0s infinite running scrollbackground;
+    opacity: 0.97;
     background-size: 4px var(--patternHeight);
 }
 
@@ -979,14 +981,14 @@ pluto-cell.queued.errored > pluto-trafficlight::after {
         hsla(0, 70%, 80%, 0.05) 16px
     );
     background-clip: content-box;
-    animation: 1s linear 0s infinite running scrollbackground;
+    opacity: 0.97;
     background-size: 4px var(--patternHeight); /* 16 * sqrt(2) */
 }
 
 pluto-cell.running.errored > pluto-trafficlight::after {
     background: repeating-linear-gradient(-45deg, hsla(0, 100%, 80%, 1), hsla(0, 100%, 80%, 1) 8px, hsla(0, 70%, 80%, 0.7) 8px, hsla(0, 70%, 80%, 0.7) 16px);
     background-clip: content-box;
-    animation: 1s linear 0s infinite running scrollbackground;
+    opacity: 0.97;
     background-size: 4px var(--patternHeight); /* 16 * sqrt(2) */
 }
 
@@ -1024,10 +1026,10 @@ pluto-cell.drop_target.drop_invalid pluto-input::after {
 /* Define --patternHeight for this keyframes animation to work! */
 @keyframes scrollbackground {
     0% {
-        transform: translateY(0px);
+        transform: translate(0px, 0px);
     }
     100% {
-        transform: translateY(calc(var(--patternHeight)));
+        transform: translate(0, calc(10 * var(--patternHeight)));
     }
 }
 

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -921,9 +921,13 @@ pluto-trafficlight::after {
     opacity: 0;
 }
 
-/* This class will toggle animation. Other classes will make animation visible with opacity */
+/*
+ * This class will toggle animation.
+ * Other classes will make animation visible with opacity (which is CHEAP?)
+ * 
+ */
 pluto-cell.activate_animation pluto-trafficlight::after {
-    animation: 10s linear 100ms infinite running scrollbackground;
+    animation: 10s linear 0s infinite running scrollbackground;
 }
 
 /* in ascending order of severity: */
@@ -968,14 +972,22 @@ pluto-cell.errored > pluto-trafficlight {
 pluto-cell.queued > pluto-trafficlight::after {
     background: repeating-linear-gradient(-45deg, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0) 8px, rgba(0, 0, 0, 0.1) 8px, rgba(0, 0, 0, 0.1) 16px);
     background-clip: content-box;
-    opacity: 0.97;
+    /* [1]
+    Queued, Running, Errored are really fast changing props.
+    We make sure to on-off the gradients with opacity and not toggle the animation
+    (Which is running all this time)
+    Make sure the browser won't skip creating a stacking context
+    https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context
+    https://www.w3.org/TR/css-color-3/#transparency
+    */
+    opacity: 0.99;
     background-size: 4px var(--patternHeight);
 }
 
 pluto-cell.running > pluto-trafficlight::after {
     background: repeating-linear-gradient(-45deg, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.1) 8px, rgba(0, 0, 0, 0.2) 8px, rgba(0, 0, 0, 0.2) 16px);
     background-clip: content-box;
-    opacity: 0.97;
+    opacity: 0.99; /* [1] */
     background-size: 4px var(--patternHeight);
 }
 
@@ -988,14 +1000,14 @@ pluto-cell.queued.errored > pluto-trafficlight::after {
         hsla(0, 70%, 80%, 0.05) 16px
     );
     background-clip: content-box;
-    opacity: 0.97;
+    opacity: 0.99; /* [1] */
     background-size: 4px var(--patternHeight); /* 16 * sqrt(2) */
 }
 
 pluto-cell.running.errored > pluto-trafficlight::after {
     background: repeating-linear-gradient(-45deg, hsla(0, 100%, 80%, 1), hsla(0, 100%, 80%, 1) 8px, hsla(0, 70%, 80%, 0.7) 8px, hsla(0, 70%, 80%, 0.7) 16px);
     background-clip: content-box;
-    opacity: 0.97;
+    opacity: 0.99; /* [1] */
     background-size: 4px var(--patternHeight); /* 16 * sqrt(2) */
 }
 

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -916,6 +916,10 @@ pluto-trafficlight::after {
     height: calc(100% + 10 * var(--patternHeight));
     position: absolute;
     opacity: 0;
+}
+
+/* This class will toggle animation. Other classes will make animation visible with opacity */
+pluto-cell.activate_animation pluto-trafficlight::after {
     animation: 10s linear 100ms infinite running scrollbackground;
 }
 


### PR DESCRIPTION
# Problem statement
When you move a slider in a graph, a significant number of repaints happen to the _whole page_, according to Google Chrome devtools

> The expectation would be for only the dependent cell _outputs_ to repaint.

# What we know happens
The [animation](https://github.com/fonsp/Pluto.jl/blob/master/frontend/editor.css#L1025) that controls pluto-trafficlight (the 'queued/running/errored-running' indicator) is causing the page repaints.

We know that because removing the animation stops the repaints.

# Why we think that happens
This animation is _supposed to_ run fast: Modern browsers state that changes in `transform: translate` properties should only trigger _composite layers_ recalculation [(a source)](https://www.html5rocks.com/en/tutorials/speed/high-performance-animations/). Though, little is being documented about how hard it is to **_start/stop_** an animation, which is exactly what happens when you move a slider many times:

1. bind sends new data
2. julia replies near instantly that some cells are '`queued`'
3. julia updates state to 'some cells are '`running`'
4. julia updates state to `ready` 

repeat X times in a second (one for each slider value update). That is a simple animation, but is also 50 times to start/stop it. _Probably_ that is slow.

---

# What [this](https://github.com/fonsp/Pluto.jl/pull/912/commits/c2e28938a00be56e3aa5f52f6ddea1984cbdc242) commit does

We make _all cells_ **contantly** run the animation **all the time**, and **hide it** with `opacity: 0`
When a cell changes from `ready` -> `running` we change the opacity with `opacity: 0.97`, so the animation becomes _visible_ (even though it was there the whole time!)

## Next steps

- [x] Identify if that is actually the cause of the repaints
- [x] Be smart about animations: a long forgotten cell should not have an animation running perpetually, _butalso_ a slider-controlled element should not restart animation but smarlty 're-use' the same.
- [x] Compare the idle CPU with the same big notebook without any. Highly likely browsers optimize that (even though that should be what they do in the first place)




 