### PR TITLE
load Revise first

### DIFF
--- a/src/analysis/Topology.jl
+++ b/src/analysis/Topology.jl
@@ -134,9 +134,9 @@ function cell_precedence_heuristic(topology::NotebookTopology, cell::Cell)::Real
 	elseif :LOAD_PATH ∈ top.references
 		# https://github.com/fonsp/Pluto.jl/issues/323
 		4
-    elseif any(expr -> revise_arg ∈ expr.args, cell.module_usings)
-        # Load Revise before other packages so that it can properly `revise` them.
-        5
+	elseif any(expr -> revise_arg ∈ expr.args, cell.module_usings)
+		# Load Revise before other packages so that it can properly `revise` them.
+		5
 	elseif !isempty(cell.module_usings)
 		# always do `using X` before other cells, because we don't (yet) know which cells depend on it (we only know it with `import X` and `import X: y, z`)
 		6

--- a/src/analysis/Topology.jl
+++ b/src/analysis/Topology.jl
@@ -119,7 +119,6 @@ end
 This is used to treat reactive dependencies between cells that cannot be found using static code anylsis."""
 function cell_precedence_heuristic(topology::NotebookTopology, cell::Cell)::Real
 	top = topology[cell]
-    revise_arg = (:(using Revise)).args[1]
 	if :Pkg ∈ top.definitions
 		1
 	elseif Symbol("Pkg.API.activate") ∈ top.references || 
@@ -134,7 +133,7 @@ function cell_precedence_heuristic(topology::NotebookTopology, cell::Cell)::Real
 	elseif :LOAD_PATH ∈ top.references
 		# https://github.com/fonsp/Pluto.jl/issues/323
 		4
-	elseif any(expr -> revise_arg ∈ expr.args, cell.module_usings)
+	elseif :Revise ∈ top.definitions
 		# Load Revise before other packages so that it can properly `revise` them.
 		5
 	elseif !isempty(cell.module_usings)

--- a/test/React.jl
+++ b/test/React.jl
@@ -168,20 +168,21 @@ import Distributed
             Cell("""Pkg.add("JSON")"""),
             Cell("Pkg.activate(mktempdir())"),
             Cell("import Pkg"),
+            Cell("using Revise"),
             Cell("1 + 1"),
         ])
         Pluto.update_caches!(notebook, notebook.cells)
         notebook.topology = Pluto.updated_topology(notebook.topology, notebook, notebook.cells)
 
         topo_order = Pluto.topological_order(notebook, notebook.topology, notebook.cells)
-        @test indexin(topo_order.runnable, notebook.cells) == [6, 5, 4, 3, 1, 2, 7]
+        @test indexin(topo_order.runnable, notebook.cells) == [6, 5, 4, 7, 3, 1, 2, 8]
         # 6, 5, 4, 3 should run first (this is implemented using `cell_precedence_heuristic`), in that order
         # 1, 2, 7 remain, and should run in notebook order.
 
         # if the cells were placed in reverse order...
         reverse!(notebook.cell_order)
         topo_order = Pluto.topological_order(notebook, notebook.topology, notebook.cells)
-        @test indexin(topo_order.runnable, reverse(notebook.cells)) == [6, 5, 4, 3, 7, 2, 1]
+        @test indexin(topo_order.runnable, reverse(notebook.cells)) == [6, 5, 4, 7, 3, 8, 2, 1]
         # 6, 5, 4, 3 should run first (this is implemented using `cell_precedence_heuristic`), in that order
         # 1, 2, 7 remain, and should run in notebook order, which is 7, 2, 1.
 
@@ -197,6 +198,7 @@ import Distributed
             Cell("Pkg.activate(envdir)"),
             Cell("envdir = mktempdir()"),
             Cell("import Pkg"),
+            Cell("using JSON3, Revise"),
         ])
 
         Pluto.update_caches!(notebook, notebook.cells)
@@ -213,6 +215,8 @@ import Distributed
         @test_broken comesbefore(run_order, 5, 3)
         @test_broken comesbefore(run_order, 3, 2)
         @test comesbefore(run_order, 2, 1)
+        @test comesbefore(run_order, 8, 2)
+        @test comesbefore(run_order, 8, 1)
 
         # the variable dependencies
         @test comesbefore(run_order, 6, 5)
@@ -1143,4 +1147,3 @@ import Distributed
         WorkspaceManager.unmake_workspace((🍭, notebook))
     end
 end
-


### PR DESCRIPTION
Adds a heuristic step to load Revise before other packages so it can revise them properly. It only works with `using Revise` or `using X, Y, Revise, Z` etc, but not with `import` since it relies on `compute_usings` which only looks for `using` expressions, not `import` expressions.