### PR TITLE
Update notebook from file with popup

### DIFF
--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -549,7 +549,6 @@ export class Editor extends Component {
                     {},
                     {notebook_id: this.state.notebook.notebook_id}
                 )
-                console.log('message',message)
                 this.setState({last_update_time: Date.now()})
                 this.setState({notebook_file_newer: false})
                 return
@@ -647,9 +646,6 @@ patch: ${JSON.stringify(
                         handle_log(message, this.state.notebook.path)
                         break
                     case "update_notebook_filetime":
-                        console.log(message)
-                        console.log(this.state.last_update_time)
-                        console.log(this.state.notebook_file_newer)
                         /* Only update the state here if the notebook_file_newer is false */
                         if (message.timestamp - this.state.last_update_time > 1000 && !this.state.notebook_file_newer) {
                             this.setState({notebook_file_newer: true})
@@ -1064,10 +1060,6 @@ patch: ${JSON.stringify(
 
         if (old_state.disable_ui !== this.state.disable_ui) {
             this.on_disable_ui()
-        }
-
-        if (old_state.last_update_time !== this.state.last_update_time) {
-            console.log('last_update_time changed from',old_state.last_update_time,'to',this.state.last_update_time)
         }
     }
 

--- a/frontend/components/Preamble.js
+++ b/frontend/components/Preamble.js
@@ -3,7 +3,7 @@ import { cl } from "../common/ClassTable.js"
 import { PlutoContext } from "../common/PlutoContext.js"
 import { is_mac_keyboard } from "../common/KeyboardShortcuts.js"
 
-export const Preamble = ({ any_code_differs, last_update_time, last_file_modified }) => {
+export const Preamble = ({ any_code_differs, last_update_time, notebook_file_newer }) => {
     let pluto_actions = useContext(PlutoContext)
 
     const [state, set_state] = useState("")
@@ -28,12 +28,12 @@ export const Preamble = ({ any_code_differs, last_update_time, last_file_modifie
     }, [any_code_differs])
 
     useEffect(() => {
-        if (last_file_modified - last_update_time > 1000) {
+        if (notebook_file_newer) {
             set_filestate("ask_to_load")
         } else {
             set_filestate("")
         }
-    },[last_file_modified])
+    },[notebook_file_newer])
 
     return html`<preamble>
         ${state === "ask_to_save"
@@ -66,9 +66,12 @@ export const Preamble = ({ any_code_differs, last_update_time, last_file_modifie
             ? html`
                   <div id="loadnotebook-container" class=${filestate}>
                       <button
-                          onClick=${() => {
-                              set_state("loading")
-                              pluto_actions.reload_from_file()
+                          onClick=${async () => {
+                              console.log("loading")
+                              set_filestate("loading")
+                              await pluto_actions.reload_from_file()
+                              console.log("reloaded")
+                              set_filestate("")
                           }}
                           title="Load notebook from file"
                       >

--- a/frontend/components/Preamble.js
+++ b/frontend/components/Preamble.js
@@ -3,10 +3,11 @@ import { cl } from "../common/ClassTable.js"
 import { PlutoContext } from "../common/PlutoContext.js"
 import { is_mac_keyboard } from "../common/KeyboardShortcuts.js"
 
-export const Preamble = ({ any_code_differs, last_update_time }) => {
+export const Preamble = ({ any_code_differs, last_update_time, last_file_modified }) => {
     let pluto_actions = useContext(PlutoContext)
 
     const [state, set_state] = useState("")
+    const [filestate, set_filestate] = useState("")
     const timeout_ref = useRef(null)
 
     useEffect(() => {
@@ -25,6 +26,14 @@ export const Preamble = ({ any_code_differs, last_update_time }) => {
         }
         return () => clearTimeout(timeout_ref?.current)
     }, [any_code_differs])
+
+    useEffect(() => {
+        if (last_file_modified - last_update_time > 1000) {
+            set_filestate("ask_to_load")
+        } else {
+            set_filestate("")
+        }
+    },[last_file_modified])
 
     return html`<preamble>
         ${state === "ask_to_save"
@@ -53,5 +62,21 @@ export const Preamble = ({ any_code_differs, last_update_time }) => {
                   </div>
               `
             : null}
+            ${filestate === "ask_to_load"
+            ? html`
+                  <div id="loadnotebook-container" class=${filestate}>
+                      <button
+                          onClick=${() => {
+                              set_state("loading")
+                              pluto_actions.reload_from_file()
+                          }}
+                          title="Load notebook from file"
+                      >
+                          <span class="only-on-hover"><b>Notebook file has changed, </b> </span><span>Click to Reload</span>
+                      </button>
+                  </div>
+              `
+            : null
+                }
     </preamble>`
 }

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -746,7 +746,8 @@ main > preamble {
     pointer-events: none;
 }
 
-main > preamble #saveall-container {
+main > preamble #saveall-container,
+main > preamble #loadnotebook-container {
     margin-left: auto;
     pointer-events: all;
     right: min(0px, 700px + 25px - 100vw);
@@ -760,8 +761,13 @@ main > preamble #saveall-container {
     font-size: 0.75rem;
 }
 
+main > preamble #saveall-container + #loadnotebook-container {
+    margin-left: 0;
+}
+
 @media screen and (min-width: calc(700px + 25px + 6px + 500px)) {
-    main > preamble #saveall-container {
+    main > preamble #saveall-container,
+    main > preamble #loadnotebook-container {
         right: -500px;
     }
 }
@@ -798,10 +804,12 @@ main > preamble button {
     position: relative;
 }
 
-#saveall-container .only-on-hover {
+#saveall-container .only-on-hover,
+#loadnotebook-container .only-on-hover {
     display: none;
 }
-#saveall-container:hover .only-on-hover {
+#saveall-container:hover .only-on-hover,
+#loadnotebook-container:hover .only-on-hover {
     display: inline;
 }
 

--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -36,6 +36,7 @@ The HTTP server options. See [`SecurityOptions`](@ref) for additional settings.
 - `disable_writing_notebook_files::Bool = false`
 - `notebook::Union{Nothing,String} = nothing`
 - `simulated_lag::Real=0.0`
+- `auto_reload_notebook_from_file::Bool = false`
 """
 @option mutable struct ServerOptions
     root_url::Union{Nothing,String} = nothing
@@ -49,6 +50,7 @@ The HTTP server options. See [`SecurityOptions`](@ref) for additional settings.
     notebook::Union{Nothing,String} = nothing
     init_with_file_viewer::Bool=false
     simulated_lag::Real=0.0
+    auto_reload_notebook_from_file::Bool = false
 end
 
 """

--- a/src/webserver/Dynamic.jl
+++ b/src/webserver/Dynamic.jl
@@ -544,3 +544,11 @@ responses[:pkg_update] = function response_pkg_update(🙋::ClientRequest)
     update_nbpkg(🙋.session, 🙋.notebook)
     putclientupdates!(🙋.session, 🙋.initiator, UpdateMessage(:🦆, Dict(), nothing, nothing, 🙋.initiator))
 end
+
+responses[:reload_from_file] = function reload_from_file(🙋::ClientRequest)
+    require_notebook(🙋)
+    println("Reloading notebook from file")
+    update_from_file(🙋.session,🙋.notebook)
+    # update_nbpkg(🙋.session, 🙋.notebook)
+    # putclientupdates!(🙋.session, 🙋.initiator, UpdateMessage(:🦆, Dict(), nothing, nothing, 🙋.initiator))
+end

--- a/src/webserver/Dynamic.jl
+++ b/src/webserver/Dynamic.jl
@@ -549,6 +549,5 @@ responses[:reload_from_file] = function reload_from_file(🙋::ClientRequest)
     require_notebook(🙋)
     println("Reloading notebook from file")
     update_from_file(🙋.session,🙋.notebook)
-    # update_nbpkg(🙋.session, 🙋.notebook)
-    # putclientupdates!(🙋.session, 🙋.initiator, UpdateMessage(:🦆, Dict(), nothing, nothing, 🙋.initiator))
+    putclientupdates!(🙋.session, 🙋.initiator, UpdateMessage(:notebook_reloaded, Dict(:update_status => "complete"), 🙋.notebook, nothing, 🙋.initiator))
 end

--- a/src/webserver/SessionActions.jl
+++ b/src/webserver/SessionActions.jl
@@ -88,7 +88,7 @@ function open(session::ServerSession, path::AbstractString; run_async=true, comp
         putplutoupdates!(session, clientupdate_notebook_list(session.notebooks))
     end
 
-    notebook_file_watch(session,nb)
+    notebook_file_watch(session,nb;ask_before_reload = !session.options.server.auto_reload_notebook_from_file)
 
     nb
 end
@@ -143,7 +143,7 @@ function new(session::ServerSession; run_async=true)
         putplutoupdates!(session, clientupdate_notebook_list(session.notebooks))
     end
 
-    notebook_file_watch(session,nb)
+    notebook_file_watch(session,nb;ask_before_reload = !session.options.server.auto_reload_notebook_from_file)
 
     nb
 end

--- a/src/webserver/SessionActions.jl
+++ b/src/webserver/SessionActions.jl
@@ -1,8 +1,8 @@
 module SessionActions
 
-import ..Pluto: ServerSession, Notebook, Cell, emptynotebook, tamepath, new_notebooks_directory, without_pluto_file_extension, numbered_until_new, readwrite, update_save_run!, putnotebookupdates!, putplutoupdates!, load_notebook, clientupdate_notebook_list, WorkspaceManager, @asynclog, UpdateMessage
+import ..Pluto: ServerSession, Notebook, Cell, emptynotebook, tamepath, new_notebooks_directory, without_pluto_file_extension, numbered_until_new, readwrite, update_save_run!, putnotebookupdates!, putplutoupdates!, load_notebook, clientupdate_notebook_list, WorkspaceManager, @asynclog, UpdateMessage, update_from_file
 import FileWatching: watch_file
-import Dates: now, datetime2unix, UTC
+import Dates: now, datetime2unix, UTC, Millisecond
 
 struct NotebookIsRunningException <: Exception
     notebook::Notebook
@@ -19,6 +19,37 @@ end
 function open_url(session::ServerSession, url::AbstractString; kwargs...)
     path = download(url, emptynotebook().path)
     open(session, path; kwargs...)
+end
+
+function notebook_file_watch(session::ServerSession,nb::Notebook;ask_before_reload = false)
+    min_time_between_changes = Millisecond(1000)
+    @asynclog begin
+        watch_file(nb.path)
+        last_timestamp = now(UTC)
+        # The first file change is skipped as that happens when the notebook is created/opened
+        while true
+            watch_file(nb.path)
+            if nb.notebook_id ∉ keys(session.notebooks)
+                # The notebook has been closed, so stop this infinite loop 
+                println("Notebook $(nb.notebook_id) has been closed, exiting the filechange_watch loop")
+                break
+            end
+            # When the file changes, send the timestamp to the editor which assess if the file was modified later than the frontend
+            timestamp = now(UTC)
+            if (timestamp - last_timestamp) > min_time_between_changes
+                println("Valid timing: $(timestamp - last_timestamp)")
+                if ask_before_reload
+                    unix_timestamp = round(Int,datetime2unix(timestamp)*1000) # Keep it in milliseconds as in js
+                    putplutoupdates!(session, UpdateMessage(:update_notebook_filetime, Dict(:timestamp => unix_timestamp), nb, nothing, nothing))
+                else
+                    update_from_file(session,nb)
+                end
+                last_timestamp = timestamp
+            else
+                println("last update was too close to the previous one")
+            end
+        end
+    end
 end
 
 function open(session::ServerSession, path::AbstractString; run_async=true, compiler_options=nothing, as_sample=false)
@@ -57,14 +88,7 @@ function open(session::ServerSession, path::AbstractString; run_async=true, comp
         putplutoupdates!(session, clientupdate_notebook_list(session.notebooks))
     end
 
-    @asynclog while true
-        watch_file(nb.path)
-        # When the file changes, send the message to the editor to update the last change last_run_timestamp
-        timestamp = now(UTC)
-        unix_timestamp = round(Int,datetime2unix(timestamp)*1000) # Keep it in milliseconds as in js
-        println("File updated at $(now()), (UTC Date: $timestamp, unixtime: $unix_timestamp)")
-        putplutoupdates!(session, UpdateMessage(:update_notebook_filetime, Dict(:timestamp => unix_timestamp), nb, nothing, nothing))
-    end
+    notebook_file_watch(session,nb)
 
     nb
 end
@@ -118,6 +142,8 @@ function new(session::ServerSession; run_async=true)
     else
         putplutoupdates!(session, clientupdate_notebook_list(session.notebooks))
     end
+
+    notebook_file_watch(session,nb)
 
     nb
 end

--- a/src/webserver/SessionActions.jl
+++ b/src/webserver/SessionActions.jl
@@ -37,7 +37,6 @@ function notebook_file_watch(session::ServerSession,nb::Notebook;ask_before_relo
             # When the file changes, send the timestamp to the editor which assess if the file was modified later than the frontend
             timestamp = now(UTC)
             if (timestamp - last_timestamp) > min_time_between_changes
-                println("Valid timing: $(timestamp - last_timestamp)")
                 if ask_before_reload
                     unix_timestamp = round(Int,datetime2unix(timestamp)*1000) # Keep it in milliseconds as in js
                     putplutoupdates!(session, UpdateMessage(:update_notebook_filetime, Dict(:timestamp => unix_timestamp), nb, nothing, nothing))


### PR DESCRIPTION
Very much inspired in functionality by https://github.com/fonsp/Pluto.jl/pull/1029, but instead of automatically reloading from file, provide a small disclaimer on the notebook (basically copied in style from the one reminding you to save updates when modifying a notebook) that actually reload the notebook from the file upon click.

I did implement this small modification as sometime I had issues with too many updates from file with the greedy update from https://github.com/fonsp/Pluto.jl/pull/1029.

Here is an example functionality:
![update_from_file_example](https://user-images.githubusercontent.com/12846528/128720536-55c07f90-06fa-4f0b-9e4b-4614197ce1a1.gif)

Let me know if this is something that might be considered interesting or if I will simply just keep it on my fork

Still to do:
- [x] Track notebook file movement from Pluto
- [x] Maybe have a configuration option to always do greedy reload without waiting for feedback
- [ ] Implement throttle for greedy update as suggested by @fonsp
- [ ] Handle cell deletion from file
- [ ] Handle cell addition from file

Edit: Added configuration option to default to greedy reload instead of waiting for confirmation. Can be enabled doing
```julia
Pluto.run(;auto_reload_notebook_from_file=true)
```