### PR TITLE
Windows 2022 for CI

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -26,7 +26,7 @@ jobs:
             matrix:
                 # We test quite a lot of versions because we do some OS and version specific things unfortunately
                 julia-version: ["1.5", "1.6", "^1.7.0-0"] #, "nightly"]
-                os: [ubuntu-latest, macOS-latest, windows-latest]
+                os: [ubuntu-latest, macOS-latest, windows-2022]
 
         steps:
             # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it


### PR DESCRIPTION
Because or tests are failing on Windows since a couple of days 😟