### PR TITLE
Better detect function assignments to disable function wrapping

### DIFF
--- a/src/analysis/TopologyUpdate.jl
+++ b/src/analysis/TopologyUpdate.jl
@@ -12,22 +12,12 @@ function updated_topology(old_topology::NotebookTopology, notebook::Notebook, ce
 			haskey(old_topology.codes, cell) && 
 			old_topology.codes[cell].code === cell.code
 		)
-			parsedcode = parse_custom(notebook, cell)
-			new_node = parsedcode |>
+			new_code = ExprAnalysisCache(notebook, cell)
+
+
+			new_node = new_code.parsedcode |>
 				ExpressionExplorer.try_compute_symbolreferences |>
 				ReactiveNode
-
-
-			using_imports = ExpressionExplorer.compute_usings_imports(parsedcode)
-			new_code = ExprAnalysisCache(
-				code=cell.code,
-				parsedcode=parsedcode,
-				module_usings_imports=using_imports,
-				function_wrapped=!any(funcname -> !startswith(string(funcname), "anon"), new_node.funcdefs_without_signatures) &&
-					:eval ∉ new_node.references && :include ∉ new_node.references &&
-					isempty(using_imports.usings) && isempty(using_imports.imports) &&
-					ExpressionExplorer.can_be_function_wrapped(parsedcode)
-			)
 
 			updated_nodes[cell] = new_node
 			updated_codes[cell] = new_code

--- a/src/analysis/TopologyUpdate.jl
+++ b/src/analysis/TopologyUpdate.jl
@@ -16,12 +16,14 @@ function updated_topology(old_topology::NotebookTopology, notebook::Notebook, ce
 			new_node = parsedcode |>
 				ExpressionExplorer.try_compute_symbolreferences |>
 				ReactiveNode
+
+
 			using_imports = ExpressionExplorer.compute_usings_imports(parsedcode)
 			new_code = ExprAnalysisCache(
 				code=cell.code,
 				parsedcode=parsedcode,
 				module_usings_imports=using_imports,
-				function_wrapped=isempty(filter(funcname -> !startswith(string(funcname), "anon"), new_node.funcdefs_without_signatures)) &&
+				function_wrapped=!any(funcname -> !startswith(string(funcname), "anon"), new_node.funcdefs_without_signatures) &&
 					:eval ∉ new_node.references && :include ∉ new_node.references &&
 					isempty(using_imports.usings) && isempty(using_imports.imports) &&
 					ExpressionExplorer.can_be_function_wrapped(parsedcode)

--- a/test/React.jl
+++ b/test/React.jl
@@ -1005,6 +1005,10 @@ import Distributed
             Cell("qn0"),
             Cell("qn1"),
 
+            Cell("""
+                 named_tuple(obj::T) where {T} = NamedTuple{fieldnames(T),Tuple{fieldtypes(T)...}}(ntuple(i -> getfield(obj, i), fieldcount(T)))
+            """),
+            Cell("named_tuple")
         ])
 
         update_run!(🍭, notebook, notebook.cells)
@@ -1067,6 +1071,10 @@ import Distributed
         @test notebook.cells[18].output.body == ":(1 + 1)"
         @test notebook.cells[19].output.body == ":(1 + 1)"
         @test notebook.cells[20].output.body == ":(1 + 1)"
+
+        @test notebook.cells[27].errored == false
+        @test notebook.topology.codes[notebook.cells[27]].function_wrapped == false
+        @test notebook.cells[28].errored == false
 
         WorkspaceManager.unmake_workspace((🍭, notebook))
 


### PR DESCRIPTION
This is a small refactor to build the `ExprAnalysisCache` and the `ReactiveNode` together as part of a topology update. This allows using the Reactive node data to enable/disable function wrapping without re-writing all the function transforms rules from `explore!` in `can_be_function_wrapped`. The Reactive nodes are also not re-computed if the code of the cell does not change, avoiding extra work.

Fixes #1199