### PR TITLE
If there is an error while saving, don't overwrite the old file

### DIFF
--- a/src/notebook/Notebook.jl
+++ b/src/notebook/Notebook.jl
@@ -127,8 +127,15 @@ function save_notebook(io, notebook::Notebook)
     notebook
 end
 
+function open_safe_write(fn::Function, path, mode)
+    file_content = sprint(fn)
+    open(path, mode) do io
+        print(io, file_content)
+    end
+end
+    
 function save_notebook(notebook::Notebook, path::String)
-    open(path, "w") do io
+    open_safe_write(path, "w") do io
         save_notebook(io, notebook)
     end
 end


### PR DESCRIPTION
This fixes #952 for a bit. Differences with writing to a temp file first:
Pros:
- Super easy to implement
- Doesn't need separate file
- Not really a pro but it still fixes by far the most errors
Cons:
- Can still overwrite the file partially if the error isn't in our code, but happens inside Julia's file writing code (I think 99%, if not more, will be in our code though)
- Writes to RAM first, where it would be more efficient to put it in a file directly.

I think we'll eventually implement the whole deal, but having this (while discussing how to best implement the rename stuff) is great I think. 