### PR TITLE
Some experimental components to run dashboards

### DIFF
--- a/frontend/components/CellOutput.js
+++ b/frontend/components/CellOutput.js
@@ -1,7 +1,7 @@
 import { html, Component, useRef, useLayoutEffect, useContext, useEffect, useMemo } from "../imports/Preact.js"
 
 import { ErrorMessage } from "./ErrorMessage.js"
-import { TreeView, TableView } from "./TreeView.js"
+import { TreeView, TableView, DivElement } from "./TreeView.js"
 
 import { add_bonds_listener, set_bound_elements_to_their_value } from "../common/Bond.js"
 import { cl } from "../common/ClassTable.js"
@@ -12,6 +12,7 @@ import register from "../imports/PreactCustomElement.js"
 
 import { EditorState, EditorView, julia_andrey, defaultHighlightStyle } from "../imports/CodemirrorPlutoSetup.js"
 import { pluto_syntax_colors } from "./CellInput.js"
+import { useState } from "../imports/Preact.js"
 
 export class CellOutput extends Component {
     constructor() {
@@ -138,7 +139,13 @@ export const OutputBody = ({ mime, body, cell_id, persist_js_state = false, last
         case "application/vnd.pluto.stacktrace+object":
             return html`<div><${ErrorMessage} cell_id=${cell_id} ...${body} /></div>`
             break
-
+            body.cell_id
+        case "application/vnd.pluto.divelement+object":
+            return DivElement({ cell_id, ...body })
+            break
+        case "application/vnd.pluto.celloutput+object":
+            return EmbeddedCellOutput({ cell_id: body.cell_id })
+            break
         case "text/plain":
             if (body) {
                 return html`<div>
@@ -152,6 +159,37 @@ export const OutputBody = ({ mime, body, cell_id, persist_js_state = false, last
             return html``
             break
     }
+}
+
+export let EmbeddedCellOutput = ({ cell_id }) => {
+    let [captured_editor_state, set_captured_editor_state] = useState(null)
+
+    useEffect(() => {
+        let still_running = true
+        const step = () => {
+            //@ts-ignore
+            const new_state = window.editor_state
+            if (captured_editor_state !== new_state) {
+                set_captured_editor_state(new_state)
+            }
+
+            if (still_running) {
+                requestAnimationFrame(step)
+            }
+        }
+        requestAnimationFrame(step)
+
+        return () => {
+            still_running = false
+        }
+    })
+
+    if (captured_editor_state == null) {
+        return null
+    }
+
+    let output = captured_editor_state?.notebook?.cell_results[cell_id]?.output
+    return html` <${CellOutput} ...${output} cell_id=${cell_id}> </${CellOutput}> `
 }
 
 register(OutputBody, "pluto-display", ["mime", "body", "cell_id", "persist_js_state", "last_run_timestamp"])

--- a/frontend/components/TreeView.js
+++ b/frontend/components/TreeView.js
@@ -1,6 +1,6 @@
 import { html, useRef, useState, useContext } from "../imports/Preact.js"
 
-import { PlutoImage, RawHTMLContainer } from "./CellOutput.js"
+import { PlutoImage, RawHTMLContainer, EmbeddedCellOutput } from "./CellOutput.js"
 import { PlutoContext } from "../common/PlutoContext.js"
 
 // this is different from OutputBody because:
@@ -27,6 +27,12 @@ const SimpleOutputBody = ({ mime, body, cell_id, persist_js_state }) => {
             break
         case "application/vnd.pluto.table+object":
             return html` <${TableView} cell_id=${cell_id} body=${body} persist_js_state=${persist_js_state} />`
+            break
+        case "application/vnd.pluto.divelement+object":
+            return DivElement({ cell_id, ...body })
+            break
+        case "application/vnd.pluto.celloutput+object":
+            return EmbeddedCellOutput({ cell_id: body.cell_id })
             break
         case "text/plain":
             return html`<pre class="no-block">${body}</pre>`
@@ -163,4 +169,10 @@ export const TableView = ({ mime, body, cell_id, persist_js_state }) => {
     return html`<table class="pluto-table" ref=${node_ref}>
         ${thead}${tbody}
     </table>`
+}
+
+export let DivElement = ({ cell_id, style, children }) => {
+    const mimepair_output = (pair) => html`<${SimpleOutputBody} cell_id=${cell_id} mime=${pair[1]} body=${pair[0]} persist_js_state=${false} />`
+
+    return html`<div style=${style}>${children.map(mimepair_output)}</div>`
 }


### PR DESCRIPTION
Can we use Pluto as a framework to build dashboards? (Yes!) We already have a great environment for writing your model, for making it interactive and for visualizing results. The 'only' thing that's missing is layout: instead of showing all these elements linearly, you want to combine them into a single compact dashboard.

You can use `@htl` from HypertextLiteral to put multiple Pluto outputs in one cell, and with CSS flex and CSS grid, you can make any dashboard layout that your heart desires. I also added [`embed_display(x)` to have Pluto's object viewer as a web component](https://github.com/fonsp/Pluto.jl/pull/1126). This means that you can embed images, interactive arrays, tables, etc, inside `@htl` expressions. Cool!

```julia
data = rand(20)

coolplot = plot(data)

@htl("""
<div style="display: flex; flex-direction: row;">
	$(embed_display(data))
	$(embed_display(coolplot))
</div>
""")
```

## Still missing: partial DOM updates
One problem arises when embedding bonds together with dependent variables:
```julia
myslider = @bind x Slider(1:20)

data = rand(x)

coolplot = plot(data)

@htl("""
<div style="display: flex; flex-direction: row;">
	$(embed_display(myslider))
	$(embed_display(data))
	$(embed_display(coolplot))
</div>
""")
```

Now, whenever you move the slider, `data` and `coolplot` will re-run, causing the final cell to re-run, which will re-render `myslider`. This causes the DOM element to lose focus, and you can't click-and-drag. Oops!

My initial solution was to use `this` (see JavaScript sample notebook) inside the `embed_display` web component to persist its last displayed element, instead of re-rendering it, when the HTML data did not change. This _almost_ works, except `embed_display` now needs a way to identify itself. From which previous embed will it take the output? (We have some ideas but let's skip over this for now.)

### Solution in this PR

There is a new special output object, a `DivElement`:
```julia
struct DivElement
	children::Vector
	style::String
end
```

If a cell outputs a `DivElement`, it won't render it as HTML in the julia process, but send the "div element data" to the frontend, which constructs it using a simple react component. If the cell re-renders, and only one of its children updates, then [Pluto's diff-based state management](https://github.com/fonsp/Pluto.jl/blob/40f9a9263984bf49faef9d33490b48296e3f0027/src/webserver/Dynamic.jl#L26-L81) will make sure that only the data for that child changes, and react will only update the HTML contents of that child, leaving the parent div and siblings as-is, solving the problem! `DivElement`s can be nested and can have user-defined styles, so you can use it to create any layout.

Our example becomes:

```julia
myslider = @bind x Slider(1:20)

data = rand(x)

coolplot = plot(data)

PlutoRunner.DivElement(
	children=[
		myslider
		data
		coolplot
	],
	style="display: flex; flex-direction: row;",
)
```

And everything works as expected!


## Still missing: intermediate DOM updates

Let's say that we have the same app as before, but our code takes a long time to execute:
```julia
myslider = @bind x Slider(1:20)

data = sleep(1); rand(x)

coolplot = sleep(5); plot(data)

PlutoRunner.DivElement(
	children=[
		myslider
		data
		coolplot
	],
	style="display: flex; flex-direction: row;",
)
```

In this case, moving the slider will re-run `data`, then re-run `coolplot`, and then re-run the last cell. This means that **you have to wait 6 seconds to see anything**. Ideally, we would see the new data after 1 second, and the new plot after 6 seconds. This does not play nicely with our reactivity model (it can't trigger re-running a cell multiple times).



https://user-images.githubusercontent.com/6933510/134893312-55e8bc77-781c-459f-a331-6a22abf18ff0.mov


### Solution in this PR

There is a new special output object, a `CellOutputMirror`:
```julia
struct CellOutputMirror
	cell_id::UUID
end
```

Wherever this `CellOutputMirror` is displayed, it will magically show a mirror of the output of another cell. It refreshes automatically, without having to re-run.

The example becomes:

Let's say that we have the same app as before, but our code takes a long time to execute:
```julia
myslider = @bind x Slider(1:20)

data = sleep(1); rand(x)

coolplot = sleep(5); plot(data)

PlutoRunner.DivElement(
	children=[
		myslider
		CellOutputMirror(UUID("ac9b833-ac3839a-a234234-23434")) # id of cell that defines `data`
		CellOutputMirror(UUID("5323434-ac9b833-ac3839a-a2334")) # id of cell that defines `coolplot`
	],
	style="display: flex; flex-direction: row;",
)
```

Now, the last cell does not re-run when `data` or `coolplot` changes (because it does depend on those vars). Instead, it contains magical mirror that update on their own.

https://user-images.githubusercontent.com/6933510/134893246-7b3865a9-4df6-4375-8786-e2183da28ddc.mov



