### PR TITLE
Add integrity verification for externally loaded .js and .css

### DIFF
--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -6,6 +6,8 @@ import { has_ctrl_or_cmd_pressed, map_cmd_to_ctrl_on_mac } from "../common/Keybo
 import { PlutoContext } from "../common/PlutoContext.js"
 import { nbpkg_fingerprint, PkgStatusMark, PkgActivateMark, pkg_disablers } from "./PkgStatusMark.js"
 
+import checkScriptIntegrity from '../imports/check-integrity.js'
+await checkScriptIntegrity('https://cdn.jsdelivr.net/gh/codemirror/CodeMirror@5.60.0/src/util/browser.js', 'sha384-JzDVZfAaGyBRnuY46iF2UrycaQug3aRlBiR9B0exCr6GrYrOpdBk0MjqfrVj9SOT');
 //@ts-ignore
 import { mac, chromeOS } from "https://cdn.jsdelivr.net/gh/codemirror/CodeMirror@5.60.0/src/util/browser.js"
 import { detect_deserializer } from "../common/Serialization.js"

--- a/frontend/components/CellOutput.js
+++ b/frontend/components/CellOutput.js
@@ -401,7 +401,10 @@ export let highlight = (code_element, language) => {
                 code_element.classList.add("cm-s-default")
             },
             {
-                path: (mode) => `https://cdn.jsdelivr.net/npm/codemirror@5.60.0/mode/${mode}/${mode}.min.js`,
+                // Commented out since 
+                // 1) not needed since this is manually loaded in editor.html already
+                // 2) it is loaded w/o integrity verification which we don't want
+                // path: (mode) => `https://cdn.jsdelivr.net/npm/codemirror@5.60.0/mode/${mode}/${mode}.min.js`,
             }
         )
     }

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -1,22 +1,5 @@
-/* @import url("https://fonts.googleapis.com/css?family=Roboto+Mono:400,400i,500,700&display=swap&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext"); */
-@import url("https://cdn.jsdelivr.net/npm/@fontsource/roboto-mono@4.4.5/400.css");
-@import url("https://cdn.jsdelivr.net/npm/@fontsource/roboto-mono@4.4.5/400-italic.css");
-@import url("https://cdn.jsdelivr.net/npm/@fontsource/roboto-mono@4.4.5/500.css");
-@import url("https://cdn.jsdelivr.net/npm/@fontsource/roboto-mono@4.4.5/700.css");
-
-/* @import url("https://fonts.googleapis.com/css?family=Alegreya+Sans:400,400i,500,500i,700,700i&display=swap&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese"); */
-@import url("https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@4.4.5/400.css");
-@import url("https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@4.4.5/500.css");
-@import url("https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@4.4.5/700.css");
-@import url("https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@4.4.5/400-italic.css");
-@import url("https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@4.4.5/500-italic.css");
-@import url("https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@4.4.5/700-italic.css");
-
 @import url("juliamono.css");
 @import url("vollkorn.css");
-/* @import url("https://fonts.googleapis.com/css2?family=Lato&display=swap"); */
-@import url("https://cdn.jsdelivr.net/npm/@fontsource/lato@4.4.5/400.css");
-@import url("https://cdn.jsdelivr.net/npm/@fontsource/lato@4.4.5/400-italic.css");
 
 /* VARIABLES */
 

--- a/frontend/editor.html
+++ b/frontend/editor.html
@@ -36,52 +36,52 @@
         integrity="sha384-fTp2I0abasco+1TIQhjTbS/v5ihiE09Kbng/klOF2y/DtZCcieGzK+ierZKtNBBx"
         crossorigin="anonymous" defer></script>
     <script
-        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/lib/codemirror.min.js"
-        integrity="sha384-I8qTInxGuHBUTrKwAEe7f6unZk1duygLU7YXXtvbu+vC2fB/PqW2C2AzCoMHs6LL"
+        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/lib/codemirror.js"
+        integrity="sha384-72EMm5SsNkNkW4SBDaWjGXA1tZ8V6aXmhnoCBeKLC3tC3QdLjqiyKmcvcwwLd9dB"
         crossorigin="anonymous" defer></script>
     <script
