### PR TITLE
Isolated cell view

### DIFF
--- a/frontend/components/Cell.js
+++ b/frontend/components/Cell.js
@@ -7,6 +7,23 @@ import { cl } from "../common/ClassTable.js"
 import { useDropHandler } from "./useDropHandler.js"
 import { PlutoContext } from "../common/PlutoContext.js"
 
+const useCellApi = (node_ref, published_objects, pluto_actions) => {
+    const [cell_api_ready, set_cell_api_ready] = useState(false)
+    const published_objects_ref = useRef(published_objects)
+    published_objects_ref.current = published_objects
+    
+    useLayoutEffect(() => {
+        Object.assign(node_ref.current, {
+            getPublishedObject: (id) => published_objects_ref.current[id],
+            _internal_pluto_actions: pluto_actions,
+        })
+
+        set_cell_api_ready(true)
+    })
+
+    return cell_api_ready
+}
+
 /**
  * @param {{
  *  cell_result: import("./Editor.js").CellResultData,
@@ -80,23 +97,13 @@ export const Cell = ({
 
     const node_ref = useRef(null)
 
-    const [cell_api_ready, set_cell_api_ready] = useState(false)
-    const published_objects_ref = useRef(published_objects)
-    published_objects_ref.current = published_objects
     const disable_input_ref = useRef(disable_input)
     disable_input_ref.current = disable_input
     const should_set_waiting_to_run_ref = useRef(true)
     should_set_waiting_to_run_ref.current = !running_disabled && !depends_on_disabled_cells
     const set_waiting_to_run_smart = (x) => set_waiting_to_run(x && should_set_waiting_to_run_ref.current)
 
-    useLayoutEffect(() => {
-        Object.assign(node_ref.current, {
-            getPublishedObject: (id) => published_objects_ref.current[id],
-            _internal_pluto_actions: pluto_actions,
-        })
-
-        set_cell_api_ready(true)
-    })
+    const cell_api_ready = useCellApi(node_ref, published_objects, pluto_actions)
 
     return html`
         <pluto-cell
@@ -214,6 +221,27 @@ export const Cell = ({
             >
                 <span></span>
             </button>
+        </pluto-cell>
+    `
+}
+
+
+export const IsolatedCell = ({
+    cell_id,
+    cell_results: { output, published_objects },
+    hidden
+}) => {
+    const node_ref = useRef(null)
+    let pluto_actions = useContext(PlutoContext)
+    const cell_api_ready = useCellApi(node_ref, published_objects, pluto_actions)
+
+    return html`
+        <pluto-cell
+            ref=${node_ref}
+            id=${cell_id}
+            class=${hidden ? 'hidden-cell' : 'isolated-cell'}
+        >
+            ${cell_api_ready ? html`<${CellOutput} ...${output} cell_id=${cell_id} />` : html``}
         </pluto-cell>
     `
 }

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -172,7 +172,7 @@ const launch_params = {
     //@ts-ignore
     disable_ui: !!(url_params.get("disable_ui") ?? window.pluto_disable_ui),
     //@ts-ignore
-    isolated_cell_id: url_params.get("isolated_cell_id") ?? window.isolated_cell_id,
+    isolated_cell_ids: url_params.getAll("isolated_cell_id") ?? window.isolated_cell_id,
     //@ts-ignore
     binder_url: url_params.get("binder_url") ?? window.pluto_binder_url,
     //@ts-ignore
@@ -1055,23 +1055,21 @@ patch: ${JSON.stringify(
         const status = this.cached_status ?? statusmap(this.state)
         const statusval = first_true_key(status)
 
-        if(launch_params.isolated_cell_id) {
-            if(!this.state.notebook.cell_results[launch_params.isolated_cell_id]) return html``
-
+        if(launch_params.isolated_cell_ids.length > 0) {
             return html`
-            <${PlutoContext.Provider} value=${this.actions}>
-                <${PlutoBondsContext.Provider} value=${this.state.notebook.bonds}>
-                    <${PlutoJSInitializingContext.Provider} value=${this.js_init_set}>
-                        <div style="width: 100%">
-                            ${this.state.notebook.cell_order.map((cell_id, i) => html`
-                                <div class=${cell_id === launch_params.isolated_cell_id ? 'isolated-cell' : 'hidden-cell'}>
-                                    <${CellOutput} ...${this.state.notebook.cell_results[cell_id].output}/>
-                                </div>
-                            `)}
-                        </div>
-                    </${PlutoJSInitializingContext.Provider}>
-                </${PlutoBondsContext.Provider}>
-            </${PlutoContext.Provider}>
+                <${PlutoContext.Provider} value=${this.actions}>
+                    <${PlutoBondsContext.Provider} value=${this.state.notebook.bonds}>
+                        <${PlutoJSInitializingContext.Provider} value=${this.js_init_set}>
+                            <div style="width: 100%">
+                                ${this.state.notebook.cell_order.map((cell_id, i) => html`
+                                    <div class=${launch_params.isolated_cell_ids.includes(cell_id) ? 'isolated-cell' : 'hidden-cell'}>
+                                        <${CellOutput} ...${this.state.notebook.cell_results[cell_id].output}/>
+                                    </div>
+                                `)}
+                            </div>
+                        </${PlutoJSInitializingContext.Provider}>
+                    </${PlutoBondsContext.Provider}>
+                </${PlutoContext.Provider}>
             `
         }
 

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -1059,13 +1059,19 @@ patch: ${JSON.stringify(
             if(!this.state.notebook.cell_results[launch_params.isolated_cell_id]) return html``
 
             return html`
-                <div style="width: 100%">
-                    ${this.state.notebook.cell_order.map((cell_id, i) => html`
-                        <div class=${cell_id === launch_params.isolated_cell_id ? 'isolated-cell' : 'hidden-cell'}>
-                            <${CellOutput} ...${this.state.notebook.cell_results[cell_id].output}/>
+            <${PlutoContext.Provider} value=${this.actions}>
+                <${PlutoBondsContext.Provider} value=${this.state.notebook.bonds}>
+                    <${PlutoJSInitializingContext.Provider} value=${this.js_init_set}>
+                        <div style="width: 100%">
+                            ${this.state.notebook.cell_order.map((cell_id, i) => html`
+                                <div class=${cell_id === launch_params.isolated_cell_id ? 'isolated-cell' : 'hidden-cell'}>
+                                    <${CellOutput} ...${this.state.notebook.cell_results[cell_id].output}/>
+                                </div>
+                            `)}
                         </div>
-                    `)}
-                </div>
+                    </${PlutoJSInitializingContext.Provider}>
+                </${PlutoBondsContext.Provider}>
+            </${PlutoContext.Provider}>
             `
         }
 

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -1068,7 +1068,7 @@ patch: ${JSON.stringify(
                         <${PlutoJSInitializingContext.Provider} value=${this.js_init_set}>
                             <div style="width: 100%">
                                 ${this.state.notebook.cell_order.map((cell_id, i) => html`
-                                    <div class=${launch_params.isolated_cell_ids.includes(cell_id) ? 'isolated-cell' : 'hidden-cell'}>
+                                    <div id=${cell_id} class=${launch_params.isolated_cell_ids.includes(cell_id) ? 'isolated-cell' : 'hidden-cell'}>
                                         <${CellOutput} ...${this.state.notebook.cell_results[cell_id].output}/>
                                     </div>
                                 `)}

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -29,6 +29,7 @@ import { start_binder, BinderPhase, count_stat } from "../common/Binder.js"
 import { read_Uint8Array_with_progress, FetchProgress } from "./FetchProgress.js"
 import { BinderButton } from "./BinderButton.js"
 import { slider_server_actions, nothing_actions } from "../common/SliderServerClient.js"
+import { CellOutput } from "./CellOutput.js"
 
 const default_path = "..."
 const DEBUG_DIFFING = false
@@ -170,6 +171,8 @@ const launch_params = {
     notebookfile: url_params.get("notebookfile") ?? window.pluto_notebookfile,
     //@ts-ignore
     disable_ui: !!(url_params.get("disable_ui") ?? window.pluto_disable_ui),
+    //@ts-ignore
+    isolated_cell_id: url_params.get("isolated_cell_id") ?? window.isolated_cell_id,
     //@ts-ignore
     binder_url: url_params.get("binder_url") ?? window.pluto_binder_url,
     //@ts-ignore
@@ -1051,6 +1054,20 @@ patch: ${JSON.stringify(
 
         const status = this.cached_status ?? statusmap(this.state)
         const statusval = first_true_key(status)
+
+        if(launch_params.isolated_cell_id) {
+            if(!this.state.notebook.cell_results[launch_params.isolated_cell_id]) return html``
+
+            return html`
+                <div style="width: 100%">
+                    ${this.state.notebook.cell_order.map((cell_id, i) => html`
+                        <div style="display: ${cell_id === launch_params.isolated_cell_id ? 'block' : 'none'}">
+                            <${CellOutput} ...${this.state.notebook.cell_results[cell_id].output}/>
+                        </div>
+                    `)}
+                </div>
+            `
+        }
 
         const restart_button = (text) => html`<a
             href="#"

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -29,8 +29,8 @@ import { start_binder, BinderPhase, count_stat } from "../common/Binder.js"
 import { read_Uint8Array_with_progress, FetchProgress } from "./FetchProgress.js"
 import { BinderButton } from "./BinderButton.js"
 import { slider_server_actions, nothing_actions } from "../common/SliderServerClient.js"
-import { CellOutput } from "./CellOutput.js"
 import { ProgressBar } from "./ProgressBar.js"
+import { IsolatedCell } from "./Cell.js"
 
 const default_path = "..."
 const DEBUG_DIFFING = false
@@ -1068,9 +1068,11 @@ patch: ${JSON.stringify(
                         <${PlutoJSInitializingContext.Provider} value=${this.js_init_set}>
                             <div style="width: 100%">
                                 ${this.state.notebook.cell_order.map((cell_id, i) => html`
-                                    <div id=${cell_id} class=${launch_params.isolated_cell_ids.includes(cell_id) ? 'isolated-cell' : 'hidden-cell'}>
-                                        <${CellOutput} ...${this.state.notebook.cell_results[cell_id].output}/>
-                                    </div>
+                                    <${IsolatedCell}
+                                        cell_id=${cell_id}
+                                        cell_results=${this.state.notebook.cell_results[cell_id]}
+                                        hidden=${!launch_params.isolated_cell_ids.includes(cell_id)}
+                                    />
                                 `)}
                             </div>
                         </${PlutoJSInitializingContext.Provider}>

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -1061,7 +1061,7 @@ patch: ${JSON.stringify(
             return html`
                 <div style="width: 100%">
                     ${this.state.notebook.cell_order.map((cell_id, i) => html`
-                        <div style="display: ${cell_id === launch_params.isolated_cell_id ? 'block' : 'none'}">
+                        <div class=${cell_id === launch_params.isolated_cell_id ? 'isolated-cell' : 'hidden-cell'}>
                             <${CellOutput} ...${this.state.notebook.cell_results[cell_id].output}/>
                         </div>
                     `)}

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -908,6 +908,15 @@ pluto-output:not(.rich_output) > div > pre {
 pluto-display > div {
     display: inline-block;
 }
+
+/* isolated cell view */
+.isolated-cell > pluto-output {
+    padding: 0;
+}
+.hidden-cell {
+    display: none;
+}
+
 /* SELECTION */
 
 pluto-cell.selected {


### PR DESCRIPTION
Isolates a single cell output to occupy the entire page. Useful for building web applications / dashboards with Pluto