### PR TITLE
Skip topology update on set bond value

### DIFF
--- a/src/evaluation/Run.jl
+++ b/src/evaluation/Run.jl
@@ -97,18 +97,17 @@ function run_reactive!(session::ServerSession, notebook::Notebook, old_topology:
 	return new_order
 end
 
-run_reactive_async!(session::ServerSession, notebook::Notebook, to_run::Vector{Cell}; kwargs...) =
-  run_reactive_async!(session, notebook, notebook.topology, notebook.topology, to_run; kwargs...)
+run_reactive_async!(session::ServerSession, notebook::Notebook, to_run::Vector{Cell}; kwargs...) = run_reactive_async!(session, notebook, notebook.topology, notebook.topology, to_run; kwargs...)
 
 function run_reactive_async!(session::ServerSession, notebook::Notebook, old::NotebookTopology, new::NotebookTopology, to_run::Vector{Cell}; run_async::Bool=true, kwargs...)
-  run_task = @async begin
-    run_reactive!(session, notebook, old, new, to_run; kwargs...)
-  end
-  if run_async
-    run_task
-  else
-    fetch(run_task)
-  end
+	run_task = @async begin
+		run_reactive!(session, notebook, old, new, to_run; kwargs...)
+	end
+	if run_async
+		run_task
+	else
+		fetch(run_task)
+	end
 end
 
 const lazymap = Base.Generator

--- a/src/evaluation/Run.jl
+++ b/src/evaluation/Run.jl
@@ -99,7 +99,8 @@ end
 
 run_reactive_async!(session::ServerSession, notebook::Notebook, to_run::Vector{Cell}; kwargs...) =
   run_reactive_async!(session, notebook, notebook.topology, notebook.topology, to_run; kwargs...)
-function run_reactive_async!(session::ServerSession, notebook::Notebook, old::NotebookTopology, new::NotebookTopology, to_run::Vector{Cell}; run_async::Bool=false, kwargs...)
+
+function run_reactive_async!(session::ServerSession, notebook::Notebook, old::NotebookTopology, new::NotebookTopology, to_run::Vector{Cell}; run_async::Bool=true, kwargs...)
   run_task = @async begin
     run_reactive!(session, notebook, old, new, to_run; kwargs...)
   end

--- a/src/evaluation/Run.jl
+++ b/src/evaluation/Run.jl
@@ -97,6 +97,19 @@ function run_reactive!(session::ServerSession, notebook::Notebook, old_topology:
 	return new_order
 end
 
+run_reactive_async!(session::ServerSession, notebook::Notebook, to_run::Vector{Cell}; kwargs...) =
+  run_reactive_async!(session, notebook, notebook.topology, notebook.topology, to_run; kwargs...)
+function run_reactive_async!(session::ServerSession, notebook::Notebook, old::NotebookTopology, new::NotebookTopology, to_run::Vector{Cell}; run_async::Bool=false, kwargs...)
+  run_task = @async begin
+    run_reactive!(session, notebook, old, new, to_run; kwargs...)
+  end
+  if run_async
+    run_task
+  else
+    fetch(run_task)
+  end
+end
+
 const lazymap = Base.Generator
 
 function defined_variables(topology::NotebookTopology, cells)
@@ -181,14 +194,7 @@ function update_save_run!(session::ServerSession, notebook::Notebook, cells::Arr
 	end
 
 	if !(isempty(to_run_online) && session.options.evaluation.lazy_workspace_creation) && will_run_code(notebook)
-		run_task = @async begin
-			run_reactive!(session, notebook, old, new, to_run_online; kwargs...)
-		end
-		if run_async
-			run_task
-		else
-			fetch(run_task)
-		end
+		run_reactive_async!(session, notebook, old, new, to_run_online; run_async=run_async, kwargs...)
 	end
 end
 

--- a/src/webserver/Dynamic.jl
+++ b/src/webserver/Dynamic.jl
@@ -481,7 +481,7 @@ function set_bond_values_reactive(; session::ServerSession, notebook::Notebook, 
     end
     to_reeval = where_referenced(notebook, notebook.topology, Set{Symbol}(to_set))
 
-    update_save_run!(session, notebook, to_reeval; deletion_hook=custom_deletion_hook, save=false, persist_js_state=true, kwargs...)
+    run_reactive_async!(session, notebook, to_reeval; deletion_hook=custom_deletion_hook, persist_js_state=true, kwargs...)
 end
 
 responses[:write_file] = function (🙋::ClientRequest)

--- a/src/webserver/Dynamic.jl
+++ b/src/webserver/Dynamic.jl
@@ -481,7 +481,7 @@ function set_bond_values_reactive(; session::ServerSession, notebook::Notebook, 
     end
     to_reeval = where_referenced(notebook, notebook.topology, Set{Symbol}(to_set))
 
-    run_reactive_async!(session, notebook, to_reeval; deletion_hook=custom_deletion_hook, persist_js_state=true, kwargs...)
+    run_reactive_async!(session, notebook, to_reeval; deletion_hook=custom_deletion_hook, persist_js_state=true, run_async=false, kwargs...)
 end
 
 responses[:write_file] = function (🙋::ClientRequest)


### PR DESCRIPTION
The topology will be unchanged because the update will only affect the bind
value. Therefore, we can skip the topology update to speed up the process. :zap: 