-        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/mode/julia/julia.min.js"
-        integrity="sha384-M/B56c5LYW5xoyMZ+7I5uTwn+Omzu8P9fKhc/YQ3ENM7pLOSt1ClLBRcC6iC7AGG"
+        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/mode/julia/julia.js"
+        integrity="sha384-dDyOA8BSiBRH42Ba2yJjj2j5eS8IiLUZfKmb1ZIFQOrthebHHYr2M8RXTeMk7ibZ"
         crossorigin="anonymous" defer></script>
     <script
-        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/mode/loadmode.min.js"
-        integrity="sha384-JlYZNznAJ6kt/dSMcu9XovRQJpbHp+UEerNnQ71mQ0UOuLHuuqfQ+XlGBf/FoQyT"
+        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/mode/loadmode.js"
+        integrity="sha384-7hBw6jBbJ/s4Xx7mLc5Wyn+HzZpkNCqS5aiVPo/UN0TzlK7Wim4Y9Ro5Zzl/AaKt"
         crossorigin="anonymous" defer></script>
     <script
-        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/mode/meta.min.js"
-        integrity="sha384-LQSN6mnF5HuaNhLWCsTD7rPsHBOxXOTbbdfRz+ON9sw5DL2sbbE3Dkg6maYgqlgd"
+        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/mode/meta.js"
+        integrity="sha384-BLItIXOFMTGM9GrO7fY9231R6ArtCltRiN4Lh/IBKJctdrOuCkFOB1PtlNs8ISdL"
         crossorigin="anonymous" defer></script>
     <script
-        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/hint/show-hint.min.js"
-        integrity="sha384-gXh5i/qGQ88Z/N+gwafvmLemUpr3sXJ46iGm8MKniJLFFerIuM0e6PZv54WRPBfb"
+        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/hint/show-hint.js"
+        integrity="sha384-WTj5X80RzO8GQN6UEHne/9THGeveBMzIpTXUfoMSzDvqXQGzh++7ZFK+33hYTU5o"
         crossorigin="anonymous" defer></script>
     <script
-        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/display/placeholder.min.js"
-        integrity="sha384-GyXVU5fiyIzLZ1f5Rzq5tk+U59yNYKVD9o8rMORSCTYmpZDG321uQ/rT41pKH19O"
+        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/display/placeholder.js"
+        integrity="sha384-SO+Sl+6+Z11Y+Ff3CUw+EQ3HwTmgQKvT7pPWV7kspErXiXlr2paY8L6ncstTbM7W"
         crossorigin="anonymous" defer></script>
     <script
-        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/edit/matchbrackets.min.js"
-        integrity="sha384-KN+Sh64Liagu/TFikVZmTuhVs/49Sp6taW1o8+D0xQEVOGI7/EejVQYETgZyay8o"
+        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/edit/matchbrackets.js"
+        integrity="sha384-LZH4xRVaSl6beetMgx4Vk8rEk6TjkniY7bMeaxalEOgDw0OpZupY6E2DNj3FCTXg"
         crossorigin="anonymous" defer></script>
     <script
-        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/runmode/runmode.min.js"
-        integrity="sha384-QuTPRaeZkxOvr+c7n9CUd+KRl1u/KQWO1BUC86SA8TpV1YjKLdwFW5UcHDxP6FvL"
+        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/runmode/runmode.js"
+        integrity="sha384-TlYFNblNR2fkiNJC0nBHHyl3e0I1XHjof9bfCe3c60HnatZeRyD1QiBo9XsXPRDg"
         crossorigin="anonymous" defer></script>
     <script
-        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/comment/comment.min.js"
-        integrity="sha384-o0r7YIj3qWZpYsk7KnivDj6MiC9Jrjk5HmJUTBzyD26O6eJDHBoqsIWRCdFiUPXJ"
+        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/comment/comment.js"
+        integrity="sha384-9DhHgfq6UM4zof0h5vmcK6l4yw+gwDnXMRstHP+QxqU+a8zUrkqTJ/F+ArGE24sa"
         crossorigin="anonymous" defer></script>
     <!-- <script src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/edit/closebrackets.min.js" defer></script> -->
     <!-- <script src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/search/searchcursor.min.js" defer></script> -->
     <link rel="stylesheet" crossorigin="anonymous"
