### PR TITLE
Separate the notebook filename and notebook location inputs

### DIFF
--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -14,7 +14,7 @@ import { SelectionArea } from "./SelectionArea.js"
 import { UndoDelete } from "./UndoDelete.js"
 import { SlideControls } from "./SlideControls.js"
 import { Scroller } from "./Scroller.js"
-import { ExportBanner } from "./ExportBanner.js"
+import { SaveBanner, ExportBanner } from "./ExportBanner.js"
 
 import { slice_utf8, length_utf8 } from "../common/UnicodeTools.js"
 import { has_ctrl_or_cmd_pressed, ctrl_or_cmd_name, is_mac_keyboard, in_textarea_or_input } from "../common/KeyboardShortcuts.js"
@@ -26,6 +26,7 @@ import { start_binder, BinderPhase } from "../common/Binder.js"
 import { read_Uint8Array_with_progress, FetchProgress } from "./FetchProgress.js"
 import { BinderButton } from "./BinderButton.js"
 import { slider_server_actions, nothing_actions } from "../common/SliderServerClient.js"
+import { cl } from "../common/ClassTable.js"
 
 const default_path = "..."
 const DEBUG_DIFFING = false
@@ -229,6 +230,7 @@ export class Editor extends Component {
                 up: false,
                 down: false,
             },
+            save_menu_open: true,
             export_menu_open: false,
 
             last_created_cell: null,
@@ -997,7 +999,7 @@ patch: ${JSON.stringify(
     }
 
     render() {
-        let { export_menu_open, notebook } = this.state
+        let { save_menu_open, export_menu_open, notebook } = this.state
 
         const status = this.cached_status ?? statusmap(this.state)
         const statusval = first_true_key(status)
@@ -1011,11 +1013,13 @@ patch: ${JSON.stringify(
             <${PlutoContext.Provider} value=${this.actions}>
                 <${PlutoBondsContext.Provider} value=${this.state.notebook.bonds}>
                     <${Scroller} active=${this.state.scroller} />
-                    <header className=${export_menu_open ? "show_export" : ""}>
+                    <header className=${cl({export_menu_open, save_menu_open})}>
+                        <${SaveBanner}
+                            onClose=${() => this.setState({ save_menu_open: false })}
+                        />
                         <${ExportBanner}
                             notebookfile_url=${export_url("notebookfile")}
                             notebookexport_url=${export_url("notebookexport")}
-                            open=${export_menu_open}
                             onClose=${() => this.setState({ export_menu_open: false })}
                         />
                         <loading-bar style=${`width: ${100 * this.state.binder_phase}vw`}></loading-bar>
@@ -1054,7 +1058,7 @@ patch: ${JSON.stringify(
                             }
                             <div class="flex_grow_2"></div>
                             <button class="toggle_export" title="Export..." onClick=${() => {
-                                this.setState({ export_menu_open: !export_menu_open })
+                                this.setState({ save_menu_open: !save_menu_open })
                             }}><span></span></button>
                             <div id="process_status">${
                                 status.binder && status.loading

--- a/frontend/components/ExportBanner.js
+++ b/frontend/components/ExportBanner.js
@@ -23,7 +23,7 @@ const Triangle = ({ fill }) => html`
 
 export const ExportBanner = ({ onClose, notebookfile_url, notebookexport_url }) => {
     return html`
-        <aside id="export">
+        <aside id="export_menu" class="banner_menu">
             <div id="container">
                 <div class="export_title">export</div>
                 <a href=${notebookfile_url} target="_blank" class="export_card" download>
@@ -45,7 +45,28 @@ export const ExportBanner = ({ onClose, notebookfile_url, notebookexport_url }) 
                 <header>mybinder.org</header>
                 <section>Publish an interactive notebook online.</section>
             </a>-->
-                <button title="Close" class="toggle_export" onClick=${() => onClose()}>
+            <button title="Close" class="toggle_export" onClick=${onClose}>
+                    <span></span>
+                </button>
+            </div>
+        </aside>
+    `
+}
+
+
+
+export const SaveBanner = ({ onClose }) => {
+    return html`
+        <aside id="save_menu" class="banner_menu">
+            <div id="container">
+            <div id="grid">
+            <span>Filename:</span>
+            <div><input /></div>
+            <span>Folder:</span>
+            <div><input /></div>
+            </div>
+                
+                <button title="Close" class="toggle_export" onClick=${onClose}>
                     <span></span>
                 </button>
             </div>

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -402,13 +402,28 @@ body > header {
     font-size: 0.75rem;
 }
 
-body > header.show_export {
+body > header.export_menu_open,
+body > header.save_menu_open {
     position: sticky;
     top: 0;
     transform: translateY(130px);
 }
 
-aside#export {
+header > aside {
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 200ms linear;
+}
+header.export_menu_open > aside#export_menu,
+header.save_menu_open > aside#save_menu {
+    opacity: 1;
+    pointer-events: inherit;
+
+    transition: opacity 0s linear;
+
+}
+
+aside.banner_menu {
     position: absolute;
     top: 0;
     width: 100%;
@@ -417,7 +432,10 @@ aside#export {
     color: rgba(255, 255, 255, 0.7);
     transform: translateY(-101%);
 }
-aside#export::before {
+aside#save_menu{
+    background: rgb(101, 60, 74);
+}
+aside.banner_menu::before {
     content: "";
     position: absolute;
     bottom: 100%;
@@ -426,18 +444,19 @@ aside#export::before {
     height: 100px;
     background: inherit;
 }
-aside#export div#container {
+aside.banner_menu div#container {
     flex-direction: row;
     display: flex;
     max-width: 1000px;
     padding-right: 20px;
     margin: 0 auto;
 }
-header aside#export div#container {
+header aside.banner_menu div#container {
     /* to prevent the div from taking up horizontal page when the export pane is closed. On small screen this causes overscroll on the right. */
     overflow-x: hidden;
 }
-header.show_export aside#export div#container {
+header.save_menu_open aside.banner_menu div#container,
+header.export_menu_open aside.banner_menu div#container {
     overflow-x: auto;
 }
 a.export_card {
@@ -477,7 +496,14 @@ a.export_card section {
     color: rgba(0, 0, 0, 0.5);
     font-weight: 500;
 }
-aside#export button.toggle_export {
+
+#save_menu #grid {
+    display: grid;
+    grid-template-rows: auto auto;
+    grid-template-columns: auto auto;
+}
+
+aside.banner_menu button.toggle_export {
     margin-left: auto;
     height: 60px;
 }
@@ -598,7 +624,7 @@ button.toggle_export span {
 nav#at_the_top button.toggle_export span {
     background-image: url(https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.0.0/src/svg/shapes-outline.svg);
 }
-aside#export button.toggle_export span {
+aside.banner_menu button.toggle_export span {
     background-image: url(https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.0.0/src/svg/close-outline.svg);
     filter: invert();
 }


### PR DESCRIPTION
The current file management is confusing to new users, because they need to understand absolute paths on their OS. The solution will be:
- Use ~/Documents/pluto_notebooks as the default location, so that most people won't need to change it
- Split the input for the file **name** and file **location** into two inputs. From feedback, I gather that this is closer to how users think about storing a file.

Saving will become a new pop-out banner, just like the export menu.