### PR TITLE
Add rectangularSelection to list of extensions

### DIFF
--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -30,6 +30,7 @@ import {
     indentOnInput,
     defaultHighlightStyle,
     closeBrackets,
+    rectangularSelection,
     highlightSelectionMatches,
     closeBracketsKeymap,
     searchKeymap,
@@ -357,6 +358,7 @@ export const CellInput = ({
                         return [{ closeBrackets: { brackets: ["(", "[", "{", "'", '"', '"""'] } }]
                     }),
                     closeBrackets(),
+                    rectangularSelection(),
                     highlightSelectionMatches(),
                     bracketMatching(),
                     docs_updater,


### PR DESCRIPTION
This PR enables rectangular selection in CM6 code inputs, addressing #1540.