-        href="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/lib/codemirror.min.css"
-        integrity="sha384-p4ahNf4SDO1NqgFLODUmBh63S/DacV24rfO5DvFXJaaMfo5sXiKAgLz1fjlG0JwN"/>
+        href="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/lib/codemirror.css"
+        integrity="sha384-KsbK45E17r4hdzdJB8hf/poBTYi0oDktKdCAyP67Uc9lE9Amf83NF+Vf6VJZ6mRK"/>
     <link rel="stylesheet" crossorigin="anonymous"
-        href="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/hint/show-hint.min.css"
-        integrity="sha384-NSxX+j3ACfCgvo2IAYEsdWkrhZoHLiLgZxcvll+xk3CwS7TpyGAnDZhpTmu6oyJs"/>
+        href="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/hint/show-hint.css"
+        integrity="sha384-ZZbLvEvLoXKrHo3Tkh7W8amMgoHFkDzWe8IAm1ZgxsG5y35H+fJCVMWwr0YBAEGA"/>
     <script
-        src="https://cdn.jsdelivr.net/npm/ansi_up@5.0.1/ansi_up.min.js"
-        integrity="sha384-rLn2uCv2YtVem7eZjB5k0z57HTdm68f/EWc2LOyxjdu8UjOL4KwTFyfBuLvgnx1U"
+        src="https://cdn.jsdelivr.net/npm/ansi_up@5.0.1/ansi_up.js"
+        integrity="sha384-FaT2nmaUscUwv2L8ojBNR8O+t7/1dB7HorWaNou5TX1mHlUeIJ5atMSKYxJqt2wX"
         crossorigin="anonymous" defer></script>
 
     <!-- @import url("https://fonts.googleapis.com/css?family=Roboto+Mono:400,400i,500,700&display=swap&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext"); -->

--- a/frontend/editor.html
+++ b/frontend/editor.html
@@ -23,24 +23,118 @@
         navigator.serviceWorker?.register(document.head.querySelector("link[rel='pluto-sw']").getAttribute("href"), { scope: "./" }).catch(console.warn)
     </script>
 
