### PR TITLE
Detect Project.toml in parent dirs and disable PlutoPkg

### DIFF
--- a/src/evaluation/WorkspaceManager.jl
+++ b/src/evaluation/WorkspaceManager.jl
@@ -1,7 +1,7 @@
 module WorkspaceManager
 import UUIDs: UUID
 import ..Pluto: Configuration, Notebook, Cell, ProcessStatus, ServerSession, ExpressionExplorer, pluto_filename, Token, withtoken, Promise, tamepath, project_relative_path, putnotebookupdates!, UpdateMessage
-import ..Pluto.PkgCompat
+import ..Pluto.PkgCompat: PkgCompat, AbstractPackageManagement, FullyManaged, ParentProject, NotManaged
 import ..Configuration: CompilerOptions, _merge_notebook_compiler_options, _resolve_notebook_project_path, _convert_to_flags
 import ..Pluto.ExpressionExplorer: FunctionName
 import ..PlutoRunner
@@ -79,7 +79,7 @@ function make_workspace((session, notebook)::SN; force_offline::Bool=false)::Wor
 end
 
 function use_nbpkg_environment((session, notebook)::SN, workspace=nothing)
-    enabled = notebook.nbpkg_ctx !== nothing
+    enabled = (notebook.nbpkg_ctx isa FullyManaged)
     if workspace.nbpkg_was_active == enabled
         return
     end

--- a/src/notebook/PathHelpers.jl
+++ b/src/notebook/PathHelpers.jl
@@ -48,9 +48,14 @@ function cutename()
     titlecase(rand(adjectives)) * " " * rand(nouns)
 end
 
+const default_notebook_dir = joinpath(first(DEPOT_PATH), "pluto_notebooks")
+const default_notebook_dirs = [
+	default_notebook_dir
+]
+
 function new_notebooks_directory()
     try
-        path = joinpath(first(DEPOT_PATH), "pluto_notebooks")
+        path = default_notebook_dir
         if !isdir(path)
             mkdir(path)
         end

--- a/src/packages/PkgUtils.jl
+++ b/src/packages/PkgUtils.jl
@@ -10,7 +10,7 @@ using Markdown
 
 export activate_notebook
 
