### PR TITLE
Correctly handle textarea paste in CM6

### DIFF
--- a/frontend/common/KeyboardShortcuts.js
+++ b/frontend/common/KeyboardShortcuts.js
@@ -21,6 +21,6 @@ export let map_cmd_to_ctrl_on_mac = (keymap) => {
 }
 
 export let in_textarea_or_input = () => {
-    const { tagName } = document.activeElement
-    return tagName === "INPUT" || tagName === "TEXTAREA"
+    const { tagName, classList } = document.activeElement
+    return tagName === "INPUT" || tagName === "TEXTAREA" || classList.contains('cm-content')
 }


### PR DESCRIPTION
The new CM6 document structure does not seem to put the text into an element with `"TEXTAREA"` as tag.
Now it seems that instead the DOM element where the text is inserted is a simple DIV with class `cm-content`.

This seems to fix https://github.com/fonsp/Pluto.jl/issues/1534.
Paste from inside cells already seemed to skip call to this function: https://github.com/fonsp/Pluto.jl/blob/ac67ba8bd40d91bc101e350c6934791b94b1cb45/frontend/common/Serialization.js#L56-L61
So there was no problem there but just on the FilePicker