### PR TITLE
Use CodeMirror.findModeByName instead of listing aliases

### DIFF
--- a/frontend/components/CellOutput.js
+++ b/frontend/components/CellOutput.js
@@ -9,6 +9,9 @@ import { cl } from "../common/ClassTable.js"
 import { observablehq_for_cells } from "../common/SetupCellEnvironment.js"
 import { PlutoBondsContext, PlutoContext } from "../common/PlutoContext.js"
 
+//@ts-ignore
+const CodeMirror = window.CodeMirror
+
 export class CellOutput extends Component {
     constructor() {
         super()
@@ -354,29 +357,26 @@ export let RawHTMLContainer = ({ body, persist_js_state = false, last_run_timest
 /** @param {HTMLElement} code_element */
 export let highlight = (code_element, language) => {
     if (code_element.children.length === 0) {
-        // @ts-ignore
-        let mode = language  // fallback
+        let mode = language // fallback
 
-        let info = window.CodeMirror.findModeByName(language)
+        let info = CodeMirror.findModeByName(language)
         if (info) {
             mode = info.mode
         }
 
-        // Not require since https://github.com/codemirror/CodeMirror/commit/bd1b7d2976d768ae4e3b8cf209ec59ad73c0305a
+        // Will not be required after release of https://github.com/codemirror/CodeMirror/commit/bd1b7d2976d768ae4e3b8cf209ec59ad73c0305a
         if (mode == "jl") {
             mode = "julia"
         }
 
-        window.CodeMirror.requireMode(
+        CodeMirror.requireMode(
             mode,
-            function () {
-                window.CodeMirror.runMode(code_element.innerText, mode, code_element)
+            () => {
+                CodeMirror.runMode(code_element.innerText, mode, code_element)
                 code_element.classList.add("cm-s-default")
             },
             {
-                path: function (mode) {
-                    return `https://cdn.jsdelivr.net/npm/codemirror@5.58.1/mode/${mode}/${mode}.min.js`
-                },
+                path: (mode) => `https://cdn.jsdelivr.net/npm/codemirror@5.58.1/mode/${mode}/${mode}.min.js`,
             }
         )
     }

--- a/frontend/components/CellOutput.js
+++ b/frontend/components/CellOutput.js
@@ -333,16 +333,7 @@ export let RawHTMLContainer = ({ body, persist_js_state = false, last_run_timest
                 for (let code_element of container.current.querySelectorAll("code")) {
                     for (let className of code_element.classList) {
                         if (className.startsWith("language-")) {
-                            let aliases = {
-                                "html": "htmlmixed",
-                                "jl": "julia",
-                                "js": "javascript",
-                            }
-
                             let language = className.substr(9)
-                            if (language in aliases) {
-                                language = aliases[language]
-                            }
 
                             // Remove "language-"
                             highlight(code_element, language)
@@ -364,15 +355,27 @@ export let RawHTMLContainer = ({ body, persist_js_state = false, last_run_timest
 export let highlight = (code_element, language) => {
     if (code_element.children.length === 0) {
         // @ts-ignore
+        let mode = language  // fallback
+
+        let info = window.CodeMirror.findModeByName(language)
+        if (info) {
+            mode = info.mode
+        }
+
+        // Not require since https://github.com/codemirror/CodeMirror/commit/bd1b7d2976d768ae4e3b8cf209ec59ad73c0305a
+        if (mode == "jl") {
+            mode = "julia"
+        }
+
         window.CodeMirror.requireMode(
-            language,
+            mode,
             function () {
-                window.CodeMirror.runMode(code_element.innerText, language, code_element)
+                window.CodeMirror.runMode(code_element.innerText, mode, code_element)
                 code_element.classList.add("cm-s-default")
             },
             {
-                path: function (language) {
-                    return `https://cdn.jsdelivr.net/npm/codemirror@5.58.1/mode/${language}/${language}.min.js`
+                path: function (mode) {
+                    return `https://cdn.jsdelivr.net/npm/codemirror@5.58.1/mode/${mode}/${mode}.min.js`
                 },
             }
         )

--- a/frontend/editor.html
+++ b/frontend/editor.html
@@ -29,6 +29,7 @@
     <script src="https://cdn.jsdelivr.net/npm/codemirror@5.58.1/lib/codemirror.min.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/codemirror@5.58.1/mode/julia/julia.min.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/codemirror@5.58.1/addon/mode/loadmode.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/codemirror@5.58.1/mode/meta.min.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/codemirror@5.58.1/addon/hint/show-hint.min.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/codemirror@5.58.1/addon/display/placeholder.min.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/codemirror@5.58.1/addon/edit/matchbrackets.min.js" defer></script>


### PR DESCRIPTION
This implements the suggestion in a [comment](https://github.com/fonsp/Pluto.jl/pull/1061#issuecomment-814965367) of #1061. Basically, all `name`s, `mode`s and `alias`es of [mode/meta.js](https://github.com/codemirror/CodeMirror/blob/master/mode/meta.js) become supported for identifying languages for syntax highlighting (i.e., JavaScript is understood as `javascript`, `ecmascript`, `js` and `node`, while HTML can be either `html`, `htmlmixed` or `xhtml`).

The only hard-coded option now is `jl`, as it became available only recently on codemirror/CodeMirror@bd1b7d2976d768ae4e3b8cf209ec59ad73c0305a.