-ensure_has_nbpkg(notebook::Notebook) = if notebook.nbpkg_ctx === nothing
+ensure_has_nbpkg(notebook::Notebook) = if (notebook.nbpkg_ctx isa FullyManaged)
 
     # TODO: update_save the notebook to init packages and stuff?
     error("""
@@ -63,7 +63,7 @@ end
 function write_dir_to_nb(dir::String, notebook::Notebook)
     assert_has_manifest(dir)
 
-    notebook.nbpkg_ctx = Pluto.PkgCompat.create_empty_ctx()
+    notebook.nbpkg_ctx = Pluto.PkgCompat.FullyManaged()
 
     readwrite(dir |> project_file, notebook |> project_file)
     readwrite(dir |> manifest_file, notebook |> manifest_file)

--- a/test/packages/Basic.jl
+++ b/test/packages/Basic.jl
@@ -5,7 +5,7 @@ using Pluto.Configuration: CompilerOptions
 using Pluto.WorkspaceManager: _merge_notebook_compiler_options
 import Pluto: update_save_run!, update_run!, WorkspaceManager, ClientSession, ServerSession, Notebook, Cell, project_relative_path, SessionActions, load_notebook
 import Pluto.PkgUtils
-import Pluto.PkgCompat
+import Pluto.PkgCompat: PkgCompat, AbstractPackageManagement, FullyManaged, ParentProject, NotManaged
 import Distributed
 
 const pluto_test_registry_spec = Pkg.RegistrySpec(;
@@ -50,7 +50,7 @@ const pluto_test_registry_spec = Pkg.RegistrySpec(;
         @test notebook.cells[7].errored == false
         @test notebook.cells[8].errored == false
 
-        @test notebook.nbpkg_ctx !== nothing
+        @test notebook.nbpkg_ctx isa FullyManaged
         @test notebook.nbpkg_restart_recommended_msg === nothing
         @test notebook.nbpkg_restart_required_msg === nothing
         @test notebook.nbpkg_ctx_instantiated
@@ -79,7 +79,7 @@ const pluto_test_registry_spec = Pkg.RegistrySpec(;
         @test notebook.cells[3].errored == false
         @test notebook.cells[4].errored == false
 
-        @test notebook.nbpkg_ctx !== nothing
+        @test notebook.nbpkg_ctx isa FullyManaged
         @test notebook.nbpkg_restart_recommended_msg === nothing
         @test notebook.nbpkg_restart_required_msg === nothing
 
@@ -97,7 +97,7 @@ const pluto_test_registry_spec = Pkg.RegistrySpec(;
         @test notebook.cells[5].errored == false
         @test notebook.cells[6].errored == false
         
-        @test notebook.nbpkg_ctx !== nothing
+        @test notebook.nbpkg_ctx isa FullyManaged
         @test (
             notebook.nbpkg_restart_recommended_msg !==  nothing || notebook.nbpkg_restart_required_msg !== nothing
         )
@@ -125,7 +125,7 @@ const pluto_test_registry_spec = Pkg.RegistrySpec(;
         @test notebook.cells[7].errored == false
         @test notebook.cells[8].errored == false
 
-        @test notebook.nbpkg_ctx !== nothing
+        @test notebook.nbpkg_ctx isa FullyManaged
         @test notebook.nbpkg_restart_recommended_msg === nothing
         @test notebook.nbpkg_restart_required_msg === nothing
 
@@ -139,7 +139,7 @@ const pluto_test_registry_spec = Pkg.RegistrySpec(;
         update_save_run!(🍭, notebook, notebook.cells[9])
 
         @test notebook.cells[9].errored == false
-        @test notebook.nbpkg_ctx !== nothing
+        @test notebook.nbpkg_ctx isa FullyManaged
         @test notebook.nbpkg_restart_recommended_msg === nothing
         @test notebook.nbpkg_restart_required_msg === nothing
 
@@ -188,7 +188,7 @@ const pluto_test_registry_spec = Pkg.RegistrySpec(;
 
         # removing a stdlib does not require a restart
         @test notebook.cells[9].errored == false
-        @test notebook.nbpkg_ctx !== nothing
+        @test notebook.nbpkg_ctx isa FullyManaged
         @test notebook.nbpkg_restart_recommended_msg === nothing
         @test notebook.nbpkg_restart_required_msg === nothing
 
@@ -200,7 +200,7 @@ const pluto_test_registry_spec = Pkg.RegistrySpec(;
         update_save_run!(🍭, notebook, notebook.cells[7])
 
         @test notebook.cells[7].errored == false
-        @test notebook.nbpkg_ctx !== nothing
+        @test notebook.nbpkg_ctx isa FullyManaged
         @test notebook.nbpkg_restart_recommended_msg !== nothing # recommend restart
         @test notebook.nbpkg_restart_required_msg === nothing
 
@@ -228,7 +228,7 @@ const pluto_test_registry_spec = Pkg.RegistrySpec(;
         @test num_backups_in(dir) == 0
 
 
-        @test notebook.nbpkg_ctx !== nothing
+        @test notebook.nbpkg_ctx isa FullyManaged
         @test notebook.nbpkg_restart_recommended_msg === nothing
         @test notebook.nbpkg_restart_required_msg === nothing
 
@@ -269,7 +269,7 @@ const pluto_test_registry_spec = Pkg.RegistrySpec(;
 
         @test notebook.cells[1].errored == false
         @test notebook.cells[2].errored == false
-        @test notebook.nbpkg_ctx === nothing
+        @test notebook.nbpkg_ctx isa NotManaged
         @test notebook.nbpkg_restart_recommended_msg === nothing
         @test notebook.nbpkg_restart_required_msg === nothing
         @test !has_embedded_pkgfiles(notebook)
@@ -291,7 +291,7 @@ const pluto_test_registry_spec = Pkg.RegistrySpec(;
         setcode(notebook.cells[3], "3")
         update_save_run!(🍭, notebook, notebook.cells[2:3])
         
-        @test notebook.nbpkg_ctx !== nothing
+        @test notebook.nbpkg_ctx isa FullyManaged
         @test notebook.nbpkg_restart_required_msg !== nothing
         @test has_embedded_pkgfiles(notebook)
 
@@ -326,7 +326,7 @@ const pluto_test_registry_spec = Pkg.RegistrySpec(;
         @test length(post_pkg_notebook) > length(pre_pkg_notebook) + 50
         @test has_embedded_pkgfiles(notebook)
 
-        @test notebook.nbpkg_ctx !== nothing
+        @test notebook.nbpkg_ctx isa FullyManaged
         @test notebook.nbpkg_restart_recommended_msg === nothing
         @test notebook.nbpkg_restart_required_msg === nothing
 
@@ -461,7 +461,7 @@ const pluto_test_registry_spec = Pkg.RegistrySpec(;
 
             @test !Pluto.only_versions_differ(notebook.path, original_path)
     
-            @test notebook.nbpkg_ctx !== nothing
+            @test notebook.nbpkg_ctx isa FullyManaged
             @test notebook.nbpkg_restart_recommended_msg === nothing
             @test notebook.nbpkg_restart_required_msg === nothing
 


### PR DESCRIPTION
_this PR does not work yet, but join the discussion below!_

One 'problem' with the new built-in package manager is:

**What to do when your notebook's folder or one of its parents has a Project.toml?**

For example, you could have a project structured like:

```julia
my_project/
    data/
        ...
    notebooks/
        Interesting analysis.jl
        sample Tower of Hanoi.jl
        ...
    Project.toml
    Manifest.toml
    ...
```

and you want all notebooks to use the same package environment.

# Why not one environment per notebook?

Because two notebooks using the same package might produce slightly different results, if they are not created at the same time. This can be very confusing. This is also important when you import code from one notebook in the other.

# What happens in `main`?

Currently, you need to write 
```julia
import Pkg
Pkg.activate(joinpath("..",".."))
```

to disable PlutoPkg and enable your shared environment. This is also recommended in our docs: https://github.com/fonsp/Pluto.jl/wiki/%F0%9F%8E%81-Package-management#pattern-the-shared-environment


# What happens in `0.14.x`?

I only recently discovered that this behaviour is inconsistent (), but:

- If you launched Pluto inside the folder, then that folder will be active for all notebooks, regardless of where they are stored.
- If you launched Pluto outside the folder, then all notebooks will use the global environment, even if they are stored inside the folder.

# Solution 1 - this PR

After this PR, when running the notebooks inside the `notebooks/` folder, Pluto will detect that they are part of a shared project environment, and PlutoPkg will be disabled (no inline GUI). The project will be activated.

When moving a notebook file in/out of a shared folder, PlutoPkg will be disabled/re-enabled. 


This will simulate the [`julia --project=@.` behaviour](https://docs.julialang.org/en/v1/manual/command-line-options/) for all notebooks:

> search through parent directories until a Project.toml or JuliaProject.toml file is found.

This matches the behaviour of Jupyter and VS Code: https://github.com/JuliaLang/Pkg.jl/issues/2640#issuecomment-868965152



# TODO
TODO
- [x] Detect
- [x] Disable
- [x] Use `AbstractPackageManagement` instead of `Union{PkgContext, Nothing}`
- [ ] Set the parent dir as `ACTIVE_PROJECT[]` or sth
- [ ] Show to the user
- [ ] Update docs

TO TEST
- [ ] Notebook in shared dir activates the dir
- [ ] Notebook in shared dir with `Pkg.activate` does not activate the dir
- [ ] Notebook moved out of shared dir becomes pluto-managed
- [ ] Notebook moved into shared dir becomes pluto-managed
- [ ] `notebook_to_js` contents
- [ ] `reset_notebook_environment`

# Bonus ideas:
- Include project data in the .jl file generated using the export button
- Detect change in shared env and recommend restart

