### PR TITLE
Add class to auto-generated cell docs markdown (CM6)

### DIFF
--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -704,7 +704,7 @@ end
 function format_output(binding::Base.Docs.Binding; context=default_iocontext)
     try
         ("""
-        <div style="margin: .5em; padding: 1em; background: #8383830a; border-radius: 1em;">
+        <div class="pluto-docs-binding" style="margin: .5em; padding: 1em; background: #8383830a; border-radius: 1em;">
         <span style="
             display: inline-block;
             transform: translate(-19px, -16px);


### PR DESCRIPTION
The new auto docs generation from cells defining documented functions is quite neat!
One issue with that is that it may conflicts with the `TableOfContents` from PlutoUI if you have markdown headings inside your documentations.

This is probably a niche problem but in my example use case I define a bunch of functions and document the arguments  always after a `# Arguments` heading in the docstring.

This is what happens when I use the table of contents:
![image](https://user-images.githubusercontent.com/12846528/135982593-ae34036a-365c-49f1-814c-25ef8b390a91.png)

Adding a class to the div containing the markdown allows to identify it better in the front-end and in this case, allow to exclude the headings inside this for the tableofcontents