### PR TITLE
fix anonymous functions with keyword args

### DIFF
--- a/src/analysis/ExpressionExplorer.jl
+++ b/src/analysis/ExpressionExplorer.jl
@@ -482,7 +482,7 @@ function explore!(ex::Expr, scopestate::ScopeState)::SymbolsState
         funcroot = ex.args[1]
         args_ex = if funcroot isa Symbol || (funcroot isa Expr && funcroot.head == :(::))
             [funcroot]
-        elseif funcroot.head == :tuple || funcroot.head == :(...)
+        elseif funcroot.head == :tuple || funcroot.head == :(...) || funcroot.head == :block
             funcroot.args
         else
             @error "Unknown lambda type"

--- a/test/ExpressionExplorer.jl
+++ b/test/ExpressionExplorer.jl
@@ -208,6 +208,12 @@ Some of these @test_broken lines are commented out to prevent printing to the te
         @test testee(:(Base.show() = 0), [:Base], [], [], [
             [:Base, :show] => ([], [], [], [])
         ])
+        @test testee(:((x;p) -> f(x+p)), [], [], [], [
+            :anon => ([], [], [:f, :+], [])
+        ])
+        @test testee(:(begin x; p end -> f(x+p)), [], [], [], [
+            :anon => ([], [], [:f, :+], [])
+        ])
         @test testee(:(minimum(x) do (a, b); a + b end), [:x], [], [:minimum], [
             :anon => ([], [], [:+], [])
         ])


### PR DESCRIPTION
Interestingly, the parameter tuple of `(x;p) -> x` gets parsed as a block so `begin x; p end -> x` is a valid syntax for an anonymous function :exploding_head: 

Closes #997