-    <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.20/lodash.min.js" defer></script>
-    <script src="https://cdn.jsdelivr.net/npm/@observablehq/stdlib@3.3.1/dist/stdlib.js" defer></script>
-    <script src="https://cdn.jsdelivr.net/npm/iframe-resizer@4.2.11/js/iframeResizer.min.js" defer></script>
-    <script src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/lib/codemirror.min.js" defer></script>
-    <script src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/mode/julia/julia.min.js" defer></script>
-    <script src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/mode/loadmode.min.js" defer></script>
-    <script src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/mode/meta.min.js" defer></script>
-    <script src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/hint/show-hint.min.js" defer></script>
-    <script src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/display/placeholder.min.js" defer></script>
-    <script src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/edit/matchbrackets.min.js" defer></script>
-    <script src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/runmode/runmode.min.js" defer></script>
-    <script src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/comment/comment.min.js" defer></script>
+    <script
+        src="https://cdn.jsdelivr.net/npm/lodash@4.17.20/lodash.min.js"
+        integrity="sha384-EnW5v27oxpPV45dNJxtnA2OWfHpDTXuO/EzFl+c1vzZcB1aWeANNH0pFZLJ6Gsbr"
+        crossorigin="anonymous" defer></script>
+    <script
+        src="https://cdn.jsdelivr.net/npm/@observablehq/stdlib@3.3.1/dist/stdlib.js"
+        integrity="sha384-puTWMrPXLOGQnFXpGilbRDiGIrohFMYhoqp9Ot/ZuJpZyZ23hA0ozqEqs75pycVy"
+        crossorigin="anonymous" defer></script>
+    <script
+        src="https://cdn.jsdelivr.net/npm/iframe-resizer@4.2.11/js/iframeResizer.min.js"
+        integrity="sha384-fTp2I0abasco+1TIQhjTbS/v5ihiE09Kbng/klOF2y/DtZCcieGzK+ierZKtNBBx"
+        crossorigin="anonymous" defer></script>
+    <script
+        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/lib/codemirror.min.js"
+        integrity="sha384-I8qTInxGuHBUTrKwAEe7f6unZk1duygLU7YXXtvbu+vC2fB/PqW2C2AzCoMHs6LL"
+        crossorigin="anonymous" defer></script>
+    <script
+        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/mode/julia/julia.min.js"
+        integrity="sha384-M/B56c5LYW5xoyMZ+7I5uTwn+Omzu8P9fKhc/YQ3ENM7pLOSt1ClLBRcC6iC7AGG"
+        crossorigin="anonymous" defer></script>
+    <script
+        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/mode/loadmode.min.js"
+        integrity="sha384-JlYZNznAJ6kt/dSMcu9XovRQJpbHp+UEerNnQ71mQ0UOuLHuuqfQ+XlGBf/FoQyT"
+        crossorigin="anonymous" defer></script>
+    <script
+        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/mode/meta.min.js"
+        integrity="sha384-LQSN6mnF5HuaNhLWCsTD7rPsHBOxXOTbbdfRz+ON9sw5DL2sbbE3Dkg6maYgqlgd"
+        crossorigin="anonymous" defer></script>
+    <script
+        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/hint/show-hint.min.js"
+        integrity="sha384-gXh5i/qGQ88Z/N+gwafvmLemUpr3sXJ46iGm8MKniJLFFerIuM0e6PZv54WRPBfb"
+        crossorigin="anonymous" defer></script>
+    <script
+        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/display/placeholder.min.js"
+        integrity="sha384-GyXVU5fiyIzLZ1f5Rzq5tk+U59yNYKVD9o8rMORSCTYmpZDG321uQ/rT41pKH19O"
+        crossorigin="anonymous" defer></script>
+    <script
+        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/edit/matchbrackets.min.js"
+        integrity="sha384-KN+Sh64Liagu/TFikVZmTuhVs/49Sp6taW1o8+D0xQEVOGI7/EejVQYETgZyay8o"
+        crossorigin="anonymous" defer></script>
+    <script
+        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/runmode/runmode.min.js"
+        integrity="sha384-QuTPRaeZkxOvr+c7n9CUd+KRl1u/KQWO1BUC86SA8TpV1YjKLdwFW5UcHDxP6FvL"
+        crossorigin="anonymous" defer></script>
+    <script
+        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/comment/comment.min.js"
+        integrity="sha384-o0r7YIj3qWZpYsk7KnivDj6MiC9Jrjk5HmJUTBzyD26O6eJDHBoqsIWRCdFiUPXJ"
+        crossorigin="anonymous" defer></script>
     <!-- <script src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/edit/closebrackets.min.js" defer></script> -->
     <!-- <script src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/search/searchcursor.min.js" defer></script> -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/lib/codemirror.min.css" />
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/hint/show-hint.min.css" />
-    <script src="https://cdn.jsdelivr.net/npm/ansi_up@5.0.1/ansi_up.min.js" defer></script>
+    <link rel="stylesheet" crossorigin="anonymous"
+        href="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/lib/codemirror.min.css"
+        integrity="sha384-p4ahNf4SDO1NqgFLODUmBh63S/DacV24rfO5DvFXJaaMfo5sXiKAgLz1fjlG0JwN"/>
+    <link rel="stylesheet" crossorigin="anonymous"
+        href="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/hint/show-hint.min.css"
+        integrity="sha384-NSxX+j3ACfCgvo2IAYEsdWkrhZoHLiLgZxcvll+xk3CwS7TpyGAnDZhpTmu6oyJs"/>
+    <script
+        src="https://cdn.jsdelivr.net/npm/ansi_up@5.0.1/ansi_up.min.js"
+        integrity="sha384-rLn2uCv2YtVem7eZjB5k0z57HTdm68f/EWc2LOyxjdu8UjOL4KwTFyfBuLvgnx1U"
+        crossorigin="anonymous" defer></script>
 
