### PR TITLE
Add aliases for syntax highlighting

### DIFF
--- a/frontend/components/CellOutput.js
+++ b/frontend/components/CellOutput.js
@@ -333,8 +333,19 @@ export let RawHTMLContainer = ({ body, persist_js_state = false, last_run_timest
                 for (let code_element of container.current.querySelectorAll("code")) {
                     for (let className of code_element.classList) {
                         if (className.startsWith("language-")) {
+                            let aliases = {
+                                "html": "htmlmixed",
+                                "jl": "julia",
+                                "js": "javascript",
+                            }
+
+                            let language = className.substr(9)
+                            if (language in aliases) {
+                                language = aliases[language]
+                            }
+
                             // Remove "language-"
-                            highlight(code_element, className.substr(9))
+                            highlight(code_element, language)
                         }
                     }
                 }


### PR DESCRIPTION
This is a continuation of #1024. It adds the following language aliases to syntax highlighting ([comment](https://github.com/fonsp/Pluto.jl/pull/1024#issuecomment-814257610)):

- `"html" => "htmlmixed"`
- `"jl" => "julia"`
- `"js" => "javascript"`

![Captura de tela de 2021-04-06 15-43-37](https://user-images.githubusercontent.com/37125/113762390-e9926380-96ee-11eb-9c52-c53733300bb8.png)
