### PR TITLE
Paste cells after currently selected input cell

### DIFF
--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -476,7 +476,7 @@ export const CellInput = ({
             const topaste = e.clipboardData.getData("text/plain")
             const deserializer = detect_deserializer(topaste, false)
             if (deserializer != null) {
-                pluto_actions.add_deserialized_cells(topaste, -1, deserializer)
+                pluto_actions.add_deserialized_cells(topaste, editor_state.notebook.cell_order.indexOf(cell_id)+1, deserializer)
                 e.stopImmediatePropagation()
                 e.preventDefault()
                 e.codemirrorIgnore = true

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -476,7 +476,7 @@ export const CellInput = ({
             const topaste = e.clipboardData.getData("text/plain")
             const deserializer = detect_deserializer(topaste, false)
             if (deserializer != null) {
-                pluto_actions.add_deserialized_cells(topaste, editor_state.notebook.cell_order.indexOf(cell_id)+1, deserializer)
+                pluto_actions.add_deserialized_cells(topaste, cell_id, deserializer)
                 e.stopImmediatePropagation()
                 e.preventDefault()
                 e.codemirrorIgnore = true

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -262,13 +262,18 @@ export class Editor extends Component {
                     code_folded: false,
                     running_disabled: false,
                 }))
-                /* Try parsing the input as a number */
-                let index = Number(index_or_id)
+
+                let index
                 
-                /* if the input is not an integer, try interpreting it as a cell id */
-                /* This defaults to -1 in case the cell_id is not found, reverting to the original behavior */
-                if (isNaN(index)) {
+                if (typeof(index_or_id) === 'number') {
+                    index = index_or_id
+                } else {
+                    /* if the input is not an integer, try interpreting it as a cell id */
                     index = this.state.notebook.cell_order.indexOf(index_or_id)
+                    if (index !== -1) {
+                        /* Make sure that the cells are pasted after the current cell */
+                        index += 1
+                    }
                 }
 
                 if (index === -1) {

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -252,7 +252,7 @@ export class Editor extends Component {
                     )
                 }
             },
-            add_deserialized_cells: async (data, index, deserializer = deserialize_cells) => {
+            add_deserialized_cells: async (data, index_or_id, deserializer = deserialize_cells) => {
                 let new_codes = deserializer(data)
                 /** @type {Array<CellInputData>} */
                 /** Create copies of the cells with fresh ids */
@@ -262,6 +262,15 @@ export class Editor extends Component {
                     code_folded: false,
                     running_disabled: false,
                 }))
+                /* Try parsing the input as a number */
+                let index = Number(index_or_id)
+                
+                /* if the input is not an integer, try interpreting it as a cell id */
+                /* This defaults to -1 in case the cell_id is not found, reverting to the original behavior */
+                if (isNaN(index)) {
+                    index = this.state.notebook.cell_order.indexOf(index_or_id)
+                }
+
                 if (index === -1) {
                     index = this.state.notebook.cell_order.length
                 }

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -254,6 +254,28 @@ export class Editor extends Component {
             },
             add_deserialized_cells: async (data, index_or_id, deserializer = deserialize_cells) => {
                 let new_codes = deserializer(data)
+
+                let index
+                /* Check if the function was called from a cell, and if it is an empty cell put the first deserialized cell inside it rather than adding a new one */
+                if (typeof(index_or_id) === 'string') {
+                    /* Try to interpret the string as a cell id and look for it among the currently existing cells */
+                    index = this.state.notebook.cell_order.indexOf(index_or_id)
+                    if (index !== -1) {
+
+                        const cell_id = index_or_id
+
+                        /* Make sure that the cells are pasted after the current cell */
+                        index += 1
+                            
+                        /* Check if content of current cell is empty, and skip the rest otherwise */
+                        const cm = document.querySelector(`[id="${cell_id}"] .CodeMirror`).CodeMirror
+
+                        if (cm.getValue() === "") {
+                            cm.setValue(new_codes.shift())
+                        }
+                    }
+                }
+                
                 /** @type {Array<CellInputData>} */
                 /** Create copies of the cells with fresh ids */
                 let new_cells = new_codes.map((code) => ({
@@ -262,20 +284,10 @@ export class Editor extends Component {
                     code_folded: false,
                     running_disabled: false,
                 }))
-
-                let index
                 
                 if (typeof(index_or_id) === 'number') {
                     index = index_or_id
-                } else {
-                    /* if the input is not an integer, try interpreting it as a cell id */
-                    index = this.state.notebook.cell_order.indexOf(index_or_id)
-                    if (index !== -1) {
-                        /* Make sure that the cells are pasted after the current cell */
-                        index += 1
-                    }
-                }
-
+                } 
                 if (index === -1) {
                     index = this.state.notebook.cell_order.length
                 }

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -254,28 +254,6 @@ export class Editor extends Component {
             },
             add_deserialized_cells: async (data, index_or_id, deserializer = deserialize_cells) => {
                 let new_codes = deserializer(data)
-
-                let index
-                /* Check if the function was called from a cell, and if it is an empty cell put the first deserialized cell inside it rather than adding a new one */
-                if (typeof(index_or_id) === 'string') {
-                    /* Try to interpret the string as a cell id and look for it among the currently existing cells */
-                    index = this.state.notebook.cell_order.indexOf(index_or_id)
-                    if (index !== -1) {
-
-                        const cell_id = index_or_id
-
-                        /* Make sure that the cells are pasted after the current cell */
-                        index += 1
-                            
-                        /* Check if content of current cell is empty, and skip the rest otherwise */
-                        const cm = document.querySelector(`[id="${cell_id}"] .CodeMirror`).CodeMirror
-
-                        if (cm.getValue() === "") {
-                            cm.setValue(new_codes.shift())
-                        }
-                    }
-                }
-                
                 /** @type {Array<CellInputData>} */
                 /** Create copies of the cells with fresh ids */
                 let new_cells = new_codes.map((code) => ({
@@ -284,10 +262,20 @@ export class Editor extends Component {
                     code_folded: false,
                     running_disabled: false,
                 }))
+
+                let index
                 
                 if (typeof(index_or_id) === 'number') {
                     index = index_or_id
-                } 
+                } else {
+                    /* if the input is not an integer, try interpreting it as a cell id */
+                    index = this.state.notebook.cell_order.indexOf(index_or_id)
+                    if (index !== -1) {
+                        /* Make sure that the cells are pasted after the current cell */
+                        index += 1
+                    }
+                }
+
                 if (index === -1) {
                     index = this.state.notebook.cell_order.length
                 }


### PR DESCRIPTION
Initial attempt to fix [#1255 ](https://github.com/fonsp/Pluto.jl/issues/1255)

This simply add the pasted cells after the input cell where the paste command has been issued:


https://user-images.githubusercontent.com/12846528/122967186-7feb3280-d38a-11eb-862e-fff8477b2ea4.mp4

Paste events outside of input cells are still put at the end of the notebook and I don't know whether there is a better way to get the position of the current cell