+    <!-- @import url("https://fonts.googleapis.com/css?family=Roboto+Mono:400,400i,500,700&display=swap&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext"); -->
+    <link rel="stylesheet" crossorigin="anonymous"
+        href="https://cdn.jsdelivr.net/npm/@fontsource/roboto-mono@4.4.5/400.css"
+        integrity="sha384-ZpKuP2A+8dwzKEfU1XI4lXgNWHtytDlGkioZbykruMG82txIX9MO5Jsc9VsPQNIb"
+        type="text/css" />
+    <link rel="stylesheet" crossorigin="anonymous"
+        href="https://cdn.jsdelivr.net/npm/@fontsource/roboto-mono@4.4.5/400-italic.css"
+        integrity="sha384-sGams23i6sA+1TM7CqA/LYM02hkGUvAKBuz1G03xiGcE+/8vA9bq5w00GfOGpRqf"
+        type="text/css" />
+    <link rel="stylesheet" crossorigin="anonymous"
+        href="https://cdn.jsdelivr.net/npm/@fontsource/roboto-mono@4.4.5/500.css"
+        integrity="sha384-lBN/G1nOOJVce0NSNmSUfNJfAU6f+D0Q9VbDIChE8ms3OgstVSr00nUAdaIkDsjG"
+        type="text/css" />
+    <link rel="stylesheet" crossorigin="anonymous"
+        href="https://cdn.jsdelivr.net/npm/@fontsource/roboto-mono@4.4.5/700.css"
+        integrity="sha384-d5oqwTd+nrMwk+nl72phHl5JxZNLAnPXO7nEdBqde83qTnkVrT3pmZOQG+5IirnF"
+        type="text/css" />
+    <!-- @import url("https://fonts.googleapis.com/css?family=Alegreya+Sans:400,400i,500,500i,700,700i&display=swap&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese"); -->
+    <link rel="stylesheet" crossorigin="anonymous"
+        href="https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@4.4.5/400.css"
+        integrity="sha384-/6fGKMeg1gVdRo28/BUC41BbaOD+1m0fauTewPxtRvZtybGcX0P+vlXTxtzLKj9/"
+        type="text/css" />
+    <link rel="stylesheet" crossorigin="anonymous"
+        href="https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@4.4.5/500.css"
+        integrity="sha384-ZYLD/1zjvcKlntg6d9WLwReYvagQ+kUNCL+mKp/uucP3KDUtunfq+U5F5sSxR2w9"
+        type="text/css" />
+    <link rel="stylesheet" crossorigin="anonymous"
+        href="https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@4.4.5/700.css"
+        integrity="sha384-Wcn8gnShBrjFCHXpHlvLWnwzyfWVxLNlRNVfcgkY7l2PtyMw/Q52SwYobW7kKQCr"
+        type="text/css" />
+    <link rel="stylesheet" crossorigin="anonymous"
+        href="https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@4.4.5/400-italic.css"
+        integrity="sha384-fD10NvWOYkVn9DGNjA+vBjtLLk1hJbxwt+gl9Mqlu65g3lQb14Yq0IpJKq1r3D0b"
+        type="text/css" />
+    <link rel="stylesheet" crossorigin="anonymous"
+        href="https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@4.4.5/500-italic.css"
+        integrity="sha384-PPUXSzVnT3q8HSk425ZcxZaphfqwwaeR3oCb+LpKwE1ggmoMIAMXNWdSWzEC0V5r"
+        type="text/css" />
+    <link rel="stylesheet" crossorigin="anonymous"
+        href="https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@4.4.5/700-italic.css"
+        integrity="sha384-Ag4Ld5KvO5rrKeRl+abEPEbUPmr2KNBf4cHAIc/NoBbNgnigzn9ZLk3aHd4h+WLh"
+        type="text/css" />
+    <!-- @import url("https://fonts.googleapis.com/css2?family=Lato&display=swap"); -->
+    <link rel="stylesheet"
+        href="https://cdn.jsdelivr.net/npm/@fontsource/lato@4.4.5/400.css"
+        integrity="sha384-kEpd/ybRZe3VGN5WkgfWVJFB4U/089JwQlXl+kzcsOjzKKS9dw7lSsCFzVbZjEin"
+        crossorigin="anonymous" type="text/css" />
+    <link rel="stylesheet"
+        href="https://cdn.jsdelivr.net/npm/@fontsource/lato@4.4.5/400-italic.css"
+        integrity="sha384-6LsNclGATGjM0Si7NnlTJawgX7HB5Qe7mncLV+ven3Y5pz37BJt5pJiJZv0zDgzm"
+        crossorigin="anonymous" type="text/css" />
     <link rel="stylesheet" href="./editor.css" type="text/css" />
     <link rel="stylesheet" href="./hide-ui.css" type="text/css" media="all" data-pluto-file="hide-ui">
     <link rel="stylesheet" href="./binder.css" type="text/css" />
