### PR TITLE
Reference outer constructor definition issue

### DIFF
--- a/src/analysis/ExpressionExplorer.jl
+++ b/src/analysis/ExpressionExplorer.jl
@@ -430,6 +430,8 @@ function explore!(ex::Expr, scopestate::ScopeState)::SymbolsState
         globalscopestate.inglobalscope = true
 
         # we register struct definitions as both a variable and a function. This is because deleting a struct is trickier than just deleting its methods.
+	# Due to this, outer constructors have to be defined in the same cell where the struct is defined.
+	# See https://github.com/fonsp/Pluto.jl/issues/732 for more details
         inner_symstate = explore!(equiv_func, globalscopestate)
 
         structname = first(keys(inner_symstate.funcdefs)).name |> join_funcname_parts


### PR DESCRIPTION
As disccused on zulip [here](https://julialang.zulipchat.com/#narrow/stream/257776-Pluto.2Ejl-development/topic/struct.20outer.20constructor.20in.20separate.20cell/near/251200448), adding a comment to ExpressionExplorer.jl to reference the issue about error when trying to define struct outer constructors outside of the struct definition cell