### PR TITLE
handle Dict containers in `sanitize_expr`

### DIFF
--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -143,12 +143,16 @@ function sanitize_expr(tuple::Tuple)
     Expr(:tuple, sanitize_expr.(tuple)...)
 end
 
-function sanitize_expr(mod::Module)
-    fullname(mod) |> wrap_dot
+function sanitize_expr(dict::Dict)
+    Expr(:call, :Dict, (sanitize_expr(pair) for pair in dict)...)
 end
 
 function sanitize_expr(pair::Pair)
-    sanitize_expr(pair.first) => sanitize_expr(pair.second)
+    Expr(:call, :(=>), sanitize_expr(pair.first), sanitize_expr(pair.second))
+end
+
+function sanitize_expr(mod::Module)
+    fullname(mod) |> wrap_dot
 end
 
 # An instanciation of a struct as part of an Expr


### PR DESCRIPTION
A dictionary with custom structs cannot be serialized between process if the receiving process does not have the package with the struct loaded. The `PlutoRunner.sanitize_expr(ex::Expr)` function removes instances of custom types from the expression and turns them into a static version with symbols. Example:

```julia
julia> import Pluto;

julia> se = Pluto.PlutoRunner.sanitize_expr
sanitize_expr (generic function with 12 methods)

julia> struct A; end; se(Expr(:(=), :a, Dict(1 => A()))) |> dump # an instance of A
Expr
  head: Symbol =
  args: Array{Any}((2,))
    1: Symbol a
    2: Expr
      head: Symbol call
      args: Array{Any}((2,))
        1: Symbol Dict
        2: Expr
          head: Symbol call
          args: Array{Any}((3,))
            1: Symbol =>
            2: Int64 1
            3: Symbol A # the symbol A
```
Most containers from the standard library should be handled and converted correctly.