### PR TITLE
Support syntax highlight for lots of languages in Markdown

### DIFF
--- a/frontend/common/OfflineHTMLExport.js
+++ b/frontend/common/OfflineHTMLExport.js
@@ -56,6 +56,7 @@ export const offline_html = async ({ pluto_version, body, head }) => {
                 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/codemirror@5.58.1/lib/codemirror.min.css" type="text/css" />
                 <script src="https://cdn.jsdelivr.net/npm/codemirror@5.59.0/lib/codemirror.min.js" defer></script>
                 <script src="https://cdn.jsdelivr.net/npm/codemirror@5.58.1/mode/julia/julia.min.js" defer></script>
+                <script src="https://cdn.jsdelivr.net/npm/codemirror@5.58.1/addon/mode/loadmode.min.js" defer></script>
 
                 ${head.querySelector("style#MJX-SVG-styles").outerHTML}
             </head>
@@ -75,7 +76,7 @@ export const offline_html = async ({ pluto_version, body, head }) => {
                         cursorBlinkRate: -1,
                         readOnly: false,
                     }
-                    document.addEventListener("DOMContentLoaded", () => 
+                    document.addEventListener("DOMContentLoaded", () =>
                         document.querySelectorAll(".init-cm").forEach(textArea => {
                             CodeMirror.fromTextArea(textArea, cmOptions)
                         })

--- a/frontend/components/CellOutput.js
+++ b/frontend/components/CellOutput.js
@@ -325,10 +325,15 @@ export let RawHTMLContainer = ({ body, persist_js_state = false, last_run_timest
                 console.info(err)
             }
 
-            // Apply julia syntax highlighting
+            // Apply syntax highlighting
             try {
-                for (let code_element of container.current.querySelectorAll("code.language-julia")) {
-                    highlight_julia(code_element)
+                for (let code_element of container.current.querySelectorAll("code")) {
+                    for (let className of code_element.classList) {
+                        if (className.startsWith("language-")) {
+                            // Remove "language-"
+                            highlight(code_element, className.substr(9))
+                        }
+                    }
                 }
             } catch (err) {}
         })
@@ -342,10 +347,14 @@ export let RawHTMLContainer = ({ body, persist_js_state = false, last_run_timest
 }
 
 /** @param {HTMLElement} code_element */
-export let highlight_julia = (code_element) => {
+export let highlight = (code_element, language) => {
     if (code_element.children.length === 0) {
         // @ts-ignore
-        window.CodeMirror.runMode(code_element.innerText, "julia", code_element)
-        code_element.classList.add("cm-s-default")
+        window.CodeMirror.requireMode(language, function() {
+            window.CodeMirror.runMode(code_element.innerText, language, code_element)
+            code_element.classList.add("cm-s-default")
+        }, {path: function(language) {
+            return `https://cdn.jsdelivr.net/npm/codemirror@5.58.1/mode/${language}/${language}.min.js`
+        }})
     }
 }

--- a/frontend/components/LiveDocs.js
+++ b/frontend/components/LiveDocs.js
@@ -3,7 +3,7 @@ import immer from "../imports/immer.js"
 import observablehq from "../common/SetupCellEnvironment.js"
 import { cl } from "../common/ClassTable.js"
 
-import { RawHTMLContainer, highlight_julia } from "./CellOutput.js"
+import { RawHTMLContainer, highlight } from "./CellOutput.js"
 import { PlutoContext } from "../common/PlutoContext.js"
 
 export let LiveDocs = ({ desired_doc_query, on_update_doc_query, notebook }) => {
@@ -41,10 +41,10 @@ export let LiveDocs = ({ desired_doc_query, on_update_doc_query, notebook }) => 
     useLayoutEffect(() => {
         // Actually, showing the jldoctest stuff wasn't as pretty... should make a mode for that sometimes
         // for (let code_element of container_ref.current.querySelectorAll("code.language-jldoctest")) {
-        //     highlight_julia(code_element)
+        //     highlight(code_element, "julia")
         // }
         for (let code_element of container_ref.current.querySelectorAll("code:not([class])")) {
-            highlight_julia(code_element)
+            highlight(code_element, "julia")
         }
     }, [state.body])
 

--- a/frontend/editor.html
+++ b/frontend/editor.html
@@ -23,6 +23,7 @@
     <script src="https://cdn.jsdelivr.net/npm/iframe-resizer@4.2.11/js/iframeResizer.min.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/codemirror@5.58.1/lib/codemirror.min.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/codemirror@5.58.1/mode/julia/julia.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/codemirror@5.58.1/addon/mode/loadmode.min.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/codemirror@5.58.1/addon/hint/show-hint.min.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/codemirror@5.58.1/addon/display/placeholder.min.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/codemirror@5.58.1/addon/edit/matchbrackets.min.js" defer></script>


### PR DESCRIPTION
This adds support for syntax highlight for many languages, as suggested/commented [here](https://github.com/fonsp/Pluto.jl/issues/235#issuecomment-794362160) (issue #235 is probably related).

![Captura de tela de 2021-03-25 11-41-17](https://user-images.githubusercontent.com/37125/112492047-ac79b900-8d5f-11eb-8fea-4913d48ad2e7.png)

It uses CodeMirror, so no new dependencies here, except for the [`loadmode` addon](https://codemirror.net/doc/manual.html#addon_loadmode) (~1.6 kB) for lazily loading new languages as they appear. Julia is always preloaded, of course.