@@ -49,8 +143,14 @@
     <link rel="preload" href="./vollkorn.css" as="style">
 
     <!-- The instant feedback form at the bottom of the page uses Google Firestore to save feedback. -->
-    <script src="https://cdn.jsdelivr.net/npm/firebase@7.13.1/firebase-app.js" defer></script>
-    <script src="https://cdn.jsdelivr.net/npm/firebase@7.13.1/firebase-firestore.js" defer></script>
+    <script
+        src="https://cdn.jsdelivr.net/npm/firebase@7.13.1/firebase-app.js"
+        integrity="sha384-Q4E1UXigqkyjIO3F08vSWRbT0b+oTUY1GwLa5BuoAZkCcxzitThNAKOleFuVCXMG"
+        crossorigin="anonymous" defer></script>
+    <script
+        src="https://cdn.jsdelivr.net/npm/firebase@7.13.1/firebase-firestore.js"
+        integrity="sha384-BSp85R+4PVtghs8vQSnx1VGWATFBYtWiEVyEM96tiZWa0NlY/oDztjaWrBEKFD9K"
+        crossorigin="anonymous" defer></script>
 
     <!-- [automatically generated launch parameters can be inserted here] -->
 
@@ -58,7 +158,10 @@
     <script src="./warn_old_browsers.js"></script>
 
     <script src="./common/SetupMathJax.js"></script>
-    <script type="text/javascript" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3.1.2/es5/tex-svg-full.js" async></script>
+    <script type="text/javascript" id="MathJax-script"
+        src="https://cdn.jsdelivr.net/npm/mathjax@3.1.2/es5/tex-svg-full.js"
+        integrity="sha384-VNy4JkI16R9GCNiJUCI27sGNe0Sw8gv1ichFHkTMKChXK32eYSMtzAkhFunKJ/fb"
+        crossorigin="anonymous" async></script>
 
 </head>
 

--- a/frontend/imports/check-integrity.js
+++ b/frontend/imports/check-integrity.js
@@ -1,24 +1,5 @@
 export default async function checkScriptIntegrity(file, integrity)
 {
-    const iframe = document.createElement('iframe');
-    iframe.src = 'javascript:void(0)';
-    iframe.style.display = 'none';
-    document.body.appendChild(iframe);
-    const doc = iframe.contentDocument;
-    const script = doc.createElement('script');
-    script.type = 'module';
-    script.integrity = integrity;
-    script.crossOrigin = 'anonymous';
-    script.src = file;
-    const promise = new Promise((resolve, reject) => {
-        script.onload = resolve;
-        script.onerror = reject;
-    });
-
-    doc.head.append(script);
-
-    return await promise.then(() => {
-        iframe.parentNode.removeChild(iframe);
-        return true
-    });
+    await fetch(file, {integrity: integrity});
+    return true
 }

--- a/frontend/imports/check-integrity.js
+++ b/frontend/imports/check-integrity.js
@@ -1,0 +1,24 @@
+export default async function checkScriptIntegrity(file, integrity)
+{
+    const iframe = document.createElement('iframe');
+    iframe.src = 'javascript:void(0)';
+    iframe.style.display = 'none';
+    document.body.appendChild(iframe);
+    const doc = iframe.contentDocument;
+    const script = doc.createElement('script');
+    script.type = 'module';
+    script.integrity = integrity;
+    script.crossOrigin = 'anonymous';
+    script.src = file;
+    const promise = new Promise((resolve, reject) => {
+        script.onload = resolve;
+        script.onerror = reject;
+    });
+
+    doc.head.append(script);
+
+    return await promise.then(() => {
+        iframe.parentNode.removeChild(iframe);
+        return true
+    });
+}

--- a/frontend/imports/immer.js
+++ b/frontend/imports/immer.js
@@ -1,3 +1,5 @@
+import checkScriptIntegrity from './check-integrity.js'
+await checkScriptIntegrity('https://cdn.jsdelivr.net/npm/immer@8.0.0/dist/immer.esm.js', 'sha384-GkoRy8Rv07826TejLI7RKpqqGD0sJDHPd2bJaN0Zyx1v/WtnsDO3OBNeB60ffFbB');
 // @ts-nocheck
 import immer, { produceWithPatches, applyPatches, enablePatches, setAutoFreeze } from "https://cdn.jsdelivr.net/npm/immer@8.0.0/dist/immer.esm.js"
 

