### PR TITLE
Remove Ctrl-d shortcut from pluto for mac os users

### DIFF
--- a/frontend/common/KeyboardShortcuts.js
+++ b/frontend/common/KeyboardShortcuts.js
@@ -12,6 +12,10 @@ export let map_cmd_to_ctrl_on_mac = (keymap) => {
     let keymap_with_cmd = { ...keymap }
     for (let [key, handler] of Object.entries(keymap)) {
         keymap_with_cmd[key.replace(/Ctrl/g, "Cmd")] = handler
+        // remove Ctrl-D from Pluto.jl keybind for MacOS
+        if (key == "Ctrl-D") {
+            delete keymap_withcmd[key]
+        }
     }
     return keymap_with_cmd
 }

--- a/frontend/common/KeyboardShortcuts.js
+++ b/frontend/common/KeyboardShortcuts.js
@@ -14,7 +14,7 @@ export let map_cmd_to_ctrl_on_mac = (keymap) => {
         keymap_with_cmd[key.replace(/Ctrl/g, "Cmd")] = handler
         // remove Ctrl-D from Pluto.jl keybind for MacOS
         if (key == "Ctrl-D") {
-            delete keymap_withcmd[key]
+            delete keymap_with_cmd[key]
         }
     }
     return keymap_with_cmd


### PR DESCRIPTION
This PR resolves #1200 . It would make texting more comfortable. for macOS users.
