### PR TITLE
State file export endpoint

### DIFF
--- a/src/webserver/Static.jl
+++ b/src/webserver/Static.jl
@@ -228,7 +228,7 @@ function http_router_for(session::ServerSession)
     ) do request::HTTP.Request
         try
             notebook = notebook_from_uri(request)
-            response = HTTP.Response(200, MsgPack.pack(Pluto.notebook_to_js(notebook)))
+            response = HTTP.Response(200, Pluto.pack(Pluto.notebook_to_js(notebook)))
             push!(response.headers, "Content-Type" => "application/octet-stream")
             push!(response.headers, "Content-Disposition" => "inline; filename=\"$(without_pluto_file_extension(basename(notebook.path))).plutostate\"")
             response

--- a/src/webserver/Static.jl
+++ b/src/webserver/Static.jl
@@ -222,6 +222,22 @@ function http_router_for(session::ServerSession)
     end
     HTTP.@register(router, "GET", "/notebookfile", serve_notebookfile)
 
+    serve_statefile = with_authentication(; 
+        required=security.require_secret_for_access || 
+        security.require_secret_for_open_links
+    ) do request::HTTP.Request
+        try
+            notebook = notebook_from_uri(request)
+            response = HTTP.Response(200, MsgPack.pack(Pluto.notebook_to_js(notebook)))
+            push!(response.headers, "Content-Type" => "application/octet-stream")
+            push!(response.headers, "Content-Disposition" => "inline; filename=\"$(without_pluto_file_extension(basename(notebook.path))).plutostate\"")
+            response
+        catch e
+            return error_response(400, "Bad query", "Please <a href='https://github.com/fonsp/Pluto.jl/issues'>report this error</a>!", sprint(showerror, e, stacktrace(catch_backtrace())))
+        end
+    end
+    HTTP.@register(router, "GET", "/statefile", serve_statefile)
+
     serve_notebookexport = with_authentication(; 
         required=security.require_secret_for_access || 
         security.require_secret_for_open_links


### PR DESCRIPTION
Exports a notebook to plutostate MessagePack binary.

Exposes a single endpoint `/statefile?id=<session-id>` which works identically to `/notebookfile` and `/notebookexport`