### PR TITLE
Ignore assignment to underscores

### DIFF
--- a/src/analysis/ExpressionExplorer.jl
+++ b/src/analysis/ExpressionExplorer.jl
@@ -175,8 +175,8 @@ function get_assignees(ex::Expr)::FunctionName
     end
 end
 
-# e.g. x = 123
-get_assignees(ex::Symbol) = Symbol[ex]
+# e.g. x = 123, but ignore _ = 456
+get_assignees(ex::Symbol) = ex === :_ ? Symbol[] : Symbol[ex]
 
 # When you assign to a datatype like Int, String, or anything bad like that
 # e.g. 1 = 2

--- a/src/analysis/ExpressionExplorer.jl
+++ b/src/analysis/ExpressionExplorer.jl
@@ -333,6 +333,7 @@ function explore!(ex::Expr, scopestate::ScopeState)::SymbolsState
         push!(scopestate.hiddenglobals, global_assignees...)
         push!(symstate.assignments, global_assignees...)
         push!(symstate.references, setdiff(assigneesymstate.references, global_assignees)...)
+        pop!(symstate.references, :_, :nosuch)  # Never record _ as a reference
 
         return symstate
     elseif ex.head in modifiers

--- a/test/ExpressionExplorer.jl
+++ b/test/ExpressionExplorer.jl
@@ -80,14 +80,14 @@ using Test
         @test testee(:(a ⊻= 1), [:a], [:a], [:⊻], [])
         @test testee(:(a[1] += 1), [:a], [], [:+], [])
         @test testee(:(x = let a = 1; a += b end), [:b], [:x], [:+], [])
-        @test testee(:(_ = a + 1), [:a, :_], [], [:+], [])
+        @test testee(:(_ = a + 1), [:a], [], [:+], [])
     end
     @testset "Tuples" begin
         @test testee(:((a, b,)), [:a,:b], [], [], [])
         @test testee(:((a = b, c = 2, d = 123,)), [:b], [], [], [])
         @test testee(:((a = b,)), [:b], [], [], [])
         @test testee(:(a, b = 1, 2), [], [:a, :b], [], [])
-        @test testee(:(a, _, c = 1, 2), [:_], [:a, :c], [], [])
+        @test testee(:(a, _, c = 1, 2), [], [:a, :c], [], [])
         @test testee(:(const a, b = 1, 2), [], [:a, :b], [], [])
         @test testee(:((a, b) = 1, 2), [], [:a, :b], [], [])
         @test testee(:(a = b, c), [:b, :c], [:a], [], [])

--- a/test/ExpressionExplorer.jl
+++ b/test/ExpressionExplorer.jl
@@ -81,6 +81,7 @@ using Test
         @test testee(:(a[1] += 1), [:a], [], [:+], [])
         @test testee(:(x = let a = 1; a += b end), [:b], [:x], [:+], [])
         @test testee(:(_ = a + 1), [:a], [], [:+], [])
+        @test testee(:(a = _ + 1), [], [:a], [:+], [])
     end
     @testset "Tuples" begin
         @test testee(:((a, b,)), [:a,:b], [], [], [])

--- a/test/ExpressionExplorer.jl
+++ b/test/ExpressionExplorer.jl
@@ -80,12 +80,14 @@ using Test
         @test testee(:(a ⊻= 1), [:a], [:a], [:⊻], [])
         @test testee(:(a[1] += 1), [:a], [], [:+], [])
         @test testee(:(x = let a = 1; a += b end), [:b], [:x], [:+], [])
+        @test testee(:(_ = a + 1), [:a], [], [:+], [])
     end
     @testset "Tuples" begin
         @test testee(:((a, b,)), [:a,:b], [], [], [])
         @test testee(:((a = b, c = 2, d = 123,)), [:b], [], [], [])
         @test testee(:((a = b,)), [:b], [], [], [])
         @test testee(:(a, b = 1, 2), [], [:a, :b], [], [])
+        @test testee(:(a, _, c = 1, 2), [], [:a, :c], [], [])
         @test testee(:(const a, b = 1, 2), [], [:a, :b], [], [])
         @test testee(:((a, b) = 1, 2), [], [:a, :b], [], [])
         @test testee(:(a = b, c), [:b, :c], [:a], [], [])

--- a/test/ExpressionExplorer.jl
+++ b/test/ExpressionExplorer.jl
@@ -87,7 +87,7 @@ using Test
         @test testee(:((a = b, c = 2, d = 123,)), [:b], [], [], [])
         @test testee(:((a = b,)), [:b], [], [], [])
         @test testee(:(a, b = 1, 2), [], [:a, :b], [], [])
-        @test testee(:(a, _, c = 1, 2), [], [:a, :c], [], [])
+        @test testee(:(a, _, c, __ = 1, 2, 3, _d), [:_d], [:a, :c], [], [])
         @test testee(:(const a, b = 1, 2), [], [:a, :b], [], [])
         @test testee(:((a, b) = 1, 2), [], [:a, :b], [], [])
         @test testee(:(a = b, c), [:b, :c], [:a], [], [])

--- a/test/ExpressionExplorer.jl
+++ b/test/ExpressionExplorer.jl
@@ -80,14 +80,14 @@ using Test
         @test testee(:(a ⊻= 1), [:a], [:a], [:⊻], [])
         @test testee(:(a[1] += 1), [:a], [], [:+], [])
         @test testee(:(x = let a = 1; a += b end), [:b], [:x], [:+], [])
-        @test testee(:(_ = a + 1), [:a], [], [:+], [])
+        @test testee(:(_ = a + 1), [:a, :_], [], [:+], [])
     end
     @testset "Tuples" begin
         @test testee(:((a, b,)), [:a,:b], [], [], [])
         @test testee(:((a = b, c = 2, d = 123,)), [:b], [], [], [])
         @test testee(:((a = b,)), [:b], [], [], [])
         @test testee(:(a, b = 1, 2), [], [:a, :b], [], [])
-        @test testee(:(a, _, c = 1, 2), [], [:a, :c], [], [])
+        @test testee(:(a, _, c = 1, 2), [:_], [:a, :c], [], [])
         @test testee(:(const a, b = 1, 2), [], [:a, :b], [], [])
         @test testee(:((a, b) = 1, 2), [], [:a, :b], [], [])
         @test testee(:(a = b, c), [:b, :c], [:a], [], [])


### PR DESCRIPTION
It's common assign throw-away values to `_`; this changes ExpressionExplorer to ignore them:

<img width="365" alt="Screenshot 2021-03-19 at 12 46 22" src="https://user-images.githubusercontent.com/32575566/111814906-6af59380-88b1-11eb-933d-a3d730eec7ac.png">

In Pluto right now, this example gives a multiple assignment error, since two cells appear to write to the same variable. But they don't really, since `_` cannot be read from.

~~(Not sure why tests seem to see a dependence on `_`, even though they correctly don't think it's being written to.)~~