### PR TITLE
 prevent scrollbar on dataframe output

### DIFF
--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -349,7 +349,7 @@ pluto-output div.footnote p:last-child {
 
 pluto-output.scroll_y {
     max-height: 80vh;
-    max-height: 400px;
+    max-height: 502px;
     overflow: auto;
 }
 


### PR DESCRIPTION
Any dataframe with more than 12 rows automatically has a scrollbar in Pluto since it is more than 400px high. 450px is enough to fit dataframes with more than 15 rows since dataframes automatically hides rows. 502px is enough to show up to 15 rows without scrollbar.

I mentioned the scrollbar before [here](https://github.com/fonsp/Pluto.jl/issues/996), but was told is was a feature. I'm understand that there might be good reasons not to increase the max output size that I'm not aware of. But I thought I give this PR a try anyway. 

