### PR TITLE
Keyword args are now explored last in a function definition

### DIFF
--- a/test/ExpressionExplorer.jl
+++ b/test/ExpressionExplorer.jl
@@ -183,6 +183,12 @@ Some of these @test_broken lines are commented out to prevent printing to the te
         @test testee(:(function f(x, args...; kwargs...) return [x, y, args..., kwargs...] end), [], [], [], [
             :f => ([:y], [], [], [])
         ])
+        @test testee(:(function f(x; y=x) y + x end), [], [], [], [
+            :f => ([], [], [:+], [])
+        ])
+        @test testee(:(function (A::MyType)(x; y=x) y + x end), [], [], [], [
+            :MyType => ([], [], [:+], [])
+        ])
         @test testee(:(f(x, y=a + 1) = x * y * z), [], [], [], [
             :f => ([:z, :a], [], [:*, :+], [])
         ])


### PR DESCRIPTION
Hello! :raised_hands: 

Another small fix for the ExpressionExplorer :+1: 

According to https://docs.julialang.org/en/v1/devdocs/ast/#Calls
the `:parameter` part of the arguments created using `;` in the argument
list is the second argument of the created `Expr`. If it is present,
it is set to be the last parameter explored, allowing references to
other parameters.

Closes #915 