### PR TITLE
Allow widgets to request updated code

### DIFF
--- a/frontend/components/Cell.js
+++ b/frontend/components/Cell.js
@@ -96,6 +96,20 @@ export const Cell = ({
         set_cell_api_ready(true)
     })
 
+    useEffect(() => {
+        if (!node_ref.current) return () => {}
+        console.log("Registering event listener")
+        const updater = (ev) => {
+            console.log("Event captured", cell_id, node_ref.current, ev)
+            pluto_actions.set_local_cell(cell_id, ev.detail.new_code)
+        }
+        node_ref.current.addEventListener("update_cell_code", updater)
+        return () => {
+            console.log("UnRegistering event listener")
+            node_ref.current.removeEventListener("update_cell_code", updater)
+        }
+    }, [node_ref.current, pluto_actions])
+
     return html`
         <pluto-cell
             ref=${node_ref}


### PR DESCRIPTION
This is just an idea -- 

What if a widget allowed you to author SQL, run it (on save) and still produce valid pluto cells?

Very draft, check out with this notebook: 
```
### A Pluto.jl notebook ###
# v0.14.7

using Markdown
using InteractiveUtils

# ╔═╡ da08cab4-c317-11eb-36b2-f574a80b07a0
using HypertextLiteral

# ╔═╡ 32d5bbb4-244c-434a-b3b3-65e5b3b97e1e
function SQLWidget(query)
	tq = '"' * '"' * '"'
	@htl("""<div>
	<script type=module id="sql">
	const {
    EditorState,
    EditorView,
    Compartment,
    EditorSelection,
    basicSetup,
    StreamLanguage,
    julia,
    keymap,
    history,
    historyKeymap,
    defaultKeymap,
    indentMore,
    indentLess,
} = await import("https://cdn.jsdelivr.net/gh/JuliaPluto/codemirror-pluto-setup@8697d451b4d1bb25bb0d772e857f8a3802cdc279/dist/index.es.min.js")
	const node = this ?? document.createElement("div")
	const onCM6Update = (update) => {
            if (update.docChanged) {
                const new_value = update.state.doc.toString()
				const new_code = `SQLWidget($(tq)\${new_value}$(tq))`;
				node.closest("pluto-cell").querySelector(".CodeMirror").CodeMirror.setValue(new_code);
                node.closest("pluto-cell").dispatchEvent(new CustomEvent("update_cell_code", {
					detail: {
						new_code
					}
				}))
				
            }
        }
	if(this == null) {
	const newcm =  new EditorView({
            /** Migration #0: New */
            state: EditorState.create({
                doc: "$(query)",
                extensions: [
                    EditorState.tabSize.of(4),
                    basicSetup,
                    EditorView.updateListener.of(onCM6Update),
                    history(),
                ],
            }),
            parent: node,
        })
	}
	
	return node
	</script>""")
end

# ╔═╡ 8cdb2625-70c0-40d1-9554-b73d40633ffd
SQLWidget("""select * from datasource""")

# ╔═╡ Cell order:
# ╠═da08cab4-c317-11eb-36b2-f574a80b07a0
# ╠═32d5bbb4-244c-434a-b3b3-65e5b3b97e1e
# ╠═8cdb2625-70c0-40d1-9554-b73d40633ffd
```