--- a/frontend/imports/msgpack-lite.js
+++ b/frontend/imports/msgpack-lite.js
@@ -1,3 +1,5 @@
+import checkScriptIntegrity from './check-integrity.js'
+await checkScriptIntegrity('https://cdn.jsdelivr.net/gh/fonsp/msgpack-lite@0.1.27-es.1/dist/msgpack-es.min.mjs', 'sha384-2+BqByYl5TbOcpgy8a6H79MQw2toLuU/l/o3HkpU7WbGnVsYm/9eFrRBMvedrPHN');
 // @ts-ignore
 import msgpack from "https://cdn.jsdelivr.net/gh/fonsp/msgpack-lite@0.1.27-es.1/dist/msgpack-es.min.mjs"
 export default msgpack

--- a/frontend/index.css
+++ b/frontend/index.css
@@ -1,6 +1,3 @@
-@import url("https://cdn.jsdelivr.net/npm/@fontsource/roboto-mono@4.4.5/400.css");
-@import url("https://cdn.jsdelivr.net/npm/@fontsource/roboto-mono@4.4.5/400-italic.css");
-
 @import url("vollkorn.css");
 @import url("juliamono.css");
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -21,14 +21,36 @@
         navigator.serviceWorker?.register(document.head.querySelector("link[rel='pluto-sw']").getAttribute("href"), { scope: "./" }).catch(console.warn)
     </script>
 
-    <script src="https://cdn.jsdelivr.net/npm/@observablehq/stdlib@3.3.1/dist/stdlib.js" defer></script>
-    <script src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/lib/codemirror.min.js" defer></script>
-    <script src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/hint/show-hint.min.js" defer></script>
-    <script src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/display/placeholder.min.js" defer></script>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/lib/codemirror.min.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/hint/show-hint.min.css">
+    <script
+        src="https://cdn.jsdelivr.net/npm/@observablehq/stdlib@3.3.1/dist/stdlib.js"
+        integrity="sha384-puTWMrPXLOGQnFXpGilbRDiGIrohFMYhoqp9Ot/ZuJpZyZ23hA0ozqEqs75pycVy"
+        crossorigin="anonymous" defer></script>
+    <script
+        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/lib/codemirror.min.js"
+        integrity="sha384-I8qTInxGuHBUTrKwAEe7f6unZk1duygLU7YXXtvbu+vC2fB/PqW2C2AzCoMHs6LL"
+        crossorigin="anonymous" defer></script>
+    <script
+        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/hint/show-hint.min.js"
+        integrity="sha384-gXh5i/qGQ88Z/N+gwafvmLemUpr3sXJ46iGm8MKniJLFFerIuM0e6PZv54WRPBfb"
+        crossorigin="anonymous" defer></script>
+    <script
+        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/display/placeholder.min.js"
+        integrity="sha384-GyXVU5fiyIzLZ1f5Rzq5tk+U59yNYKVD9o8rMORSCTYmpZDG321uQ/rT41pKH19O"
+        crossorigin="anonymous" defer></script>
+    <link rel="stylesheet" crossorigin="anonymous"
+        href="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/lib/codemirror.min.css"
+        integrity="sha384-p4ahNf4SDO1NqgFLODUmBh63S/DacV24rfO5DvFXJaaMfo5sXiKAgLz1fjlG0JwN">
+    <link rel="stylesheet" crossorigin="anonymous"
+        href="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/hint/show-hint.min.css"
+        integrity="sha384-NSxX+j3ACfCgvo2IAYEsdWkrhZoHLiLgZxcvll+xk3CwS7TpyGAnDZhpTmu6oyJs">
 
 
+    <link rel="stylesheet" crossorigin="anonymous"
+        href="https://cdn.jsdelivr.net/npm/@fontsource/roboto-mono@4.4.5/400.css"
+        integrity="sha384-ZpKuP2A+8dwzKEfU1XI4lXgNWHtytDlGkioZbykruMG82txIX9MO5Jsc9VsPQNIb">
+    <link rel="stylesheet" crossorigin="anonymous" 
+        href="https://cdn.jsdelivr.net/npm/@fontsource/roboto-mono@4.4.5/400-italic.css"
+        integrity="sha384-sGams23i6sA+1TM7CqA/LYM02hkGUvAKBuz1G03xiGcE+/8vA9bq5w00GfOGpRqf">
     <link rel="stylesheet" href="index.css">
 
     <script src="index.js" type="module" defer></script>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -26,23 +26,23 @@
         integrity="sha384-puTWMrPXLOGQnFXpGilbRDiGIrohFMYhoqp9Ot/ZuJpZyZ23hA0ozqEqs75pycVy"
         crossorigin="anonymous" defer></script>
     <script
