### PR TITLE
Allow pasting REPL sessions

### DIFF
--- a/frontend/common/Serialization.js
+++ b/frontend/common/Serialization.js
@@ -6,7 +6,7 @@ import { in_textarea_or_input } from "./KeyboardShortcuts.js"
  * Used for implementing clipboard functionality. This isn't in topological
  * order, so you won't necessarily be able to run it directly.
  *
- * @param {Array<CellInputData>} cells
+ * @param {Array<import("../components/Editor.js").CellInputData>} cells
  * @return {String}
  */
 export function serialize_cells(cells) {
@@ -52,9 +52,9 @@ export function deserialize_repl(repl_session) {
         .filter((s) => s !== "")
 }
 
-export const detect_deserializer = (topaste) =>
+export const detect_deserializer = (topaste, check_in_textarea_or_input = true) =>
     topaste.match(/^julia> /m) != null
         ? deserialize_repl
-        : !in_textarea_or_input() || topaste.match(/# ╔═╡ ........-....-....-....-............/g)?.length
+        : (check_in_textarea_or_input && !in_textarea_or_input()) || topaste.match(/# ╔═╡ ........-....-....-....-............/g)?.length
         ? deserialize_cells
         : null

--- a/frontend/common/Serialization.js
+++ b/frontend/common/Serialization.js
@@ -1,3 +1,5 @@
+import { in_textarea_or_input } from "./KeyboardShortcuts"
+
 /**
  * Serialize an array of cells into a string form (similar to the .jl file).
  *
@@ -42,3 +44,11 @@
         return (indent + s).split("\n").filter((line) => line.startsWith(indent)).map((s) => s.replace(indent, "")).join("\n")
     }).map((s) => s.trim()).filter((s) => s !== "")
 }
+
+
+export const detect_deserializer = (topaste) =>
+    !in_textarea_or_input() || topaste.match(/# ╔═╡ ........-....-....-....-............/g)?.length
+        ? deserialize_cells
+        : topaste.match(/julia> /) != null
+        ? deserialize_repl
+        : null

--- a/frontend/common/Serialization.js
+++ b/frontend/common/Serialization.js
@@ -1,4 +1,4 @@
-import { in_textarea_or_input } from "./KeyboardShortcuts"
+import { in_textarea_or_input } from "./KeyboardShortcuts.js"
 
 /**
  * Serialize an array of cells into a string form (similar to the .jl file).
@@ -53,8 +53,8 @@ export function deserialize_repl(repl_session) {
 }
 
 export const detect_deserializer = (topaste) =>
-    !in_textarea_or_input() || topaste.match(/# ╔═╡ ........-....-....-....-............/g)?.length
-        ? deserialize_cells
-        : topaste.match(/^julia> /m) != null
+    topaste.match(/^julia> /m) != null
         ? deserialize_repl
+        : !in_textarea_or_input() || topaste.match(/# ╔═╡ ........-....-....-....-............/g)?.length
+        ? deserialize_cells
         : null

--- a/frontend/common/Serialization.js
+++ b/frontend/common/Serialization.js
@@ -1,0 +1,44 @@
+/**
+ * Serialize an array of cells into a string form (similar to the .jl file).
+ *
+ * Used for implementing clipboard functionality. This isn't in topological
+ * order, so you won't necessarily be able to run it directly.
+ *
+ * @param {Array<CellInputData>} cells
+ * @return {String}
+ */
+ export function serialize_cells(cells) {
+    return cells.map((cell) => `# ╔═╡ ${cell.cell_id}\n` + cell.code + "\n").join("\n")
+}
+
+/**
+ * Deserialize a Julia program or output from `serialize_cells`.
+ *
+ * If a Julia program, it will return a single String containing it. Otherwise,
+ * it will split the string into cells based on the special delimiter.
+ *
+ * @param {String} serialized_cells
+ * @return {Array<String>}
+ */
+ export function deserialize_cells(serialized_cells) {
+    const segments = serialized_cells.replace(/\r\n/g, "\n").split(/# ╔═╡ \S+\n/)
+    return segments.map((s) => s.trim()).filter((s) => s !== "")
+}
+
+/**
+ * Deserialize a Julia REPL session.
+ *
+ * It will split the string into cells based on the Julia prompt. Multiple
+ * lines are detected based on indentation.
+ *
+ * @param {String} repl_session
+ * @return {Array<String>}
+ */
+ export function deserialize_repl(repl_session) {
+    const prompt = "julia> "
+    const segments = repl_session.replace(/\r\n/g, "\n").split(prompt)
+    const indent = " ".repeat(prompt.length);
+    return segments.map(function(s) {
+        return (indent + s).split("\n").filter((line) => line.startsWith(indent)).map((s) => s.replace(indent, "")).join("\n")
+    }).map((s) => s.trim()).filter((s) => s !== "")
+}

--- a/frontend/common/Serialization.js
+++ b/frontend/common/Serialization.js
@@ -9,7 +9,7 @@ import { in_textarea_or_input } from "./KeyboardShortcuts"
  * @param {Array<CellInputData>} cells
  * @return {String}
  */
- export function serialize_cells(cells) {
+export function serialize_cells(cells) {
     return cells.map((cell) => `# ╔═╡ ${cell.cell_id}\n` + cell.code + "\n").join("\n")
 }
 
@@ -22,7 +22,7 @@ import { in_textarea_or_input } from "./KeyboardShortcuts"
  * @param {String} serialized_cells
  * @return {Array<String>}
  */
- export function deserialize_cells(serialized_cells) {
+export function deserialize_cells(serialized_cells) {
     const segments = serialized_cells.replace(/\r\n/g, "\n").split(/# ╔═╡ \S+\n/)
     return segments.map((s) => s.trim()).filter((s) => s !== "")
 }
@@ -36,15 +36,21 @@ import { in_textarea_or_input } from "./KeyboardShortcuts"
  * @param {String} repl_session
  * @return {Array<String>}
  */
- export function deserialize_repl(repl_session) {
+export function deserialize_repl(repl_session) {
     const prompt = "julia> "
     const segments = repl_session.replace(/\r\n/g, "\n").split(prompt)
-    const indent = " ".repeat(prompt.length);
-    return segments.map(function(s) {
-        return (indent + s).split("\n").filter((line) => line.startsWith(indent)).map((s) => s.replace(indent, "")).join("\n")
-    }).map((s) => s.trim()).filter((s) => s !== "")
+    const indent = " ".repeat(prompt.length)
+    return segments
+        .map(function (s) {
+            return (indent + s)
+                .split("\n")
+                .filter((line) => line.startsWith(indent))
+                .map((s) => s.replace(indent, ""))
+                .join("\n")
+        })
+        .map((s) => s.trim())
+        .filter((s) => s !== "")
 }
-
 
 export const detect_deserializer = (topaste) =>
     !in_textarea_or_input() || topaste.match(/# ╔═╡ ........-....-....-....-............/g)?.length

--- a/frontend/common/Serialization.js
+++ b/frontend/common/Serialization.js
@@ -49,6 +49,6 @@ import { in_textarea_or_input } from "./KeyboardShortcuts"
 export const detect_deserializer = (topaste) =>
     !in_textarea_or_input() || topaste.match(/# ╔═╡ ........-....-....-....-............/g)?.length
         ? deserialize_cells
-        : topaste.match(/julia> /) != null
+        : topaste.match(/^julia> /m) != null
         ? deserialize_repl
         : null

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -7,6 +7,7 @@ import { PlutoContext } from "../common/PlutoContext.js"
 
 //@ts-ignore
 import { mac, chromeOS } from "https://cdn.jsdelivr.net/gh/codemirror/CodeMirror@5.60.0/src/util/browser.js"
+import { detect_deserializer } from "../common/Serialization.js"
 
 // @ts-ignore
 const CodeMirror = window.CodeMirror
@@ -469,8 +470,9 @@ export const CellInput = ({
 
         cm.on("paste", (cm, e) => {
             const topaste = e.clipboardData.getData("text/plain")
-            if (topaste.match(/# ╔═╡ ........-....-....-....-............/g)?.length) {
-                pluto_actions.add_deserialized_cells(topaste, -1)
+            const deserializer = detect_deserializer(topaste)
+            if (deserializer != null) {
+                pluto_actions.add_deserialized_cells(topaste, -1, deserializer)
                 e.stopImmediatePropagation()
                 e.preventDefault()
                 e.codemirrorIgnore = true

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -470,7 +470,7 @@ export const CellInput = ({
 
         cm.on("paste", (cm, e) => {
             const topaste = e.clipboardData.getData("text/plain")
-            const deserializer = detect_deserializer(topaste)
+            const deserializer = detect_deserializer(topaste, false)
             if (deserializer != null) {
                 pluto_actions.add_deserialized_cells(topaste, -1, deserializer)
                 e.stopImmediatePropagation()

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -962,17 +962,18 @@ patch: ${JSON.stringify(
         document.addEventListener("paste", async (e) => {
             const topaste = e.clipboardData.getData("text/plain")
             console.log("paste", topaste)
+
+            let deserializer
+            let deserialize = false
             if (topaste.match(/julia> /g)?.length) {
-                // Deselect everything first, to clean things up
-                this.setState({
-                    selected_cells: [],
-                })
-
-                // Paste in the cells at the end of the notebook
-                const data = e.clipboardData.getData("text/plain")
-                this.actions.add_deserialized_cells(data, -1, deserialize_repl)
-                e.preventDefault()
+                deserialize = true
+                deserializer = deserialize_repl
             } else if (!in_textarea_or_input() || topaste.match(/# ╔═╡ ........-....-....-....-............/g)?.length) {
+                deserialize = true
+                deserializer = deserialize_cells
+            }
+
+            if (deserialize) {
                 // Deselect everything first, to clean things up
                 this.setState({
                     selected_cells: [],
@@ -980,7 +981,7 @@ patch: ${JSON.stringify(
 
                 // Paste in the cells at the end of the notebook
                 const data = e.clipboardData.getData("text/plain")
-                this.actions.add_deserialized_cells(data, -1)
+                this.actions.add_deserialized_cells(data, -1, deserializer)
                 e.preventDefault()
             }
         })

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -272,6 +272,9 @@ export class Editor extends Component {
                  */
                 await this.setStatePromise(
                     immer((state) => {
+                        // Deselect everything first, to clean things up
+                        state.selected_cells = []
+
                         for (let cell of new_cells) {
                             state.cell_inputs_local[cell.cell_id] = cell
                         }
@@ -917,18 +920,9 @@ patch: ${JSON.stringify(
 
         document.addEventListener("paste", async (e) => {
             const topaste = e.clipboardData.getData("text/plain")
-            console.log("paste", topaste)
-
             const deserializer = detect_deserializer(topaste)
             if (deserializer != null) {
-                // Deselect everything first, to clean things up
-                this.setState({
-                    selected_cells: [],
-                })
-
-                // Paste in the cells at the end of the notebook
-                const data = e.clipboardData.getData("text/plain")
-                this.actions.add_deserialized_cells(data, -1, deserializer)
+                this.actions.add_deserialized_cells(topaste, -1, deserializer)
                 e.preventDefault()
             }
         })

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -81,7 +81,7 @@ function deserialize_cells(serialized_cells) {
     const segments = repl_session.replace(/\r\n/g, "\n").split(prompt)
     const indent = " ".repeat(prompt.length);
     return segments.map(function(s) {
-        return (indent + s).split("\n").filter((line) => line.startsWith(indent)).map((s) => s.trim()).join("\n")
+        return (indent + s).split("\n").filter((line) => line.startsWith(indent)).map((s) => s.replace(indent, "")).join("\n")
     }).map((s) => s.trim()).filter((s) => s !== "")
 }
 


### PR DESCRIPTION
Fix #1140.

![Peek 08-05-2021 11-57](https://user-images.githubusercontent.com/37125/117543781-ad576900-aff4-11eb-8e1b-bf8a26683555.gif)

This does a small rewiring of the logic behind pasting Pluto notebooks to work with generic "deserializing" functions (a mapping from a string to an array of strings representing cell contents).

~(**Don't merge yet.** I have to solve a small issue with indentation before this can be merged.)~

EDIT: The REPL indentation is nicely preserved,

![Peek 08-05-2021 12-19](https://user-images.githubusercontent.com/37125/117544455-e8a76700-aff7-11eb-9e0d-7f79c4b01544.gif)
