### PR TITLE
Open multiple notebooks at start and without browser

### DIFF
--- a/src/webserver/WebServer.jl
+++ b/src/webserver/WebServer.jl
@@ -74,6 +74,12 @@ end
 
 function run(options::Configuration.Options)
     session = ServerSession(;options=options)
+
+    notebook_to_start = options.server.notebook
+    if notebook_to_start !== nothing
+        SessionActions.open(session, notebook_to_start; compiler_options=options.compiler)
+    end
+
     run(session)
 end
 


### PR DESCRIPTION
#1278 

- [ ] support opening single notebook without need to start browser
- [ ] remove notebook to open from Configuration and add it as kwarg to `Pluto.run()`
- [ ] support opening multiple notebooks