### PR TITLE
Separate notebook boot env

### DIFF
--- a/src/runner/Loader.jl
+++ b/src/runner/Loader.jl
@@ -7,11 +7,11 @@ popfirst!(LOAD_PATH)
 local my_dir = @__DIR__
 local pluto_dir = joinpath(my_dir, "..", "..")
 
-local runner_env_dir = mkpath(joinpath(Pkg.envdir(Pkg.depots()[1]), "__pluto_boot_" * string(VERSION)))
+local runner_env_dir = mkpath(joinpath(Pkg.envdir(Pkg.depots()[1]), "__pluto_boot_v2_" * string(VERSION)))
 local new_ptoml_path = joinpath(runner_env_dir, "Project.toml")
 
-local ptoml_contents = read(joinpath(pluto_dir, "Project.toml"), String)
-write(new_ptoml_path, ptoml_contents[findfirst("[deps]", ptoml_contents)[1]:end])
+local ptoml_contents = read(joinpath(my_dir, "NotebookProcessProject.toml"), String)
+write(new_ptoml_path, ptoml_contents)
 
 local pkg_ctx = Pkg.Types.Context(env=Pkg.Types.EnvCache(new_ptoml_path))
 

--- a/src/runner/NotebookProcessProject.toml
+++ b/src/runner/NotebookProcessProject.toml
@@ -1,0 +1,15 @@
+[deps]
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+FuzzyCompletions = "fb4132e2-a121-4a70-b8a1-d5b831dcdcc2"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[compat]
+FuzzyCompletions = "0.3,0.4"

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -4,6 +4,7 @@
 # These baby processes don't import Pluto, they only import this module. Functions from this module are called by WorkspaceManager.jl, using Distributed
 
 # So when reading this file, pretend that you are living in process 2, and you are communicating with Pluto's server, who lives in process 1.
+# The package environment that this file is laoded with is the NotebookProcessProject.toml file in this directory.
 
 module PlutoRunner
 

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -4,7 +4,7 @@
 # These baby processes don't import Pluto, they only import this module. Functions from this module are called by WorkspaceManager.jl, using Distributed
 
 # So when reading this file, pretend that you are living in process 2, and you are communicating with Pluto's server, who lives in process 1.
-# The package environment that this file is laoded with is the NotebookProcessProject.toml file in this directory.
+# The package environment that this file is loaded with is the NotebookProcessProject.toml file in this directory.
 
 module PlutoRunner
 

--- a/test/Notebook.jl
+++ b/test/Notebook.jl
@@ -164,7 +164,7 @@ end
             readwrite(nb.path, new_path)
 
             # load_notebook also does parsing and analysis - this is needed to save the notebook with cells in their correct order
-            # laod_notebook is how they are normally loaded, load_notebook_nobackup
+            # load_notebook is how they are normally loaded, load_notebook_nobackup
             new_nb = load_notebook(new_path)
 
             before_contents = read(new_path, String)


### PR DESCRIPTION
(This is a boring PR)

Continuation of #808

Recently, a version of HTTP was removed ('yanked') from the registry, causing some confusing issues with people that were using that version inside the notebook boot environment (`~/.julia/__pluto_boot_1.6.3`). We don't need HTTP in the boot environment, because the notebook process does not use it, so this PR adds a separate Project.toml to be used as the notebook boot environment.