### PR TITLE
Preserve scope of `Symbol` to fix #1128

### DIFF
--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -1160,7 +1160,7 @@ function binding_from(x::Expr, workspace::Module)
         error("Couldn't infer `$x` for Live Docs.")
     end
 end
-binding_from(s::Symbol, workspace::Module) = Core.eval(workspace, s)
+binding_from(s::Symbol, workspace::Module) = Docs.Binding(workspace, s)
 binding_from(r::GlobalRef, workspace::Module) = Docs.Binding(r.mod, r.name)
 binding_from(other, workspace::Module) = error("Invalid @var syntax `$other`.")
 

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -1155,6 +1155,11 @@ function binding_from(x::Expr, workspace::Module)
             error("Couldn't infer `$x` for Live Docs.")
         end
     elseif is_pure_expression(x)
+        if x.head == :.
+            # Simply calling Core.eval on `a.b` will retrieve the value instead of the binding
+            m = Core.eval(workspace, x.args[1])
+            isa(m, Module) && return Docs.Binding(m, x.args[2].value)
+        end
         Core.eval(workspace, x)
     else
         error("Couldn't infer `$x` for Live Docs.")

--- a/test/Dynamic.jl
+++ b/test/Dynamic.jl
@@ -147,6 +147,17 @@ end
         @test occursin("square root", Pluto.PlutoRunner.doc_fetcher("sqrt", Main)[1])
         @test occursin("square root", Pluto.PlutoRunner.doc_fetcher("Base.sqrt", Main)[1])
         @test occursin("No documentation found", Pluto.PlutoRunner.doc_fetcher("Base.findmeta", Main)[1])
+        # Issue #1128
+        # Ref https://docs.julialang.org/en/v1/manual/documentation/#Dynamic-documentation
+        struct MyType
+            value::String
+        end
+
+        Docs.getdoc(t::MyType) = "Documentation for MyType with value $(t.value)"
+
+        global x = MyType("x")
+        
+        @test occursin("Documentation for MyType with value", Pluto.PlutoRunner.doc_fetcher("x", Main)[1])
     end
 
     @testset "PlutoRunner API" begin


### PR DESCRIPTION
Replace `Core.eval` with `Docs.Binding` for Symbols
Fix #1128 