### PR TITLE
Add Support for Browser Choice

### DIFF
--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -19,6 +19,25 @@ function notebook_path_suggestion()
     return joinpath(preferred_dir, "") # so that it ends with / or \
 end
 
+function default_browser()::Function
+    function construct_cmd(url::AbstractString)::Union{Nothing, Cmd}
+        try
+            if Sys.isapple()
+                return `open $url`
+            elseif Sys.iswindows() || detectwsl()
+                return `powershell.exe Start "'$url'"`
+            elseif Sys.islinux()
+                return `xdg-open $url`
+            else
+                return nothing
+            end
+        catch ex
+            return nothing
+        end
+    end
+    return construct_cmd
+end
+
 """
     ServerOptions([; kwargs...])
 
@@ -30,6 +49,7 @@ The HTTP server options. See [`SecurityOptions`](@ref) for additional settings.
 - `host::String = "127.0.0.1"`
 - `port::Union{Nothing,Integer} = nothing`
 - `launch_browser::Bool = true`
+- `browser::Function = default_browser()`
 - `dismiss_update_notification::Bool = false`
 - `show_file_system::Bool = true`
 - `notebook_path_suggestion::String = notebook_path_suggestion()`
@@ -42,6 +62,7 @@ The HTTP server options. See [`SecurityOptions`](@ref) for additional settings.
     host::String = "127.0.0.1"
     port::Union{Nothing,Integer} = nothing
     launch_browser::Bool = true
+    browser::Function = default_browser()
     dismiss_update_notification::Bool = false
     show_file_system::Bool = true
     notebook_path_suggestion::String = notebook_path_suggestion()

--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -49,7 +49,7 @@ The HTTP server options. See [`SecurityOptions`](@ref) for additional settings.
 - `host::String = "127.0.0.1"`
 - `port::Union{Nothing,Integer} = nothing`
 - `launch_browser::Bool = true`
-- `browser::Function = default_browser()`
+- `on_url::Function = default_browser()`
 - `dismiss_update_notification::Bool = false`
 - `show_file_system::Bool = true`
 - `notebook_path_suggestion::String = notebook_path_suggestion()`
@@ -62,7 +62,7 @@ The HTTP server options. See [`SecurityOptions`](@ref) for additional settings.
     host::String = "127.0.0.1"
     port::Union{Nothing,Integer} = nothing
     launch_browser::Bool = true
-    browser::Function = default_browser()
+    on_url::Function = default_browser()
     dismiss_update_notification::Bool = false
     show_file_system::Bool = true
     notebook_path_suggestion::String = notebook_path_suggestion()

--- a/src/webserver/WebServer.jl
+++ b/src/webserver/WebServer.jl
@@ -230,8 +230,10 @@ function run(session::ServerSession)
     address = pretty_address(session, hostIP, port)
 
     println()
-    if session.options.server.launch_browser && open_in_default_browser(address)
-        println("Opening $address in your default browser... ~ have fun!")
+    browser_cmd = session.options.server.browser(address)
+    if session.options.server.launch_browser & !(browser_cmd === nothing)
+        Base.run(browser_cmd)
+        println("Opening $address in your browser... ~ have fun!")
     else
         println("Go to $address in your browser to start writing ~ have fun!")
     end

--- a/src/webserver/WebServer.jl
+++ b/src/webserver/WebServer.jl
@@ -19,25 +19,6 @@ function detectwsl()
     occursin(r"Microsoft|WSL"i, read("/proc/sys/kernel/osrelease", String))
 end
 
-function open_in_default_browser(url::AbstractString)::Bool
-    try
-        if Sys.isapple()
-            Base.run(`open $url`)
-            true
-        elseif Sys.iswindows() || detectwsl()
-            Base.run(`powershell.exe Start "'$url'"`)
-            true
-        elseif Sys.islinux()
-            Base.run(`xdg-open $url`)
-            true
-        else
-            false
-        end
-    catch ex
-        false
-    end
-end
-
 isurl(s::String) = startswith(s, "http://") || startswith(s, "https://")
 
 swallow_exception(f, exception_type::Type{T}) where T =

--- a/src/webserver/WebServer.jl
+++ b/src/webserver/WebServer.jl
@@ -211,7 +211,7 @@ function run(session::ServerSession)
     address = pretty_address(session, hostIP, port)
 
     println()
-    browser_cmd = session.options.server.browser(address)
+    browser_cmd = session.options.server.on_url(address)
     if session.options.server.launch_browser & !(browser_cmd === nothing)
         Base.run(browser_cmd)
         println("Opening $address in your browser... ~ have fun!")


### PR DESCRIPTION
This pull request adds support for editing the `Base.Cmd` that opens Pluto in the browser.

```julia
julia> chromeapp(url) = `/Applications/Google\ Chrome.app/Contents/MacOS/Google\ Chrome --app="$url"`
chromeapp (generic function with 1 method)

julia> using Pluto; Pluto.run(browser=chromeapp)
```