### PR TITLE
Remove `project` configuration

### DIFF
--- a/test/Configuration.jl
+++ b/test/Configuration.jl
@@ -12,32 +12,29 @@ cd(Pluto.project_relative_path("test")) do
 end
 
 @testset "from_flat_kwargs" begin
-    opt = from_flat_kwargs(;compile="min", project="test")
+    opt = from_flat_kwargs(;compile="min", launch_browser=false)
     @test opt.compiler.compile == "min"
-    @test opt.compiler.project == "test"
+    @test opt.server.launch_browser == false
 
-    @test_throws ArgumentError from_flat_kwargs(;fake_project="test")    
+    @test_throws ArgumentError from_flat_kwargs(;asdfasdf="test")    
 end
 
 @testset "flag conversion" begin
     if VERSION > v"1.5.0-"
         @test _convert_to_flags(Configuration.CompilerOptions(threads="123")) ==
-            ["--project=@.", "--startup-file=no", "--history-file=no", "--threads=123"]
+            ["--startup-file=no", "--history-file=no", "--threads=123"]
 
         @test _convert_to_flags(Configuration.CompilerOptions(threads=123)) ==
-            ["--project=@.", "--startup-file=no", "--history-file=no", "--threads=123"]
+            ["--startup-file=no", "--history-file=no", "--threads=123"]
 
         @test _convert_to_flags(Configuration.CompilerOptions()) ⊇
-            ["--project=@.", "--startup-file=no", "--history-file=no"]
+            ["--startup-file=no", "--history-file=no"]
     else
         @test _convert_to_flags(Configuration.CompilerOptions()) ==
-            ["--project=@.", "--startup-file=no", "--history-file=no"]
+            ["--startup-file=no", "--history-file=no"]
     end
     @test _convert_to_flags(Configuration.CompilerOptions(compile="min")) ⊇
-    ["--compile=min", "--project=@.", "--startup-file=no", "--history-file=no"]
-
-    @test _convert_to_flags(Configuration.CompilerOptions(compile="min", project="test")) ⊇
-    ["--compile=min", "--project=test", "--startup-file=no", "--history-file=no"]
+    ["--compile=min", "--startup-file=no", "--history-file=no"]
 end
 
 @testset "authentication" begin

--- a/test/WorkspaceManager.jl
+++ b/test/WorkspaceManager.jl
@@ -64,23 +64,6 @@ import Distributed
         WorkspaceManager.unmake_workspace((🍭, notebook))
     end
 
-    @testset "Notebook environment" begin
-        session_options = CompilerOptions()
-        notebook = Notebook([Cell("x")])
-        notebook.compiler_options = CompilerOptions(;project="test")
-        @test _merge_notebook_compiler_options(notebook, session_options).project ==
-            joinpath(dirname(notebook.path), "test")
-
-        notebook.compiler_options = CompilerOptions(;project=project_relative_path("test"))
-        @test _merge_notebook_compiler_options(notebook, session_options).project ==
-            project_relative_path("test")
-        
-        session_options = CompilerOptions(;project=project_relative_path("test"))
-        notebook.compiler_options = CompilerOptions(;project=project_relative_path("Project.toml"))
-        @test _merge_notebook_compiler_options(notebook, session_options).project ==
-            project_relative_path("Project.toml")
-    end
-
     Sys.iswindows() || (VERSION < v"1.6.0-a") || @testset "Pluto inside Pluto" begin
 
         client = ClientSession(:fakeA, nothing)


### PR DESCRIPTION
Because:
- I noticed that this system did not work as expected: it uses the `pwd` of the Pluto server to resolve the environment for notebook processes. We want these to be disconnected.
- Since #844, the environment is now either embedded in the notebook file (default), or set up using `Pkg.activate` inside notebook code. 

Finally, this option conflicts with the new Pkg logic, and no longer works. Let's see if the need for such an option arises again, but the new Pkg behaviour might cover all use cases.