### PR TITLE
Precompilation for faster Pluto startup

### DIFF
--- a/src/Pluto.jl
+++ b/src/Pluto.jl
@@ -74,4 +74,6 @@ if get(ENV, "JULIA_PLUTO_SHOW_BANNER", "1") !== "0"
 \n"""
 end
 
+include("./precompile_module.jl")
+
 end

--- a/src/precompile_module.jl
+++ b/src/precompile_module.jl
@@ -1,0 +1,30 @@
+
+let
+    session = ServerSession()
+    session.options.evaluation.workspace_use_distributed = false
+
+    fakeclient = ClientSession(:fake, nothing)
+    session.connected_clients[fakeclient.id] = fakeclient
+
+    notebook = Notebook([
+                Cell("""y = begin
+                    1 + x
+                end"""),
+                Cell("x = 2"),
+                Cell("z = sqrt(y)"),
+                Cell("a = 4x"),
+                Cell("w = z^5"),
+                Cell(""),
+            ])
+    fakeclient.connected_notebook = notebook
+
+    # update_run!(session, notebook, notebook.cells) cannot be used here because it crashes
+    # the following lines are extracted from this function.
+    cells = notebook.cells
+    old = notebook.topology
+    new = notebook.topology = updated_topology(old, notebook, cells) # macros are not yet resolved
+	update_dependency_cache!(notebook)
+
+    # run_reactive!(session, notebook, old, new, cells) # crashes
+
+end


### PR DESCRIPTION
In SciML a trick is used for reducing startup times - essentially it is just including a minimal example inside the source code module itself. This example is then executed in precompilation stage and the functions it requires are then already compiled when the user need them. 

See
https://discourse.julialang.org/t/22-seconds-to-3-and-now-more-lets-fix-all-of-the-differentialequations-jl-universe-compile-times/66313

and 

https://github.com/SciML/OrdinaryDiffEq.jl/blob/v5.61.1/src/OrdinaryDiffEq.jl#L175-L193

For measuring startup performance, I used the following script:

```
using Pluto

test_notebook = "../sample/Getting started.jl"

@time let
    session = Pluto.ServerSession()

    fakeclient = Pluto.ClientSession(:fake, nothing)
    session.connected_clients[fakeclient.id] = fakeclient

    Pluto.SessionActions.open(session, test_notebook)

    notebook = first(values(session.notebooks))
    Pluto.update_run!(session, notebook, notebook.cells)
    Pluto.SessionActions.shutdown(session, notebook)
end

@time let # cross check - everything already compiled here
    session = Pluto.ServerSession()

    fakeclient = Pluto.ClientSession(:fake, nothing)
    session.connected_clients[fakeclient.id] = fakeclient

    Pluto.SessionActions.open(session, test_notebook)

    notebook = first(values(session.notebooks))
    Pluto.update_run!(session, notebook, notebook.cells)
    Pluto.SessionActions.shutdown(session, notebook)
end
```

This PR increases Pluto startup time by roughly a factor of 2, measured by the script above. And also the "standard" Pluto startup feels significantly faster.

Pretty sure more could be done here by including more Pluto functionality for precompilation.