### PR TITLE
Trailing throttle syncs to front-end

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,11 @@
     "prettier.printWidth": 160,
     "prettier.tabWidth": 4,
     "prettier.semi": false,
-    "prettier.quoteProps": "consistent"
+    "prettier.quoteProps": "consistent",
+    "julia.format.calls": false,
+    "julia.format.comments": false,
+    "julia.format.curly": false,
+    "julia.format.docs": false,
+    "julia.format.indents": false,
+    "julia.format.iterOps": false
 }

--- a/src/evaluation/Run.jl
+++ b/src/evaluation/Run.jl
@@ -1,4 +1,4 @@
-import REPL: ends_with_semicolon
+import REPL:ends_with_semicolon
 import .Configuration
 import .ExpressionExplorer: FunctionNameSignaturePair, is_joined_funcname, UsingsImports, external_package_names
 
@@ -48,7 +48,7 @@ function run_reactive!(session::ServerSession, notebook::Notebook, old_topology:
 
 	# Send intermediate updates to the clients at most 20 times / second during a reactive run. (The effective speed of a slider is still unbounded, because the last update is not throttled.)
 	# flush_send_notebook_changes_throttled, 
-	send_notebook_changes_throttled, flush_notebook_changes = throttled(1.0/20; leading=false, trailing=true) do
+	send_notebook_changes_throttled, flush_notebook_changes = throttled(1.0 / 20) do
 		send_notebook_changes!(ClientRequest(session=session, notebook=notebook))
 	end
 	send_notebook_changes_throttled()
@@ -195,55 +195,50 @@ update_run!(args...) = update_save_run!(args...; save=false)
 
 
 """
-		throttled(f, timeout; leading=true, trailing=false)
+	throttled(f::Function, timeout::Real)
 
 Return a function that when invoked, will only be triggered at most once
 during `timeout` seconds.
-Normally, the throttled function will run as much as it can, without ever
-going more than once per `wait` duration; but if you'd like to disable the
-execution on the leading edge, pass `leading=false`. To enable execution on
-the trailing edge, pass `trailing=true`.
-Copied from FluxML
+The throttled function will run as much as it can, without ever
+going more than once per `wait` duration.
+Inspired by FluxML
 See: https://github.com/FluxML/Flux.jl/blob/8afedcd6723112ff611555e350a8c84f4e1ad686/src/utils.jl#L662
-Also added thread safety:
-That means that the function is called every ` t = timeout + (call duration) s` and that a function
-run "sequentially".
 """
-function throttled(f, timeout; leading=false, trailing=true)
+function throttled(f::Function, timeout::Real)
 	tlock = ReentrantLock()
-	iscoolnow = true
-	later = false
+	iscoolnow = false
+	run_later = false
 
 	function flush()
-		lock(tlock)
-		try
-			later = false
+		lock(tlock) do
+			run_later = false
 			f()
-		finally
-			unlock(tlock)
 		end
 	end
 
-	function throttled_f()
-		yield()
-		if iscoolnow
-			if leading
+	function schedule()
+		@async begin
+			sleep(timeout)
+			if run_later
 				flush()
-			else
-				later = true
 			end
+			iscoolnow = true
+		end
+	end
+	schedule()
+
+	function throttled_f()
+		if iscoolnow
 			iscoolnow = false
-			@async try
-				while (sleep(timeout); later)
-					flush()
-				end
-			finally
-				iscoolnow = true
-			end
-		elseif trailing
-			later = true
+			flush()
+			schedule()
+		else
+			run_later = true
 		end
 	end
 
 	return throttled_f, flush
 end
+
+
+

--- a/test/Throttled.jl
+++ b/test/Throttled.jl
@@ -1,0 +1,50 @@
+import Pluto:throttled
+
+@testset "Throttled" begin
+    x = Ref(0)
+
+    function f()
+        x[] += 1
+    end
+    f()
+    @test x[] == 1
+    
+    dt = 1 / 100
+    ft, stop = throttled(f, dt)
+    
+    for x in 1:10
+        ft()
+    end
+    @test x[] == 2
+    sleep(2dt)
+    @test x[] == 3
+    
+    for x in 1:10
+        ft()
+    end
+    @test x[] == 4
+    sleep(2dt)
+    @test x[] == 5
+    
+    
+    for x in 1:5
+        ft()
+        sleep(1.5dt)
+    end
+    @test x[] == 10
+    sleep(2dt)
+    @test x[] == 10
+    
+    ###
+    
+    ft()
+    ft()
+    @test x[] == 11
+    stop()
+    @test x[] == 12
+    sleep(2dt)
+    @test x[] == 12
+
+    @test false
+end
+    

--- a/test/Throttled.jl
+++ b/test/Throttled.jl
@@ -1,50 +1,84 @@
 import Pluto:throttled
 
-@testset "Throttled" begin
+@testset "Throttled" begin    
     x = Ref(0)
-
+    
     function f()
-        x[] += 1
+    	x[] += 1
     end
     f()
+    # f was not throttled
     @test x[] == 1
     
-    dt = 1 / 100
-    ft, stop = throttled(f, dt; leading=false, trailing=true)
+    dt = 4 / 100
+    ft, flush = throttled(f, dt)
     
     for x in 1:10
-        ft()
+    	ft()
     end
-    @test x[] == 1 # Update scheduled
+    # we have an initial cooldown period in which f should not fire...
+    # ...so x is still 1...
+    @test x[] == 1
     sleep(2dt)
-    @test x[] == 2 # Update done
-    
+    # ...but after a delay, the call should go through.
+    @test x[] == 2
+
+    # sleep(0) ## ASYNC MAGIC :(
+
+    # at this point, the *initial* cooldown period is over
+    # and the cooldown period for the first throttled calls is over
+
     for x in 1:10
-        ft()
+    	ft()
     end
-    @test x[] == 2 # Update scheduled
+    # we want to send plots to the user as soon as they are available,
+    # so no leading timeout
+    @test x[] == 3
+    # the 2nd until 10th calls were still queued
     sleep(2dt)
-    @test x[] == 3 # Update done
+    @test x[] == 4
     
     
     for x in 1:5
-        ft() 
-        sleep(1.5dt) # wait to go through
+    	ft()
+    	sleep(1.5dt)
     end
-    @test x[] == 8 # all updates happened
-    sleep(2dt) 
-    @test x[] == 8 # no new updates
+    @test x[] == 9
+    sleep(2dt)
+    @test x[] == 9
+    
     
     ###
     
-    ft() # schedule
-    ft() # schedule
-    @test x[] == 8
-    stop() # cancel schedule and run
-    @test x[] == 9
-    sleep(2dt) # cancel works
-    @test x[] == 9
-
-    @test false
-end
+    # "call 1"
+    ft()
+    # no leading timeout, immediately set to 10
+    @test x[] == 10
     
+    sleep(.5dt)
+    
+    # "call 2"
+    ft()
+    # throttled
+    @test x[] == 10
+    
+    sleep(.7dt)
+    
+    # we waited 1.2dt > dt seconds since "call 1", which should have started the dt cooldown. "call 2" landed during that calldown, and should have triggered by now
+    @test x[] == 11
+    
+    
+    sleep(2dt)
+    @test x[] == 11
+    
+    ###
+    
+    ft()
+    ft()
+    @test x[] == 12
+    flush()
+    @test x[] == 13
+    sleep(2dt)
+    @test x[] == 13
+
+end

--- a/test/Throttled.jl
+++ b/test/Throttled.jl
@@ -10,40 +10,40 @@ import Pluto:throttled
     @test x[] == 1
     
     dt = 1 / 100
-    ft, stop = throttled(f, dt)
+    ft, stop = throttled(f, dt; leading=false, trailing=true)
     
     for x in 1:10
         ft()
     end
-    @test x[] == 2
+    @test x[] == 1 # Update scheduled
     sleep(2dt)
-    @test x[] == 3
+    @test x[] == 2 # Update done
     
     for x in 1:10
         ft()
     end
-    @test x[] == 4
+    @test x[] == 2 # Update scheduled
     sleep(2dt)
-    @test x[] == 5
+    @test x[] == 3 # Update done
     
     
     for x in 1:5
-        ft()
-        sleep(1.5dt)
+        ft() 
+        sleep(1.5dt) # wait to go through
     end
-    @test x[] == 10
-    sleep(2dt)
-    @test x[] == 10
+    @test x[] == 8 # all updates happened
+    sleep(2dt) 
+    @test x[] == 8 # no new updates
     
     ###
     
-    ft()
-    ft()
-    @test x[] == 11
-    stop()
-    @test x[] == 12
-    sleep(2dt)
-    @test x[] == 12
+    ft() # schedule
+    ft() # schedule
+    @test x[] == 8
+    stop() # cancel schedule and run
+    @test x[] == 9
+    sleep(2dt) # cancel works
+    @test x[] == 9
 
     @test false
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 include("./helpers.jl")
+include("./Throttled.jl")
 include("./WorkspaceManager.jl")
 include("./RichOutput.jl")
 include("./React.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,4 @@
 include("./helpers.jl")
-include("./Throttled.jl")
 include("./WorkspaceManager.jl")
 include("./RichOutput.jl")
 include("./React.jl")
@@ -10,6 +9,7 @@ include("./Notebook.jl")
 include("./Configuration.jl")
 include("./Analysis.jl")
 include("./Firebasey.jl")
+include("./Throttled.jl")
 
 # TODO: test PlutoRunner functions like:
 # - from_this_notebook


### PR DESCRIPTION
I'm using a slightly modified version of `Flux.jl`'s throttle: https://github.com/FluxML/Flux.jl/blob/8afedcd6723112ff611555e350a8c84f4e1ad686/src/utils.jl#L662

