### PR TITLE
Update usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ To run Pluto, run the following commands in your Julia REPL:
 
 ```julia
 julia> using Pluto: run
-
 julia> run()
 ```
 


### PR DESCRIPTION
This change would mean typing two symbols less and it is actually safer too[^safer]. See also the [JuMP Style Guide](https://jump.dev/JuMP.jl/v0.21/developers/style/#using-vs.-import).

[^safer]: `import` is quite a risky way of loading code because once you do `import: foo`, defining a function `foo` will either extend an existing function or it will override an existing method definition. In both cases, the updated definition for `foo` can actually introduces errors deep down in other packages or even Julia base.