### PR TITLE
Compact tree viewer types

### DIFF
--- a/frontend/components/TreeView.js
+++ b/frontend/components/TreeView.js
@@ -52,13 +52,17 @@ const More = ({ on_click_more }) => {
     >`
 }
 
+// const prefix = ({ prefix, prefix_short }) => prefix_short
+const prefix = ({ prefix, prefix_short }) => html`<jlprefix class="long">${prefix}</jlprefix><jlprefix class="short">${prefix_short}</jlprefix>`
+
 export const TreeView = ({ mime, body, cell_id, persist_js_state }) => {
     let pluto_actions = useContext(PlutoContext)
     const node_ref = useRef(null)
     const onclick = (e) => {
         // TODO: this could be reactified but no rush
         let self = node_ref.current
-        if (e.target !== self && !self.classList.contains("collapsed")) {
+        let clicked = e.target.tagName === "JLPREFIX" ? e.target.parentElement : e.target
+        if (clicked !== self && !self.classList.contains("collapsed")) {
             return
         }
         const parent_tree = self.parentElement.closest("jltree")
@@ -90,12 +94,14 @@ export const TreeView = ({ mime, body, cell_id, persist_js_state }) => {
         case "Array":
         case "Set":
         case "Tuple":
-            inner = html`${body.prefix}<jlarray class=${body.type}
-                    >${body.elements.map((r) => (r === "more" ? more : html`<r>${body.type === "Set" ? "" : html`<k>${r[0]}</k>`}<v>${mimepair_output(r[1])}</v></r>`))}</jlarray
+            inner = html`${prefix(body)}<jlarray class=${body.type}
+                    >${body.elements.map((r) =>
+                        r === "more" ? more : html`<r>${body.type === "Set" ? "" : html`<k>${r[0]}</k>`}<v>${mimepair_output(r[1])}</v></r>`
+                    )}</jlarray
                 >`
             break
         case "Dict":
-            inner = html`${body.prefix}<jldict class=${body.type}
+            inner = html`${prefix(body)}<jldict class=${body.type}
                     >${body.elements.map((r) => (r === "more" ? more : html`<r><k>${mimepair_output(r[0])}</k><v>${mimepair_output(r[1])}</v></r>`))}</jldict
                 >`
             break
@@ -105,7 +111,7 @@ export const TreeView = ({ mime, body, cell_id, persist_js_state }) => {
             >`
             break
         case "struct":
-            inner = html`${body.prefix}<jlstruct>${body.elements.map((r) => html`<r><k>${r[0]}</k><v>${mimepair_output(r[1])}</v></r>`)}</jlstruct>`
+            inner = html`${prefix(body)}<jlstruct>${body.elements.map((r) => html`<r><k>${r[0]}</k><v>${mimepair_output(r[1])}</v></r>`)}</jlstruct>`
             break
     }
 

--- a/frontend/components/TreeView.js
+++ b/frontend/components/TreeView.js
@@ -52,7 +52,6 @@ const More = ({ on_click_more }) => {
     >`
 }
 
-// const prefix = ({ prefix, prefix_short }) => prefix_short
 const prefix = ({ prefix, prefix_short }) => html`<jlprefix class="long">${prefix}</jlprefix><jlprefix class="short">${prefix_short}</jlprefix>`
 
 export const TreeView = ({ mime, body, cell_id, persist_js_state }) => {

--- a/frontend/treeview.css
+++ b/frontend/treeview.css
@@ -35,7 +35,9 @@ jltree.collapsed jlstruct {
     flex-direction: row;
 }
 
-jltree * {
+jlarray,
+jldict,
+jlstruct {
     cursor: auto;
 }
 
@@ -68,6 +70,19 @@ jltree r > v {
 jltree.collapsed jlarray > r > k,
 jltree.collapsed jlstruct > r > k {
     display: none;
+}
+
+jltree > jlprefix.long {
+    display: block;
+}
+jltree > jlprefix.short {
+    display: none;
+}
+jltree.collapsed > jlprefix.long {
+    display: none;
+}
+jltree.collapsed > jlprefix.short {
+    display: block;
 }
 
 /*  */

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -824,9 +824,8 @@ function tree_data(@nospecialize(x::Any), context::IOContext)
             for i in 1:nf
         ]
 
-        prefix = repr(t; context=context)
         Dict{Symbol,Any}(
-            :prefix => prefix,
+            :prefix => repr(t; context=context),
             :prefix_short => string(t |> trynameof),
             :objectid => string(objectid(x), base=16),
             :type => :struct,

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -706,6 +706,7 @@ function tree_data(@nospecialize(x::AbstractSet{<:Any}), context::IOContext)
 
     Dict{Symbol,Any}(
         :prefix => string(typeof(x)),
+        :prefix_short => string(typeof(x) |> trynameof),
         :objectid => string(objectid(x), base=16),
         :type => :Set,
         :elements => elements
@@ -729,8 +730,10 @@ function tree_data(@nospecialize(x::AbstractArray{<:Any,1}), context::IOContext)
         ]
     end
 
+    prefix = array_prefix(x)
     Dict{Symbol,Any}(
-        :prefix => array_prefix(x),
+        :prefix => prefix,
+        :prefix_short => x isa Vector ? "" : prefix, # if not abstract
         :objectid => string(objectid(x), base=16),
         :type => :Array,
         :elements => elements
@@ -761,7 +764,8 @@ function tree_data(@nospecialize(x::AbstractDict{<:Any,<:Any}), context::IOConte
     end
 
     Dict{Symbol,Any}(
-        :prefix => string(typeof(x) |> trynameof),
+        :prefix => string(typeof(x)),
+        :prefix_short => string(typeof(x) |> trynameof),
         :objectid => string(objectid(x), base=16),
         :type => :Dict,
         :elements => elements
@@ -820,8 +824,10 @@ function tree_data(@nospecialize(x::Any), context::IOContext)
             for i in 1:nf
         ]
 
+        prefix = repr(t; context=context)
         Dict{Symbol,Any}(
-            :prefix => repr(t; context=context),
+            :prefix => prefix,
+            :prefix_short => string(t |> trynameof),
             :objectid => string(objectid(x), base=16),
             :type => :struct,
             :elements => elements,


### PR DESCRIPTION
# Before

<img width="730" alt="Schermafbeelding 2021-04-14 om 18 58 34" src="https://user-images.githubusercontent.com/6933510/114749680-783c5b80-9d53-11eb-84be-a06fb13cf3ad.png">
<img width="730" alt="Schermafbeelding 2021-04-14 om 18 58 28" src="https://user-images.githubusercontent.com/6933510/114749688-7a9eb580-9d53-11eb-8383-d8ad7143db82.png">

# After

<img width="730" alt="Schermafbeelding 2021-04-14 om 18 57 47" src="https://user-images.githubusercontent.com/6933510/114749707-7ecad300-9d53-11eb-8599-6bfe95191c10.png">
<img width="730" alt="Schermafbeelding 2021-04-14 om 18 57 42" src="https://user-images.githubusercontent.com/6933510/114749715-812d2d00-9d53-11eb-893f-6a2b34aef3c9.png">
<img width="730" alt="Schermafbeelding 2021-04-14 om 18 59 51" src="https://user-images.githubusercontent.com/6933510/114749814-9e61fb80-9d53-11eb-9116-8debc0b0b72b.png">

Full type information is shown when the object is uncollapsed.