### PR TITLE
Fix #936

### DIFF
--- a/src/webserver/WebServer.jl
+++ b/src/webserver/WebServer.jl
@@ -41,7 +41,7 @@ function open_in_default_browser(url::AbstractString)::Bool
             Base.run(`open $url`)
             true
         elseif Sys.iswindows() || detectwsl()
-            Base.run(`powershell.exe Start "$url"`)
+            Base.run(`powershell.exe Start "'$url'"`)
             true
         elseif Sys.islinux()
             Base.run(`xdg-open $url`)


### PR DESCRIPTION
Adding one more set of single quotes around the url seems to fix the issue. It feels a little hacky, but it's the only way I found to get around this. I tried using `Cmd()` with `windows_verbatim = true` too, but it didn't work either.