### PR TITLE
🥐 Bake jl file into static export, binder button on exported HTML files

### DIFF
--- a/frontend/binder.css
+++ b/frontend/binder.css
@@ -165,6 +165,7 @@ body.wiggle_binder #binder_launch_help {
     background-image: url(https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.0.0/src/svg/close-outline.svg);
 }
 
+.download_div,
 .copy_div {
     padding: 4px 8px;
     display: flex;
@@ -174,7 +175,9 @@ body.wiggle_binder #binder_launch_help {
     margin-bottom: 0.75rem;
 }
 
+.download_div,
 #launch_binder button,
+.download_div,
 .copy_div {
     width: max(60%, 10rem);
     margin: 0px auto;
@@ -183,6 +186,7 @@ body.wiggle_binder #binder_launch_help {
     overflow: hidden;
 }
 
+.download_div a,
 .copy_div input {
     width: calc(100% - 8px - 1rem);
     outline: none;
@@ -193,6 +197,12 @@ body.wiggle_binder #binder_launch_help {
     cursor: text;
 }
 
+.download_div,
+.download_div a {
+    cursor: pointer;
+}
+
+.download_icon,
 .copy_icon {
     position: relative;
     cursor: pointer;
@@ -203,6 +213,10 @@ body.wiggle_binder #binder_launch_help {
     background-repeat: no-repeat;
     background-image: url(https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.0.0/src/svg/copy-outline.svg);
     box-shadow: 0px 0px 60px 60px white;
+}
+
+.download_icon {
+    background-image: url(https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.0.0/src/svg/download-outline.svg);
 }
 
 .copy_icon.success_copy::after {

--- a/frontend/common/Binder.js
+++ b/frontend/common/Binder.js
@@ -114,19 +114,26 @@ export const start_binder = async ({ setStatePromise, connect, launch_params }) 
 
         let open_response
 
-        for (const [p1, p2] of [
-            ["path", launch_params.notebookfile],
-            ["url", new URL(launch_params.notebookfile, window.location.href).href],
-        ]) {
-            const open_url = new URL("open", binder_session_url)
-            open_url.searchParams.set(p1, p2)
-
-            console.log(`open ${p1}:`, String(open_url))
-            open_response = await fetch(with_token(open_url), {
+        if (launch_params.notebookfile.startsWith("data:")) {
+            open_response = await fetch(with_token(new URL("notebookupload", binder_session_url)), {
                 method: "POST",
+                body: await (await fetch(launch_params.notebookfile)).arrayBuffer(),
             })
-            if (open_response.ok) {
-                break
+        } else {
+            for (const [p1, p2] of [
+                ["path", launch_params.notebookfile],
+                ["url", new URL(launch_params.notebookfile, window.location.href).href],
+            ]) {
+                const open_url = new URL("open", binder_session_url)
+                open_url.searchParams.set(p1, p2)
+
+                console.log(`open ${p1}:`, String(open_url))
+                open_response = await fetch(with_token(open_url), {
+                    method: "POST",
+                })
+                if (open_response.ok) {
+                    break
+                }
             }
         }
 

--- a/frontend/components/BinderButton.js
+++ b/frontend/components/BinderButton.js
@@ -71,7 +71,12 @@ export const BinderButton = ({ binder_phase, start_binder, notebookfile }) => {
                         ${recommend_download
                             ? html`
                                   <div class="command">Download the notebook:</div>
-                                  <div onClick=${(e) => e.target.closest("div").firstElementChild.click()} class="download_div">
+                                  <div
+                                      onClick=${(e) => {
+                                          e.target.tagName === "A" || e.target.closest("div").firstElementChild.click()
+                                      }}
+                                      class="download_div"
+                                  >
                                       <a href=${notebookfile_ref.current} target="_blank" download="notebook.jl">notebook.jl</a>
                                       <span class="download_icon"></span>
                                   </div>

--- a/frontend/components/BinderButton.js
+++ b/frontend/components/BinderButton.js
@@ -30,6 +30,7 @@ export const BinderButton = ({ binder_phase, start_binder, notebookfile }) => {
     const show = binder_phase === BinderPhase.wait_for_user
     if (!show) return null
     const show_binder = binder_phase != null
+    const recommend_download = notebookfile_ref.current.startsWith("data:")
     return html` <div id="launch_binder">
         <span
             id="binder_launch_help"
@@ -67,18 +68,28 @@ export const BinderButton = ({ binder_phase, start_binder, notebookfile }) => {
             <ol style="padding: 0 2rem;">
                 <li>
                     <div>
-                        <div class="command">Copy the notebook URL:</div>
-                        <div class="copy_div">
-                            <input onClick=${(e) => e.target.select()} value=${notebookfile_ref.current} readonly />
-                            <span
-                                class=${`copy_icon ${showCopyPopup ? "success_copy" : ""}`}
-                                onClick=${async () => {
-                                    await navigator.clipboard.writeText(notebookfile_ref.current)
-                                    setShowCopyPopup(true)
-                                    setTimeout(() => setShowCopyPopup(false), 3000)
-                                }}
-                            />
-                        </div>
+                        ${recommend_download
+                            ? html`
+                                  <div class="command">Download the notebook:</div>
+                                  <div onClick=${(e) => e.target.closest("div").firstElementChild.click()} class="download_div">
+                                      <a href=${notebookfile_ref.current} target="_blank" download="notebook.jl">notebook.jl</a>
+                                      <span class="download_icon"></span>
+                                  </div>
+                              `
+                            : html`
+                                  <div class="command">Copy the notebook URL:</div>
+                                  <div class="copy_div">
+                                      <input onClick=${(e) => e.target.select()} value=${notebookfile_ref.current} readonly />
+                                      <span
+                                          class=${`copy_icon ${showCopyPopup ? "success_copy" : ""}`}
+                                          onClick=${async () => {
+                                              await navigator.clipboard.writeText(notebookfile_ref.current)
+                                              setShowCopyPopup(true)
+                                              setTimeout(() => setShowCopyPopup(false), 3000)
+                                          }}
+                                      />
+                                  </div>
+                              `}
                     </div>
                 </li>
                 <li>
@@ -90,8 +101,16 @@ export const BinderButton = ({ binder_phase, start_binder, notebookfile }) => {
                     <img src="https://user-images.githubusercontent.com/6933510/107865594-60864b00-6e68-11eb-9625-2d11fd608e7b.png" />
                 </li>
                 <li>
-                    <div class="command">Paste URL in the <em>Open</em> box</div>
-                    <video playsinline autoplay loop src="https://i.imgur.com/wf60p5c.mp4" />
+                    ${recommend_download
+                        ? html`
+                              <div class="command">Open the notebook file</div>
+                              <p>Type the saved filename in the <em>open</em> box.</p>
+                              <img src="https://user-images.githubusercontent.com/6933510/119374043-65556900-bcb9-11eb-9026-149c1ba2d05b.png" />
+                          `
+                        : html`
+                              <div class="command">Paste URL in the <em>Open</em> box</div>
+                              <video playsinline autoplay loop src="https://i.imgur.com/wf60p5c.mp4" />
+                          `}
                 </li>
             </ol>
         </div>`}

--- a/frontend/components/PasteHandler.js
+++ b/frontend/components/PasteHandler.js
@@ -75,8 +75,6 @@ const processFile = async (ev) => {
     const reply = await fetch("./notebookupload", {
         method: "POST",
         body: notebook,
-        cache: "no-cache",
-        credentials: "same-origin",
     }).then((res) => res.text())
     window.location.href = link_edit(reply)
 }

--- a/src/notebook/Export.jl
+++ b/src/notebook/Export.jl
@@ -44,7 +44,7 @@ function generate_html(;
 end
 
 
-function generate_html(notebook; kwargs...)
+function generate_html(notebook; kwargs...)::String
     state = notebook_to_js(notebook)
 
     notebookfile_js = let
@@ -52,7 +52,7 @@ function generate_html(notebook; kwargs...)
             save_notebook(io, notebook)
         end
 
-        "\"data:;base64,$(notebookfile64)\""
+        "\"data:text/julia;charset=utf-8;base64,$(notebookfile64)\""
     end
 
     statefile_js = let

--- a/src/notebook/Export.jl
+++ b/src/notebook/Export.jl
@@ -47,6 +47,14 @@ end
 function generate_html(notebook; kwargs...)
     state = notebook_to_js(notebook)
 
+    notebookfile_js = let
+        notebookfile64 = base64encode() do io
+            save_notebook(io, notebook)
+        end
+
+        "\"data:;base64,$(notebookfile64)\""
+    end
+
     statefile_js = let
         statefile64 = base64encode() do io
             pack(io, state)
@@ -55,5 +63,5 @@ function generate_html(notebook; kwargs...)
         "\"data:;base64,$(statefile64)\""
     end
     
-    generate_html(; statefile_js=statefile_js, kwargs...)
+    generate_html(; statefile_js=statefile_js, notebookfile_js=notebookfile_js, kwargs...)
 end

--- a/src/notebook/Export.jl
+++ b/src/notebook/Export.jl
@@ -1,10 +1,15 @@
 import Pkg
 using Base64
 
+const default_binder_url = "https://mybinder.org/v2/gh/fonsp/pluto-on-binder/v$(string(PLUTO_VERSION))"
+
+"""
+See [PlutoSliderServer.jl](https://github.com/JuliaPluto/PlutoSliderServer.jl) if you are interested in exporting notebooks programatically.
+"""
 function generate_html(;
         version=nothing, pluto_cdn_root=nothing,
         notebookfile_js="undefined", statefile_js="undefined", 
-        slider_server_url_js="undefined", binder_url_js="undefined", 
+        slider_server_url_js="undefined", binder_url_js=repr(default_binder_url),
         disable_ui=true
     )::String
 

--- a/src/notebook/PathHelpers.jl
+++ b/src/notebook/PathHelpers.jl
@@ -1,3 +1,5 @@
+import Base64: base64decode
+
 const adjectives = [
 	"groundbreaking"
 	"revolutionary"
@@ -75,6 +77,19 @@ const pluto_file_extensions = [
 ]
 
 endswith_pluto_file_extension(s) = any(endswith(s, e) for e in pluto_file_extensions)
+
+function embedded_notebookfile(html_contents::AbstractString)::String
+	if !occursin("</html>", html_contents)
+		throw(ArgumentError("Pass the contents of a Pluto-exported HTML file as argument."))
+	end
+
+	m = match(r"pluto_notebookfile.*\"data\:.*base64\,(.*)\"", html_contents)
+	if m === nothing
+		throw(ArgumentError("Notebook does not have an embedded notebook file."))
+	else
+		String(base64decode(m.captures[1]))
+	end
+end
 
 """
 Does the path end with a pluto file extension (like `.jl` or `.pluto.jl`) and does the first line say `### A Pluto.jl notebook ###`? 

--- a/test/Notebook.jl
+++ b/test/Notebook.jl
@@ -216,6 +216,25 @@ end
         end
     end
 
+    @testset "Import & export HTML" begin
+        nb = basic_notebook()
+        export_html = Pluto.generate_html(nb)
+
+        embedded_jl = Pluto.embedded_notebookfile(export_html)
+        jl_path = tempname()
+        write(jl_path, embedded_jl)
+        
+        result = load_notebook_nobackup(jl_path)
+        @test notebook_inputs_equal(nb, result; check_paths_equality=false)
+
+        
+        filename = "howdy.jl"
+
+        export_html = Pluto.generate_html(nb; notebookfile_js=filename)
+        @test occursin(filename, export_html)
+        @test_throws ArgumentError Pluto.embedded_notebookfile(export_html)
+    end
+
     @testset "Utilities" begin
         @testset "Cute file names" begin
             trash = mktempdir()

--- a/test/helpers.jl
+++ b/test/helpers.jl
@@ -105,10 +105,10 @@ function occursinerror(needle, haystack::Pluto.Cell)
 end
 
 "Test notebook equality, ignoring cell UUIDs and such."
-function notebook_inputs_equal(nbA, nbB)
-    x = normpath(nbA.path) == normpath(nbB.path)
+function notebook_inputs_equal(nbA, nbB; check_paths_equality=true)
+    x = !check_paths_equality || (normpath(nbA.path) == normpath(nbB.path))
 
-    to_compare(cell) = (cell.cell_id, cell.code)
+    to_compare(cell) = (cell.cell_id, cell.code_folded, cell.code)
     y = to_compare.(nbA.cells) == to_compare.(nbB.cells)
     
     x && y


### PR DESCRIPTION
A generated HTML file now contains the contents of the original notebook file, as a base64-encoded data URL. This means that HTML files generated from the export menu now have a binder button and a "download notebook" button built-in!

The goal was to also add the ability to open HTML files from the main menu, but we still need to think about where to store the jl file after it is loaded. What about storing it back into the HTML file, skipping a .jl file entirely? 👀 With embedded state? 👀👀 Would be neat!


Example of a new export file:


https://gist.github.com/fonsp/28b2480990372f001d356aa00644119b

View it in your browser: https://htmlview.glitch.me/?https://gist.github.com/fonsp/28b2480990372f001d356aa00644119b