### PR TITLE
Update to macro runtime & PlutoHooks.jl

### DIFF
--- a/src/analysis/DependencyCache.jl
+++ b/src/analysis/DependencyCache.jl
@@ -28,21 +28,12 @@ function upstream_cells_map(cell::Cell, notebook::Notebook)::Dict{Symbol,Vector{
     )
 end
 
-"Checks whether or not the cell references user-defined macrocalls"
-function contains_user_defined_macrocalls(cell::Cell, notebook::Notebook)::Bool
-    calls = notebook.topology.nodes[cell].macrocalls
-    !isempty(calls) && any(notebook.cells) do other
-        !disjoint(notebook.topology.nodes[other].funcdefs_without_signatures, calls)
-    end
-end
-
 "Fills cell dependency information for display in the GUI"
 function update_dependency_cache!(cell::Cell, notebook::Notebook)
     cell.cell_dependencies = CellDependencies(
         downstream_cells_map(cell, notebook), 
         upstream_cells_map(cell, notebook), 
         cell_precedence_heuristic(notebook.topology, cell),
-        contains_user_defined_macrocalls(cell, notebook)
     )
 end
 

--- a/src/analysis/ExpressionExplorer.jl
+++ b/src/analysis/ExpressionExplorer.jl
@@ -1242,7 +1242,9 @@ function can_be_function_wrapped(x::Expr)
         x.head === :using ||
         x.head === :import ||
         x.head === :module ||
-        x.head === :function ||
+        # Only bail on named functions, but anonymous functions (args[1].head == :tuple) are fine.
+        # TODO Named functions INSIDE other functions should be fine too
+        (x.head === :function && x.args[1].head != :tuple) ||
         x.head === :macro ||
         # Cells containing macrocalls will actually be function wrapped using the expanded version of the expression
         # See https://github.com/fonsp/Pluto.jl/pull/1597

--- a/src/analysis/ExpressionExplorer.jl
+++ b/src/analysis/ExpressionExplorer.jl
@@ -1226,7 +1226,9 @@ function can_be_function_wrapped(x::Expr)
         x.head === :module ||
         x.head === :function ||
         x.head === :macro ||
-        x.head === :macrocall || # we might want to get rid of this one, but that requires some work
+        # Cells containing macrocalls will actually be function wrapped using the expanded version of the expression
+        # See https://github.com/fonsp/Pluto.jl/pull/1597
+        x.head === :macrocall ||
         x.head === :struct ||
         x.head === :abstract ||
         (x.head === :(=) && is_function_assignment(x)) || # f(x) = ...

--- a/src/analysis/Topology.jl
+++ b/src/analysis/Topology.jl
@@ -36,6 +36,10 @@ end
 
 is_resolved(topology::NotebookTopology) = isempty(topology.unresolved_cells)
 
+function set_unresolved(topology::NotebookTopology, unresolved_cells::Vector{Cell})
+    NotebookTopology(nodes=topology.nodes, codes=topology.codes, unresolved_cells=union(topology.unresolved_cells, unresolved_cells))
+end
+
 DefaultDict{K,V}(default::Union{Function,DataType}) where {K,V} = DefaultDict{K,V}(default, Dict{K,V}())
 
 function Base.getindex(aid::DefaultDict{K,V}, key::K)::V where {K,V}

--- a/src/analysis/Topology.jl
+++ b/src/analysis/Topology.jl
@@ -30,7 +30,7 @@ Base.@kwdef struct NotebookTopology
     nodes::DefaultDict{Cell,ReactiveNode} = DefaultDict{Cell,ReactiveNode}(ReactiveNode)
     codes::DefaultDict{Cell,ExprAnalysisCache}=DefaultDict{Cell,ExprAnalysisCache}(ExprAnalysisCache)
 
-    unresolved_cells::Dict{Cell,SymbolsState} = Dict{Cell,SymbolsState}()
+    unresolved_cells::Set{Cell} = Set{Cell}()
 end
 
 

--- a/src/analysis/TopologyUpdate.jl
+++ b/src/analysis/TopologyUpdate.jl
@@ -6,30 +6,27 @@ function updated_topology(old_topology::NotebookTopology, notebook::Notebook, ce
 	
 	updated_codes = Dict{Cell,ExprAnalysisCache}()
 	updated_nodes = Dict{Cell,ReactiveNode}()
-	unresolved_cells = Dict{Cell,SymbolsState}()
+	unresolved_cells = Set{Cell}()
 	for cell in cells
-		if !(
-			haskey(old_topology.codes, cell) && 
-			old_topology.codes[cell].code === cell.code
-		)
+		if !(old_topology.codes[cell].code === cell.code)
 			new_code = updated_codes[cell] = ExprAnalysisCache(notebook, cell)
 			new_symstate = new_code.parsedcode |>
 				ExpressionExplorer.try_compute_symbolreferences
 			new_reactive_node = ReactiveNode(new_symstate)
 
-			if isempty(new_reactive_node.macrocalls)
-				updated_nodes[cell] = new_reactive_node
-			else
-				# The unresolved cells are the cells for wich we cannot create
-				# a ReactiveNode yet, because they contains macrocalls.
-				updated_nodes[cell] = new_reactive_node
-				unresolved_cells[cell] = new_symstate
-			end
+			updated_nodes[cell] = new_reactive_node
+		end
+
+		new_reactive_node = get(updated_nodes, cell, old_topology.nodes[cell])
+		if !isempty(new_reactive_node.macrocalls)
+			# The unresolved cells are the cells for wich we cannot create
+			# a ReactiveNode yet, because they contains macrocalls.
+			push!(unresolved_cells, cell) 
 		end
 	end
 	new_codes = merge(old_topology.codes, updated_codes)
 	new_nodes = merge(old_topology.nodes, updated_nodes)
-	new_unresolved_cells = merge(old_topology.unresolved_cells, unresolved_cells)
+	new_unresolved_cells = union(old_topology.unresolved_cells, unresolved_cells)
 
 	for removed_cell in setdiff(keys(old_topology.nodes), notebook.cells)
 		delete!(new_nodes, removed_cell)

--- a/src/analysis/TopologyUpdate.jl
+++ b/src/analysis/TopologyUpdate.jl
@@ -8,13 +8,17 @@ function updated_topology(old_topology::NotebookTopology, notebook::Notebook, ce
 	updated_nodes = Dict{Cell,ReactiveNode}()
 	unresolved_cells = copy(old_topology.unresolved_cells)
 	for cell in cells
-		if old_topology.codes[cell].code !== cell.code
+		old_code = old_topology.codes[cell]
+		if old_code.code !== cell.code
 			new_code = updated_codes[cell] = ExprAnalysisCache(notebook, cell)
 			new_symstate = new_code.parsedcode |>
 				ExpressionExplorer.try_compute_symbolreferences
 			new_reactive_node = ReactiveNode(new_symstate)
 
 			updated_nodes[cell] = new_reactive_node
+		elseif old_code.forced_expr_id !== nothing
+			# reset computer code
+			updated_codes[cell] = ExprAnalysisCache(old_code; forced_expr_id=nothing, function_wrapped=false)
 		end
 
 		new_reactive_node = get(updated_nodes, cell, old_topology.nodes[cell])
@@ -28,14 +32,12 @@ function updated_topology(old_topology::NotebookTopology, notebook::Notebook, ce
 	end
 	new_codes = merge(old_topology.codes, updated_codes)
 	new_nodes = merge(old_topology.nodes, updated_nodes)
-	# new_unresolved_cells = union(old_topology.unresolved_cells, unresolved_cells)
-	new_unresolved_cells = unresolved_cells
 
 	for removed_cell in setdiff(keys(old_topology.nodes), notebook.cells)
 		delete!(new_nodes, removed_cell)
 		delete!(new_codes, removed_cell)
-		delete!(new_unresolved_cells, removed_cell)
+		delete!(unresolved_cells, removed_cell)
 	end
 
-	NotebookTopology(nodes=new_nodes, codes=new_codes, unresolved_cells=new_unresolved_cells)
+	NotebookTopology(nodes=new_nodes, codes=new_codes, unresolved_cells=unresolved_cells)
 end

--- a/src/evaluation/Run.jl
+++ b/src/evaluation/Run.jl
@@ -319,12 +319,13 @@ function resolve_topology(
 	NotebookTopology(nodes=all_nodes, codes=unresolved_topology.codes, unresolved_cells=still_unresolved_nodes)
 end
 
+"""Tries to add information about macro calls without running any code, using knowledge about common macros.
+So, the resulting reactive nodes may not be absolutely accurate. If you can run code in a session, use `resolve_topology` instead.
+"""
 function static_macroexpand(topology::NotebookTopology, cell::Cell)
-	cell_node = topology.nodes[cell].macrocalls
-
 	new_node = ExpressionExplorer.maybe_macroexpand(topology.codes[cell].parsedcode; recursive=true) |>
 		ExpressionExplorer.try_compute_symbolreferences |> ReactiveNode
-	union!(new_node.macrocalls, cell_node.macrocalls)
+	union!(new_node.macrocalls, topology.nodes[cell].macrocalls)
 
 	new_node
 end

--- a/src/evaluation/Run.jl
+++ b/src/evaluation/Run.jl
@@ -275,10 +275,13 @@ function resolve_topology(
 	sn = (session, notebook)
 
 	function macroexpand_cell(cell)
-		try_macroexpand(module_name::Union{Nothing,Symbol}=nothing) = try
-			Success(macroexpand_in_workspace(sn, unresolved_topology.codes[cell].parsedcode, cell.cell_id, module_name))
-		catch e
-			Failure(e)
+		try_macroexpand(module_name::Union{Nothing,Symbol}=nothing) = begin
+			success, result = macroexpand_in_workspace(sn, unresolved_topology.codes[cell].parsedcode, cell.cell_id, module_name)
+			if success
+				Success(result)
+			else
+				Failure(result)
+			end
 		end
 
 		result = try_macroexpand()

--- a/src/evaluation/Run.jl
+++ b/src/evaluation/Run.jl
@@ -326,7 +326,12 @@ function resolve_topology(
 				push!(still_unresolved_nodes, cell)
 			end
 
-			result = analyze_macrocell(cell)
+			result = try
+				analyze_macrocell(cell)
+			catch error
+				@error "Macro call expansion failed with a non-macroexpand error" error
+				Failure(error)
+			end
 			if result isa Success
 				(new_node, function_wrapped, forced_expr_id) = result.result
 				union!(new_node.macrocalls, unresolved_topology.nodes[cell].macrocalls)

--- a/src/evaluation/RunBonds.jl
+++ b/src/evaluation/RunBonds.jl
@@ -43,5 +43,5 @@ function set_bond_values_reactive(; session::ServerSession, notebook::Notebook, 
     end
     to_reeval = where_referenced(notebook, notebook.topology, Set{Symbol}(to_set))
 
-    run_reactive_async!(session, notebook, to_reeval; deletion_hook=custom_deletion_hook, persist_js_state=true, run_async=false, kwargs...)
+    run_reactive_async!(session, notebook, to_reeval; deletion_hook=custom_deletion_hook, user_requested_run=false, run_async=false, kwargs...)
 end

--- a/src/evaluation/WorkspaceManager.jl
+++ b/src/evaluation/WorkspaceManager.jl
@@ -1,5 +1,6 @@
 module WorkspaceManager
 import UUIDs: UUID
+import ..Pluto
 import ..Pluto: Configuration, Notebook, Cell, ProcessStatus, ServerSession, ExpressionExplorer, pluto_filename, Token, withtoken, Promise, tamepath, project_relative_path, putnotebookupdates!, UpdateMessage
 import ..Pluto.PkgCompat
 import ..Configuration: CompilerOptions, _merge_notebook_compiler_options, _convert_to_flags
@@ -58,6 +59,9 @@ function make_workspace((session, notebook)::SN; force_offline::Bool=false)::Wor
     log_channel = Core.eval(Main, quote
         $(Distributed).RemoteChannel(() -> eval(:(Main.PlutoRunner.log_channel)), $pid)
     end)
+    run_channel = Core.eval(Main, quote
+        $(Distributed).RemoteChannel(() -> eval(:(Main.PlutoRunner.run_channel)), $pid)
+    end)
     module_name = create_emptyworkspacemodule(pid)
     
     original_LOAD_PATH, original_ACTIVE_PROJECT = Distributed.remotecall_eval(Main, pid, :(Base.LOAD_PATH, Base.ACTIVE_PROJECT[]))
@@ -71,6 +75,7 @@ function make_workspace((session, notebook)::SN; force_offline::Bool=false)::Wor
     )
 
     @async start_relaying_logs((session, notebook), log_channel)
+    @async start_relaying_self_updates((session, notebook), run_channel)
     cd_workspace(workspace, notebook.path)
     use_nbpkg_environment((session, notebook), workspace)
 
@@ -100,6 +105,22 @@ function use_nbpkg_environment((session, notebook)::SN, workspace=nothing)
         end)
     else
         # uhmmmmmm TODO
+    end
+end
+
+function start_relaying_self_updates((session, notebook)::SN, run_channel::Distributed.RemoteChannel)
+    while true
+        try
+            next_run_uuid = take!(run_channel)
+
+            cell_to_run = notebook.cells_dict[next_run_uuid]
+            Pluto.run_reactive!(session, notebook, notebook.topology, notebook.topology, Cell[cell_to_run]; persist_js_state=true)
+        catch e
+            if !isopen(run_channel)
+                break
+            end
+            @error "Failed to relay self-update" exception=(e, catch_backtrace())
+        end
     end
 end
 

--- a/src/evaluation/WorkspaceManager.jl
+++ b/src/evaluation/WorkspaceManager.jl
@@ -277,7 +277,6 @@ function eval_format_fetch_in_workspace(
     ends_with_semicolon::Bool=false,
     function_wrapped_info::Union{Nothing,Tuple}=nothing,
     forced_expr_id::Union{PlutoRunner.ObjectID,Nothing}=nothing,
-    contains_user_defined_macrocalls::Bool=false
 )::NamedTuple{(:output_formatted, :errored, :interrupted, :process_exited, :runtime, :published_objects),Tuple{PlutoRunner.MimedOutput,Bool,Bool,Bool,Union{UInt64,Nothing},Dict{String,Any}}}
 
     workspace = get_workspace(session_notebook)
@@ -302,7 +301,6 @@ function eval_format_fetch_in_workspace(
             $cell_id, 
             $function_wrapped_info,
             $forced_expr_id,
-            $contains_user_defined_macrocalls,
         )))
         put!(workspace.dowork_token)
         nothing
@@ -360,11 +358,7 @@ function macroexpand_in_workspace(session_notebook::Union{SN,Workspace}, macroca
     expr = quote
         PlutoRunner.try_macroexpand($(module_name), $(cell_uuid), $(macrocall |> QuoteNode))
     end
-    try
-        return Distributed.remotecall_eval(Main, workspace.pid, expr)
-    catch e
-        return e
-    end
+    return Distributed.remotecall_eval(Main, workspace.pid, expr)
 end
 
 "Evaluate expression inside the workspace - output is returned. For internal use."

--- a/src/notebook/Cell.jl
+++ b/src/notebook/Cell.jl
@@ -17,7 +17,6 @@ struct CellDependencies{T} # T == Cell, but this has to be parametric to avoid a
     downstream_cells_map::Dict{Symbol,Vector{T}}
     upstream_cells_map::Dict{Symbol,Vector{T}}
     precedence_heuristic::Int
-    contains_user_defined_macrocalls::Bool
 end
 
 "The building block of a `Notebook`. Contains code, output, reactivity data, mitochondria and ribosomes."
@@ -38,7 +37,7 @@ Base.@kwdef mutable struct Cell
     runtime::Union{Nothing,UInt64}=nothing
 
     # note that this field might be moved somewhere else later. If you are interested in visualizing the cell dependencies, take a look at the cell_dependencies field in the frontend instead.
-    cell_dependencies::CellDependencies{Cell}=CellDependencies{Cell}(Dict{Symbol,Vector{Cell}}(), Dict{Symbol,Vector{Cell}}(), 99, false)
+    cell_dependencies::CellDependencies{Cell}=CellDependencies{Cell}(Dict{Symbol,Vector{Cell}}(), Dict{Symbol,Vector{Cell}}(), 99)
 
     running_disabled::Bool=false
     depends_on_disabled_cells::Bool=false

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -448,7 +448,7 @@ function run_expression(m::Module, expr::Any, cell_id::UUID, function_wrapped_in
             try
                 computer = register_computer(expr, expr_id, cell_id, collect.(function_wrapped_info)...)
             catch e
-                # @error "Failed to generate computer function" expr exception=(e,stacktrace(catch_backtrace()))
+                @error "Failed to generate computer function" expr exception=(e,stacktrace(catch_backtrace()))
                 return run_expression(m, expr, cell_id, nothing)
             end
         end
@@ -457,7 +457,7 @@ function run_expression(m::Module, expr::Any, cell_id::UUID, function_wrapped_in
         # The fix is to detect this situation and run the expression in the classical way.
         ans, runtime = if any(name -> !isdefined(m, name), computer.input_globals)
             # Do run_expression but with function_wrapped_info=nothing so it doesn't go in a Computer()
-            # @warn "Got variables that don't exist, running outside of computer" not_existing=filter(name -> !isdefined(m, name), computer.input_globals)
+            @warn "Got variables that don't exist, running outside of computer" not_existing=filter(name -> !isdefined(m, name), computer.input_globals)
             run_expression(m, expr, cell_id, nothing)
         else
             run_inside_trycatch(m, () -> compute(m, computer), computer.return_proof)

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -453,7 +453,8 @@ function run_expression(m::Module, expr::Any, cell_id::UUID, function_wrapped_in
         try
             try_macroexpand(m, cell_id, expr)
         catch e
-            bt = stacktrace(catch_backtrace())
+            # On error during macroexpand, we override the stacktrace with this faux one
+            bt = [StackTraces.StackFrame(Symbol("Macro Expansion"), Symbol("pluto-cell"), 1, nothing, false, false, 0)]
             result = CapturedException(e, bt)
             cell_results[cell_id], cell_runtimes[cell_id] = (result, nothing)
             return (result, nothing)

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -361,7 +361,7 @@ end
 """
 Run the expression or function inside a try ... catch block, and verify its "return proof".
 """
-function run_inside_trycatch(m::Module, f::Union{Expr,Function})::Tuple{Any,UInt64}
+function run_inside_trycatch(m::Module, f::Union{Expr,Function})::Tuple{Any,Union{UInt64,Nothing}}
     return try
         if f isa Expr
             # We eval `f` in the global scope of the workspace module:

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -263,7 +263,7 @@ function register_computer(expr::Expr, key::ObjectID, cell_id::UUID, input_globa
         Expr(:(=), result, timed_expr(expr, proof)),
         Expr(:tuple,
             result,
-            Expr(:tuple, map(x -> :(@isdefined($(x)) ? $(x) : $(NotDefined())),output_globals)...)
+            Expr(:tuple, map(x -> :(@isdefined($(x)) ? $(x) : $(OutputNotDefined())), output_globals)...)
         )
     ))
 
@@ -297,7 +297,7 @@ end
 quote_if_needed(x) = x
 quote_if_needed(x::Union{Expr, Symbol, QuoteNode, LineNumberNode}) = QuoteNode(x)
 
-struct NotDefined end
+struct OutputNotDefined end
 
 function compute(m::Module, computer::Computer)
     # 1. get the referenced global variables
@@ -312,7 +312,7 @@ function compute(m::Module, computer::Computer)
         for (name, val) in zip(computer.output_globals, output_global_values)
             # Core.eval(m, Expr(:(=), name, quote_if_needed(val)))
             Core.eval(m, quote
-                if $(quote_if_needed(val)) === $(NotDefined())
+                if $(quote_if_needed(val)) !== $(OutputNotDefined())
                     $(name) = $(quote_if_needed(val))
                 end
             end)

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -38,12 +38,10 @@ const cell_expanded_exprs = Dict{UUID,CachedMacroExpansion}()
 
 const supported_integration_features = Any[]
 
-struct GiveMeCellID end
-struct GiveMeRerunCellFunction end
-struct GiveMeRegisterCleanupFunction end
-
-
-
+abstract type SpecialPlutoExprValue end
+struct GiveMeCellID <: SpecialPlutoExprValue end
+struct GiveMeRerunCellFunction <: SpecialPlutoExprValue end
+struct GiveMeRegisterCleanupFunction <: SpecialPlutoExprValue end
 
 ###
 # WORKSPACE MANAGER
@@ -528,11 +526,6 @@ end
 const run_channel = Channel{UUID}(10)
 
 function rerun_cell_from_notebook(cell_id::UUID)
-    if cell_id != currently_running_cell_id[]
-        error("Cell($cell_id) rerun triggered from Cell($(currently_running_cell_id[])), this can lead to infinite loops so it is prohibited for now.")
-        # @warn "rerun_cell_from_notebook($cell_id) called from outside the cell (from $(currently_running_cell_id[])), this can lead to infinite loops"
-    end
-
     # make sure only one of this cell_id is in the run channel
     # by emptying it and filling it again
     new_uuids = UUID[]

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -448,7 +448,7 @@ function run_expression(m::Module, expr::Any, cell_id::UUID, function_wrapped_in
             try
                 computer = register_computer(expr, expr_id, cell_id, collect.(function_wrapped_info)...)
             catch e
-                @error "Failed to generate computer function" expr exception=(e,stacktrace(catch_backtrace()))
+                # @error "Failed to generate computer function" expr exception=(e,stacktrace(catch_backtrace()))
                 return run_expression(m, expr, cell_id, nothing)
             end
         end
@@ -457,7 +457,7 @@ function run_expression(m::Module, expr::Any, cell_id::UUID, function_wrapped_in
         # The fix is to detect this situation and run the expression in the classical way.
         ans, runtime = if any(name -> !isdefined(m, name), computer.input_globals)
             # Do run_expression but with function_wrapped_info=nothing so it doesn't go in a Computer()
-            @warn "Got variables that don't exist, running outside of computer" not_existing=filter(name -> !isdefined(m, name), computer.input_globals)
+            # @warn "Got variables that don't exist, running outside of computer" not_existing=filter(name -> !isdefined(m, name), computer.input_globals)
             run_expression(m, expr, cell_id, nothing)
         else
             run_inside_trycatch(m, () -> compute(m, computer), computer.return_proof)

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -144,7 +144,13 @@ function globalref_to_workspaceref(expr)
         # This way the expression explorer doesn't care (it just sees references to variables outside of the workspace), 
         # and the variables don't get overwriten by local assigments to the same name (because we have special names). 
         map(mutable_ref_list) do ref
-            :($(ref[2]) = $(ref[1]))
+            # I can just do Expr(:isdefined, ref[1]) here, but it feels better to macroexpand,
+            #   because it's more obvious what's going on, and when they ever change the ast, we're safe :D
+            macroexpand(Main, quote
+                if @isdefined($(ref[1]))
+                    $(ref[2]) = $(ref[1])
+                end
+            end)
         end...,
         new_expr,
     )

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -146,16 +146,11 @@ end
 
 sanitize_expr(linenumbernode::LineNumberNode) = linenumbernode
 sanitize_expr(bool::Bool) = bool
+sanitize_expr(quoted::QuoteNode) = QuoteNode(sanitize_expr(quoted.value))
+
 # In all cases of more complex objects, we just don't send it.
 # It's not like the expression explorer will look into them at all.
 sanitize_expr(other) = nothing
-
-# A vector of Symbols need to be serialized as QuoteNode(sym)
-# sanitize_value(sym::Symbol) = QuoteNode(sym)
-
-# sanitize_value(ex::Expr) = Expr(:quote, ex)
-
-# sanitize_value(other) = sanitize_expr(other)
 
 
 function try_macroexpand(mod, cell_uuid, expr)

--- a/test/MacroAnalysis.jl
+++ b/test/MacroAnalysis.jl
@@ -520,7 +520,7 @@ import Pluto: PlutoRunner, Notebook, WorkspaceManager, Cell, ServerSession, Clie
         @test noerror(cell(1))
         runtime = cell(1).runtime*ns
         output_1 = cell(1).output.body
-        @test sleep_time <= runtime <= 2sleep_time
+        @test sleep_time <= runtime
 
         setcode(cell(3), "updater = :fast")
         update_run!(🍭, notebook, cell(3))

--- a/test/MacroAnalysis.jl
+++ b/test/MacroAnalysis.jl
@@ -173,7 +173,7 @@ import Pluto: PlutoRunner, Notebook, WorkspaceManager, Cell, ServerSession, Clie
     @testset "Expr sanitization" begin
         struct A; end
         f(x) = x
-        unserializable_expr = Expr(:call, f, A(), A[A(), A(), A()], PlutoRunner, PlutoRunner.sanitize_expr)
+        unserializable_expr = :($(f)(A(), A[A(), A(), A()], PlutoRunner, PlutoRunner.sanitize_expr))
 
         get_expr_types(other) = typeof(other)
         get_expr_types(ex::Expr) = get_expr_types.(ex.args)
@@ -185,11 +185,7 @@ import Pluto: PlutoRunner, Notebook, WorkspaceManager, Cell, ServerSession, Clie
         types = sanitized_expr |> get_expr_types |> flatten |> Set
 
         # Checks that no fancy type is part of the serialized expression
-        @test Set([Symbol, QuoteNode]) == types
-
-        @test Meta.isexpr(sanitized_expr.args[3], :vect, 3)
-        @test sanitized_expr.args[2] == :A
-        @test sanitized_expr.args[1] == :(Main.f)
+        @test Set([Nothing]) == types
     end
 
     @testset "Macrodef cells not root of run" begin

--- a/test/MacroAnalysis.jl
+++ b/test/MacroAnalysis.jl
@@ -704,7 +704,6 @@ import Pluto: PlutoRunner, Notebook, WorkspaceManager, Cell, ServerSession, Clie
         @test ":hello" == cell(4).output.body
         @test :b ∈ notebook.topology.nodes[cell(3)].definitions
         @test [:c, Symbol("@my_assign")] ⊆ notebook.topology.nodes[cell(3)].references
-        @test cell(3).cell_dependencies.contains_user_defined_macrocalls == true
 
         setcode(notebook.cells[2], "c = :world")
         update_run!(🍭, notebook, cell(2))

--- a/test/MacroAnalysis.jl
+++ b/test/MacroAnalysis.jl
@@ -185,7 +185,7 @@ import Pluto: PlutoRunner, Notebook, WorkspaceManager, Cell, ServerSession, Clie
         types = sanitized_expr |> get_expr_types |> flatten |> Set
 
         # Checks that no fancy type is part of the serialized expression
-        @test Set([Nothing]) == types
+        @test Set([Nothing, Symbol, QuoteNode]) == types
     end
 
     @testset "Macrodef cells not root of run" begin

--- a/test/MacroAnalysis.jl
+++ b/test/MacroAnalysis.jl
@@ -281,8 +281,6 @@ import Pluto: PlutoRunner, Notebook, WorkspaceManager, Cell, ServerSession, Clie
     end
 
     @testset "Redefines macro with new SymbolsState" begin
-        🍭.options.evaluation.workspace_use_distributed = true
-
         notebook = Notebook(Cell.([
             "@b x",
             raw"""macro b(sym)
@@ -306,8 +304,6 @@ import Pluto: PlutoRunner, Notebook, WorkspaceManager, Cell, ServerSession, Clie
         # for @b(x) has not changed.
         @test_broken cell(4).output.body == "42"
         @test cell(3).errored == true
-
-        WorkspaceManager.unmake_workspace((🍭, notebook))
 
         notebook = Notebook(Cell.([
             "@b x",
@@ -333,9 +329,6 @@ import Pluto: PlutoRunner, Notebook, WorkspaceManager, Cell, ServerSession, Clie
         # See Run.jl#resolve_topology.
         @test cell(4).output.body == "42"
         @test cell(3).errored == true
-
-        WorkspaceManager.unmake_workspace((🍭, notebook))
-        🍭.options.evaluation.workspace_use_distributed = false
     end
 
     @testset "Reactive macro update does not invalidate the macro calls" begin

--- a/test/MacroAnalysis.jl
+++ b/test/MacroAnalysis.jl
@@ -442,7 +442,7 @@ import Pluto: PlutoRunner, Notebook, WorkspaceManager, Cell, ServerSession, Clie
         notebook = Notebook(Cell.([
             "x",
             "@b x",
-            raw"macro b(sym) esc(:($sym = 42))",
+            raw"macro b(sym) esc(:($sym = 42)) end",
         ]))
         update_run!(🍭, notebook, notebook.cells)
 

--- a/test/helpers.jl
+++ b/test/helpers.jl
@@ -116,8 +116,8 @@ function setcode(cell, newcode)
     cell.code = newcode
 end
 
-function noerror(cell)
-    if cell.errored
+function noerror(cell; verbose=true)
+    if cell.errored && verbose
         @show cell.output.body
     end
     !cell.errored


### PR DESCRIPTION
## The companion package is [PlutoHooks.jl](https://github.com/JuliaPluto/PlutoHooks.jl)

 - [x] indirectly/directly updating the definition of a macro updates the nodes of all macros calling that macro
 - [x] directly running a macrocall updates the reactive node for that macrocall
 - [x] indirectly running a macrocall does not updates the reactive node for that macrocall
 - [x] Change computer lifecycle to use cell UUIDs instead of expression hash
 - [x] PlutoRunner hooks for cell related cleanups when the computer is removed
 - [x] PlutoRunner hooks to rerun cell implicitely
 - [x] can't use `:(function() end)` as macro outputs :cry: 
 - [x] work without function wrapping

Reactive node update also means update of the underlying function wrapper.

## Function wrapping

Cells with macro calls will be function wrapped. that means at list two things:

#### Stateful cells in Julia (similar to `this` in JavaScript)
![wrapped_macrocall](https://user-images.githubusercontent.com/9824244/138893442-a5bf1374-7a97-4c08-b92a-3c613e808f96.gif)

<details>
<summary>Other example</summary>


![wrapped_macro_acc](https://user-images.githubusercontent.com/9824244/138902774-d39a4c9d-bc5a-4dee-9f06-8ac9a378fba5.gif)

</details>

#### Faster execution because of a single compilation
![macro_wrapped_htl](https://user-images.githubusercontent.com/9824244/138894173-82c4e250-cf1a-4854-842c-38873ae49ac4.gif)

