### PR TITLE
toplevel QuoteNode fix

### DIFF
--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -109,7 +109,7 @@ function register_computer(expr::Expr, key, input_globals::Vector{Symbol}, outpu
 end
 
 quote_if_needed(x) = x
-quote_if_needed(x::Union{Expr,Symbol}) = QuoteNode(x)
+quote_if_needed(x::Union{Expr, Symbol, QuoteNode}) = QuoteNode(x)
 
 function compute(computer::Computer)
     # 1. get the referenced global variables

--- a/test/React.jl
+++ b/test/React.jl
@@ -996,11 +996,23 @@ import Distributed
             Cell("@__FILE__; eighteen = :(1 + 1)"),
             Cell("@__FILE__; eighteen"),
             Cell("eighteen"),
+
+            Cell("qb = quote value end"),
+            Cell("typeof(qb)"),
+
+            Cell("qn0 = QuoteNode(:value)"),
+            Cell("qn1 = :(:value)"),
+            Cell("qn0"),
+            Cell("qn1"),
+
         ])
 
         update_run!(🍭, notebook, notebook.cells)
         @test notebook.cells[1].errored == false
         @test notebook.cells[1].output.body == "false"
+        @test notebook.cells[22].output.body == "Expr"
+        @test notebook.cells[25].output.body == ":(:value)"
+        @test notebook.cells[26].output.body == ":(:value)"
 
         function benchmark(fonsi)
             filter(1:fonsi) do x


### PR DESCRIPTION
We must wrap all top-level defined metaprogramming units (Symbol, Expr, QuoteNode) in user code.
Close #1039