-        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/lib/codemirror.min.js"
-        integrity="sha384-I8qTInxGuHBUTrKwAEe7f6unZk1duygLU7YXXtvbu+vC2fB/PqW2C2AzCoMHs6LL"
+        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/lib/codemirror.js"
+        integrity="sha384-72EMm5SsNkNkW4SBDaWjGXA1tZ8V6aXmhnoCBeKLC3tC3QdLjqiyKmcvcwwLd9dB"
         crossorigin="anonymous" defer></script>
     <script
-        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/hint/show-hint.min.js"
-        integrity="sha384-gXh5i/qGQ88Z/N+gwafvmLemUpr3sXJ46iGm8MKniJLFFerIuM0e6PZv54WRPBfb"
+        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/hint/show-hint.js"
+        integrity="sha384-WTj5X80RzO8GQN6UEHne/9THGeveBMzIpTXUfoMSzDvqXQGzh++7ZFK+33hYTU5o"
         crossorigin="anonymous" defer></script>
     <script
-        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/display/placeholder.min.js"
-        integrity="sha384-GyXVU5fiyIzLZ1f5Rzq5tk+U59yNYKVD9o8rMORSCTYmpZDG321uQ/rT41pKH19O"
+        src="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/display/placeholder.js"
+        integrity="sha384-SO+Sl+6+Z11Y+Ff3CUw+EQ3HwTmgQKvT7pPWV7kspErXiXlr2paY8L6ncstTbM7W"
         crossorigin="anonymous" defer></script>
     <link rel="stylesheet" crossorigin="anonymous"
-        href="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/lib/codemirror.min.css"
-        integrity="sha384-p4ahNf4SDO1NqgFLODUmBh63S/DacV24rfO5DvFXJaaMfo5sXiKAgLz1fjlG0JwN">
+        href="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/lib/codemirror.css"
+        integrity="sha384-KsbK45E17r4hdzdJB8hf/poBTYi0oDktKdCAyP67Uc9lE9Amf83NF+Vf6VJZ6mRK"/>
     <link rel="stylesheet" crossorigin="anonymous"
-        href="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/hint/show-hint.min.css"
-        integrity="sha384-NSxX+j3ACfCgvo2IAYEsdWkrhZoHLiLgZxcvll+xk3CwS7TpyGAnDZhpTmu6oyJs">
+        href="https://cdn.jsdelivr.net/npm/codemirror@5.60.0/addon/hint/show-hint.css"
+        integrity="sha384-ZZbLvEvLoXKrHo3Tkh7W8amMgoHFkDzWe8IAm1ZgxsG5y35H+fJCVMWwr0YBAEGA"/>
 
 
     <link rel="stylesheet" crossorigin="anonymous"

--- a/frontend/treeview.css
+++ b/frontend/treeview.css
@@ -1,7 +1,3 @@
-@import url("https://cdn.jsdelivr.net/npm/@fontsource/roboto-mono@4.4.5/400.css");
-@import url("https://cdn.jsdelivr.net/npm/@fontsource/roboto-mono@4.4.5/400-italic.css");
-@import url("https://cdn.jsdelivr.net/npm/@fontsource/roboto-mono@4.4.5/700.css");
-
 @import url("juliamono.css");
 
 /*  */


### PR DESCRIPTION
This is a quick fix for #1315 . Especially for the imports in the js modules, this is only a quick-and-dirty fix using a manually added `checkScriptIntegrity` function.

I guess a proper fix should probably come with #1125 . The correct way would probably be to do proper js and css dependency
management using something like npm. Then one can either bundle everything in Pluto.jl or ship an (integrity-verified) artifact.

Until such a proper fix is merged, I think is is an acceptable short-term solution.