### PR TITLE
🐣 New package AbstractPlutoDingetjes.jl for intial bond values, bond value transformation and more

### DIFF
--- a/sample/Interactivity.jl
+++ b/sample/Interactivity.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.14.0
+# v0.17.0
 
 using Markdown
 using InteractiveUtils
@@ -7,8 +7,9 @@ using InteractiveUtils
 # This Pluto notebook uses @bind for interactivity. When running this notebook outside of Pluto, the following 'mock version' of @bind gives bound variables a default value (instead of an error).
 macro bind(def, element)
     quote
+        local iv = try Base.loaded_modules[Base.PkgId(Base.UUID("6e696c72-6542-2067-7265-42206c756150"), "AbstractPlutoDingetjes")].Bonds.initial_value catch; b -> missing; end
         local el = $(esc(element))
-        global $(esc(def)) = Core.applicable(Base.get, el) ? Base.get(el) : missing
+        global $(esc(def)) = Core.applicable(Base.get, el) ? Base.get(el) : iv(el)
         el
     end
 end
@@ -16,7 +17,7 @@ end
 # ╔═╡ db24490e-7eac-11ea-094e-9d3fc8f22784
 md"# Introducing _bound_ variables
 
-With the new `@bind` macro, Pluto.jl can listen to real-time events from HTML objects!"
+With the `@bind` macro, Pluto.jl can synchronize a Julia variable with an HTML object!"
 
 # ╔═╡ bd24d02c-7eac-11ea-14ab-95021678e71e
 @bind x html"<input type=range>"
@@ -24,7 +25,7 @@ With the new `@bind` macro, Pluto.jl can listen to real-time events from HTML ob
 # ╔═╡ cf72c8a2-7ead-11ea-32b7-d31d5b2dacc2
 md"This syntax displays the HTML object as the cell's output, and uses its latest value as the definition of `x`. Of course, the variable `x` is _reactive_, and all references to `x` come to life ✨
 
-_Try it out!_ 👆" 
+_Try moving the slider!_ 👆" 
 
 # ╔═╡ cb1fd532-7eac-11ea-307c-ab16b1977819
 x
@@ -39,18 +40,22 @@ The `@bind` macro returns a `Bond` object, which can be used inside Markdown and
 
 # ╔═╡ fc99521c-7eae-11ea-269b-0d124b8cbe48
 begin
-	🐶slider = @bind 🐶 html"<input type=range>"
-	🐱slider = @bind 🐱 html"<input type=range>"
+	dog_slider = @bind 🐶 html"<input type=range>"
+	cat_slider = @bind 🐱 html"<input type=range>"
 	
-	md"""**How many pets do you have?**
+	md"""
+	**How many pets do you have?**
 	
-	Dogs: $(🐶slider)
-
-	Cats: $(🐱slider)"""
+	Dogs: $(dog_slider)
+	
+	Cats: $(cat_slider)
+	"""
 end
 
 # ╔═╡ 1cf27d7c-7eaf-11ea-3ee3-456ed1e930ea
-md"You have $(🐶) dogs and $(🐱) cats!"
+md"""
+You have $(🐶) dogs and $(🐱) cats!
+"""
 
 # ╔═╡ e3204b38-7eae-11ea-32be-39db6cc9faba
 md""
@@ -90,11 +95,13 @@ Try drawing a rectangle in the canvas below 👇 and notice that the `area` vari
 
 # ╔═╡ 7f4b0e1e-7f16-11ea-02d3-7955921a70bd
 @bind dims html"""
+<span>
 <canvas width="200" height="200" style="position: relative"></canvas>
 
 <script>
 // 🐸 `currentScript` is the current script tag - we use it to select elements 🐸 //
-const canvas = currentScript.parentElement.querySelector("canvas")
+const span = currentScript.parentElement
+const canvas = span.querySelector("canvas")
 const ctx = canvas.getContext("2d")
 
 var startX = 80
@@ -102,13 +109,13 @@ var startY = 40
 
 function onmove(e){
 	// 🐸 We send the value back to Julia 🐸 //
-	canvas.value = [e.layerX - startX, e.layerY - startY]
-	canvas.dispatchEvent(new CustomEvent("input"))
+	span.value = [e.layerX - startX, e.layerY - startY]
+	span.dispatchEvent(new CustomEvent("input"))
 
 	ctx.fillStyle = '#ffecec'
 	ctx.fillRect(0, 0, 200, 200)
 	ctx.fillStyle = '#3f3d6d'
-	ctx.fillRect(startX, startY, ...canvas.value)
+	ctx.fillRect(startX, startY, ...span.value)
 }
 
 canvas.onpointerdown = e => {
@@ -125,6 +132,7 @@ canvas.onpointerup = e => {
 onmove({layerX: 130, layerY: 160})
 
 </script>
+</span>
 """
 
 # ╔═╡ 5876b98e-7f32-11ea-1748-0bb47823cde1
@@ -141,7 +149,7 @@ md"""## Can I use it?
 
 The `@bind` macro is **built into Pluto.jl** — it works without having to install a package. 
 
-You can use the (tiny) package [`PlutoUI`](https://github.com/fonsp/PlutoUI.jl) for some predefined `<input>` HTML codes. For example, you use `PlutoUI` to write
+You can use the (tiny) package [PlutoUI.jl](https://github.com/JuliaPluto/PlutoUI.jl) for some predefined input elements. For example, you use `PlutoUI` to write
 
 ```julia
 @bind x Slider(5:15)
@@ -159,11 +167,11 @@ _The `@bind` syntax in not limited to `html"..."` objects, but **can be used for
 """
 
 # ╔═╡ d5b3be4a-7f52-11ea-2fc7-a5835808207d
-md"""#### More packages
+md"""
+#### More packages
 
-In fact, **_any package_ can add bindable values to their objects**. For example, a geoplotting package could add a JS `input` event to their plot that contains the cursor coordinates when it is clicked. You can then use those coordinates inside Julia.
-
-A package _does not need to add `Pluto.jl` as a dependency to do so_: only the `Base.show(io, MIME("text/html"), obj)` function needs to be extended to contain a `<script>` that triggers the `input` event with a value. (It's up to the package creator _when_ and _what_.) This _does not affect_ how the object is displayed outside of Pluto.jl: uncaught events are ignored by your browser."""
+In fact, **_any package_ can add bindable values to their objects**. For example, a geoplotting package could add a JS `input` event to their plot that contains the cursor coordinates when it is clicked. You can then use those coordinates inside Julia. Take a look at the [JavaScript sample notebook](./sample/JavaScript.jl) to learn more about these techniques!
+"""
 
 # ╔═╡ aa8f6a0e-303a-11eb-02b7-5597c167596d
 
@@ -208,22 +216,20 @@ For example, _expanding_ the `@bind` macro turns this expression:
 @bind x Slider(5:15)
 ```
 
-into:
+into (simplified):
 ```julia
 begin
-	local el = Slider(5:15)
-	global x = if applicable(Base.get, el)
-		Base.get(el)
-	else
-		missing
-	end
-	PlutoRunner.Bond(el, :x)
+    local el = Slider(5:15)
+    global x = AbstractPlutoDingetjes.intial_value(el)
+    PlutoRunner.create_bond(el, :x)
 end
 ```
 
-The `if` block in the middle assigns an initial value to `x`, which will be `missing`, unless an extension of `Base.get` has been declared for the element. Most objects (like `html"<input>"` or `md"quelque chose"`) don't have a `Base.get` method defined. In fact, `Base.get` has _no_ single-argument methods by default, but you can write one for your special types!
+We see that the macro creates a variable `x`, which is given the value `AbstractPlutoDingetjes.intial_value(el)`. This function returns `missing` by default, unless a method was implemented for your widget type. For example, `PlutoUI` has a `Slider` type, and it defines a method for `intial_value(slider::Slider)` that returns the default number.
 
-Declaring a default value using `Base.get` is **not necessary**, as shown by the examples above, but the default value will be used for `x` if the `notebook.jl` file is _run as a plain julia file_, without Pluto's interactivity. The package [`PlutoUI`](https://github.com/fonsp/PlutoUI.jl) defines default values.
+Declaring a default value using `AbstractPlutoDingetjes` is **not necessary**, as shown by the earlier examples in this notebook, but the default value will be used for `x` if the `notebook.jl` file is _run as a plain julia file_, without Pluto's interactivity.
+
+You don't need to worry about this if you are just getting started with Pluto and interactive elements, but more advanced users should take a look at [`AbstractPlutoDingetjes.jl`](https://github.com/JuliaPluto/AbstractPlutoDingetjes.jl).
 
 """
 
@@ -232,9 +238,9 @@ md"#### JavaScript?
 
 Yes! We are using `Generator.input` from [`observablehq/stdlib`](https://github.com/observablehq/stdlib#Generators_input) to create a JS _Generator_ (kind of like an Observable) that listens to `onchange`, `onclick` or `oninput` events, [depending on the element type](https://github.com/observablehq/stdlib#Generators_input).
 
-This makes it super easy to create nice HTML/JS-based interaction elements - a package creator simply has to write a `show` method for MIME type `text/html` that creates a DOM object that triggers the `input` event. In other words, _Pluto's `@bind` will behave exactly like `viewof` in observablehq_.
+This makes it super easy to create nice HTML/JS-based interaction elements - a package creator simply has to write a `show` method for MIME type `text/html` that creates a DOM object that triggers the `input` event. In other words, _Pluto's `@bind` will behave exactly like [`viewof` in observablehq](https://observablehq.com/@observablehq/introduction-to-views)_.
 
-_If you want to make a cool new UI, go to [observablehq.com/@observablehq/introduction-to-views](https://observablehq.com/@observablehq/introduction-to-views) to learn how._"
+_If you want to make a cool new UI for Pluto, go to the [JavaScript sample notebook](./sample/JavaScript.jl) to learn how!_"
 
 # ╔═╡ dddb9f34-7f37-11ea-0abb-272ef1123d6f
 md""
@@ -243,7 +249,7 @@ md""
 md""
 
 # ╔═╡ f7555734-7f34-11ea-069a-6bb67e201bdc
-md"That's it for now! Let us know what you think using the feedback button below! 👇"
+md"That's it for now! Let us know what you think using the feedback box below! 👇"
 
 # ╔═╡ Cell order:
 # ╟─db24490e-7eac-11ea-094e-9d3fc8f22784

--- a/src/evaluation/RunBonds.jl
+++ b/src/evaluation/RunBonds.jl
@@ -38,7 +38,7 @@ function set_bond_values_reactive(; session::ServerSession, notebook::Notebook, 
         to_delete_vars = Set([to_delete_vars..., to_set...]) # also delete the bound symbols
         WorkspaceManager.move_vars((session, notebook), old_workspace_name, new_workspace_name, to_delete_vars, methods_to_delete, to_reimport)
         for (bound_sym, new_value) in zip(to_set, new_values)
-            WorkspaceManager.eval_in_workspace((session, notebook), :($(bound_sym) = $(new_value)))
+            WorkspaceManager.eval_in_workspace((session, notebook), :($(bound_sym) = Main.PlutoRunner.transform_bond_value($(QuoteNode(bound_sym)), $(new_value))))
         end
     end
     to_reeval = where_referenced(notebook, notebook.topology, Set{Symbol}(to_set))

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -1429,7 +1429,12 @@ const registered_bond_elements = Dict{Symbol, Any}()
 
 function transform_bond_value(s::Symbol, value_from_js)
     element = get(registered_bond_elements, s, nothing)
-    return transform_value_ref[](element, value_from_js)
+    return try
+        transform_value_ref[](element, value_from_js)
+    catch e
+        @error "AbstractPlutoDingetjes: Bond value transformation errored." exception=(e, catch_backtrace())
+        (Text("❌ AbstractPlutoDingetjes: Bond value transformation errored."), e, stacktrace(catch_backtrace()))
+    end
 end
 
 """

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -29,7 +29,7 @@ const ObjectDimPair = Tuple{ObjectID,Int64}
 const ExpandedCallCells = Dict{UUID,Expr}()
 
 
-
+const supported_integration_features = Any[]
 
 
 
@@ -643,7 +643,7 @@ end
 Base.IOContext(io::IOContext, ::Nothing) = io
 
 "The `IOContext` used for converting arbitrary objects to pretty strings."
-const default_iocontext = IOContext(devnull, :color => false, :limit => true, :displaysize => (18, 88), :is_pluto => true)
+const default_iocontext = IOContext(devnull, :color => false, :limit => true, :displaysize => (18, 88), :is_pluto => true, :pluto_supported_integration_features => supported_integration_features)
 
 const imagemimes = [MIME"image/svg+xml"(), MIME"image/png"(), MIME"image/jpg"(), MIME"image/jpeg"(), MIME"image/bmp"(), MIME"image/gif"()]
 # in descending order of coolness
@@ -1118,11 +1118,17 @@ end
 # This is similar to how Requires.jl works, except we don't use a callback, we just check every time.
 const integrations = Integration[
     Integration(
-        id = Base.PkgId(UUID(reinterpret(Int128, codeunits("Paul Berg Berlin")) |> first), "AbstractPlutoDingetjes"),
+        id = Base.PkgId(Base.UUID(reinterpret(Int128, codeunits("Paul Berg Berlin")) |> first), "AbstractPlutoDingetjes"),
         code = quote
-            if v"1.0.0" <= AbstractPlutoDingetjes.MY_VERSION < v"2.0.0"
-                initial_value_getter_ref[] = AbstractPlutoDingetjes.Bonds.initial_value
-            end
+            @assert v"1.0.0" <= AbstractPlutoDingetjes.MY_VERSION < v"2.0.0"
+            initial_value_getter_ref[] = AbstractPlutoDingetjes.Bonds.initial_value
+            transform_value_ref[] = AbstractPlutoDingetjes.Bonds.transform_value
+            
+            push!(supported_integration_features,
+                AbstractPlutoDingetjes,
+                AbstractPlutoDingetjes.Bonds,
+                AbstractPlutoDingetjes.Bonds.initial_value,
+            )
         end,
     ),
     Integration(

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -1442,7 +1442,7 @@ function show(io::IO, ::MIME"text/html", bond::Bond)
     end
 end
 
-const initial_value_getter_ref = useRef{Function}(bond -> missing)
+const initial_value_getter_ref = Ref{Function}(bond -> missing)
 
 """
     `@bind symbol element`

--- a/test/Bonds.jl
+++ b/test/Bonds.jl
@@ -1,0 +1,243 @@
+using Test
+import Pluto
+import Pluto: update_run!, WorkspaceManager, ClientSession, ServerSession, Notebook, Cell
+
+
+@testset "Bonds" begin
+
+    🍭 = ServerSession()
+    🍭.options.evaluation.workspace_use_distributed = false
+    fakeclient = ClientSession(:fake, nothing)
+    🍭.connected_clients[fakeclient.id] = fakeclient
+    
+    @testset "AbstractPlutoDingetjes.jl" begin
+        🍭.options.evaluation.workspace_use_distributed = true
+        notebook = Notebook([
+                Cell("""
+                begin
+                    import Pkg
+                    try
+                        Pkg.UPDATED_REGISTRY_THIS_SESSION[] = true
+                    catch; end
+                    Pkg.activate(mktempdir())
+                    Pkg.add(Pkg.PackageSpec(name="AbstractPlutoDingetjes", rev="0494e5a"))
+                    import AbstractPlutoDingetjes
+                    const APD = AbstractPlutoDingetjes
+                    import AbstractPlutoDingetjes.Bonds
+                end
+                """),
+                Cell("""
+                begin
+                    struct HTMLShower
+                        f::Function
+                    end
+                    Base.show(io::IO, m::MIME"text/html", hs::HTMLShower) = hs.f(io)
+                end
+                """),
+                Cell("""
+                APD.is_inside_pluto()
+                """),
+                Cell("""
+                HTMLShower() do io
+                    write(io, string(APD.is_inside_pluto(io)))
+                end
+                """),
+                Cell("""
+                HTMLShower() do io
+                    write(io, string(APD.is_supported_by_display(io, Bonds.initial_value)))
+                end
+                """),
+                Cell("""
+                HTMLShower() do io
+                    write(io, string(APD.is_supported_by_display(io, Bonds.transform_value)))
+                end
+                """),
+                Cell("""
+                HTMLShower() do io
+                    write(io, string(APD.is_supported_by_display(io, Bonds.validate_value)))
+                end
+                """),
+                Cell("""
+                HTMLShower() do io
+                    write(io, string(APD.is_supported_by_display(io, sqrt)))
+                end
+                """),
+                Cell("""
+                @bind x_simple html"<input type=range>"
+                """),
+                Cell("""
+                x_simple
+                """),
+                Cell("""
+                begin
+                    struct OldSlider end
+                    
+                    Base.show(io::IO, m::MIME"text/html", os::OldSlider) = write(io, "<input type=range value=1>")
+                    
+                    Base.get(os::OldSlider) = 1
+                end
+                """),
+                Cell("""
+                @bind x_old OldSlider()
+                """),
+                Cell("""
+                x_old
+                """),
+                Cell("""
+                begin
+                    struct NewSlider end
+                    
+                    Base.show(io::IO, m::MIME"text/html", os::NewSlider) = write(io, "<input type=range value=1>")
+                    
+                    Bonds.initial_value(os::NewSlider) = 1
+                end
+                """),
+                Cell("""
+                @bind x_new NewSlider()
+                """),
+                Cell("""
+                x_new
+                """),
+                Cell("""
+                begin
+                    struct TransformSlider end
+                    
+                    Base.show(io::IO, m::MIME"text/html", os::TransformSlider) = write(io, "<input type=range value=1>")
+                    
+                    Bonds.initial_value(os::TransformSlider) = "x"
+                    Bonds.transform_value(os::TransformSlider, from_js) = repeat("x", from_js)
+                end
+                """),
+                Cell("""
+                @bind x_transform TransformSlider()
+                """),
+                Cell("""
+                x_transform
+                """),
+                Cell("""
+                begin
+                    struct BadTransformSlider end
+                    
+                    Base.show(io::IO, m::MIME"text/html", os::BadTransformSlider) = write(io, "<input type=range value=1>")
+                    
+                    Bonds.initial_value(os::BadTransformSlider) = "x"
+                    Bonds.transform_value(os::BadTransformSlider, from_js) = repeat("x", from_js)
+                end
+                """),
+                Cell("""
+                @bind x_badtransform BadTransformSlider()
+                """),
+                Cell("""
+                x_badtransform
+                """),
+                Cell("""
+                count = Ref(0)
+                """),
+                Cell("""
+                @bind x_counter NewSlider() #or OldSlider(), same idea
+                """),
+                Cell("""
+                let
+                    x_counter
+                    count[] += 1
+                end
+                """),
+            ])
+        fakeclient.connected_notebook = notebook
+
+        update_run!(🍭, notebook, notebook.cells)
+
+        @test noerror(notebook.cells[1])
+        @test noerror(notebook.cells[2])
+        @test noerror(notebook.cells[3])
+        @test noerror(notebook.cells[4])
+        @test noerror(notebook.cells[5])
+        @test noerror(notebook.cells[6])
+        @test noerror(notebook.cells[7])
+        @test noerror(notebook.cells[8])
+        
+        @test notebook.cells[3].output.body == "true"
+        @test notebook.cells[4].output.body == "true"
+        @test notebook.cells[5].output.body == "true"
+        @test notebook.cells[6].output.body == "true"
+        @test notebook.cells[7].output.body == "false"
+        @test notebook.cells[8].output.body == "false"
+        
+        
+        
+        
+        @test noerror(notebook.cells[9])
+        @test noerror(notebook.cells[10])
+        @test noerror(notebook.cells[11])
+        @test noerror(notebook.cells[12])
+        @test noerror(notebook.cells[13])
+        @test noerror(notebook.cells[14])
+        @test noerror(notebook.cells[15])
+        @test noerror(notebook.cells[16])
+        @test noerror(notebook.cells[17])
+        @test noerror(notebook.cells[18])
+        @test noerror(notebook.cells[19])
+        @test noerror(notebook.cells[20])
+        @test noerror(notebook.cells[21])
+        @test noerror(notebook.cells[22])
+        @test noerror(notebook.cells[23])
+        @test noerror(notebook.cells[24])
+        @test noerror(notebook.cells[25])
+        
+        
+        function set_bond_value(name, value, is_first_value=false)
+            notebook.bonds[name] = Dict("value" => value, "is_first_value" => is_first_value)
+            Pluto.set_bond_values_reactive(;
+                session=🍭,
+                notebook=notebook,
+                bound_sym_names=[name],
+                run_async=false,
+            )
+        end
+        
+        
+        @test notebook.cells[10].output.body == "missing"
+        set_bond_value(:x_simple, 1, true)
+        @test notebook.cells[10].output.body == "1"
+        
+        
+        @test notebook.cells[13].output.body == "1"
+        set_bond_value(:x_old, 1, true)
+        @test notebook.cells[13].output.body == "1"
+        set_bond_value(:x_old, 99, false)
+        @test notebook.cells[13].output.body == "99"
+        
+        
+        @test notebook.cells[16].output.body == "1"
+        set_bond_value(:x_new, 1, true)
+        @test notebook.cells[16].output.body == "1"
+        set_bond_value(:x_new, 99, false)
+        @test notebook.cells[16].output.body == "99"
+        
+        
+        @test notebook.cells[19].output.body == "\"x\""
+        set_bond_value(:x_transform, 1, true)
+        @test notebook.cells[19].output.body == "\"x\""
+        set_bond_value(:x_transform, 3, false)
+        @test notebook.cells[19].output.body == "\"xxx\""
+        
+        
+        @test notebook.cells[22].output.body != "missing"
+        set_bond_value(:x_badtransform, 1, true)
+        @test notebook.cells[22].output.body != "missing"
+        set_bond_value(:x_badtransform, 7, false)
+        @test notebook.cells[22].output.body != "missing"
+        
+        
+        @test notebook.cells[25].output.body == "1"
+        set_bond_value(:x_counter, 1, true)
+        @test notebook.cells[25].output.body == "1"
+        set_bond_value(:x_counter, 7, false)
+        @test notebook.cells[25].output.body == "2"
+        
+        
+        WorkspaceManager.unmake_workspace((🍭, notebook))
+        🍭.options.evaluation.workspace_use_distributed = false
+        
+    end
+end

--- a/test/Bonds.jl
+++ b/test/Bonds.jl
@@ -142,6 +142,15 @@ import Pluto: update_run!, WorkspaceManager, ClientSession, ServerSession, Noteb
                     count[] += 1
                 end
                 """),
+                Cell("""
+                @assert x_old == 1
+                """),
+                Cell("""
+                @assert x_new == 1
+                """),
+                Cell("""
+                @assert x_transform == "x"
+                """),
             ])
         fakeclient.connected_notebook = notebook
 
@@ -183,6 +192,9 @@ import Pluto: update_run!, WorkspaceManager, ClientSession, ServerSession, Noteb
         @test noerror(notebook.cells[23])
         @test noerror(notebook.cells[24])
         @test noerror(notebook.cells[25])
+        @test noerror(notebook.cells[26])
+        @test noerror(notebook.cells[27])
+        @test noerror(notebook.cells[28])
         
         
         function set_bond_value(name, value, is_first_value=false)
@@ -238,6 +250,16 @@ import Pluto: update_run!, WorkspaceManager, ClientSession, ServerSession, Noteb
         
         WorkspaceManager.unmake_workspace((🍭, notebook))
         🍭.options.evaluation.workspace_use_distributed = false
+        
+        
+        @test jl_is_runnable(notebook.path)
+        
+        # should_not_run = """
+        # @assert 1 == 2
+        # """
+        # p = tempname()
+        # write(p, should_not_run)
+        # @test !jl_is_runnable(p)
         
     end
 end

--- a/test/Bonds.jl
+++ b/test/Bonds.jl
@@ -20,7 +20,7 @@ import Pluto: update_run!, WorkspaceManager, ClientSession, ServerSession, Noteb
                         Pkg.UPDATED_REGISTRY_THIS_SESSION[] = true
                     catch; end
                     Pkg.activate(mktempdir())
-                    Pkg.add(Pkg.PackageSpec(name="AbstractPlutoDingetjes", rev="0494e5a"))
+                    Pkg.add(Pkg.PackageSpec(name="AbstractPlutoDingetjes", rev="30f4f76"))
                     import AbstractPlutoDingetjes
                     const APD = AbstractPlutoDingetjes
                     import AbstractPlutoDingetjes.Bonds

--- a/test/ExpressionExplorer.jl
+++ b/test/ExpressionExplorer.jl
@@ -456,10 +456,10 @@ Some of these @test_broken lines are commented out to prevent printing to the te
         @test testee(:(Base.@kwdef struct A; x = 1; y::Int = two; z end), [], [], [], [], [[:Base, Symbol("@kwdef")]])
         @test testee(quote "asdf" f(x) = x end, [], [], [], [], [Symbol("@doc")])
 
-        @test testee(:(@bind a b), [:b, :PlutoRunner, :Base, :Core], [:a], [[:PlutoRunner, :Bond], [:Core, :applicable], [:Base, :get]], [], [Symbol("@bind")])
-        @test testee(:(PlutoRunner.@bind a b), [:b, :PlutoRunner, :Base, :Core], [:a], [[:PlutoRunner, :Bond], [:Core, :applicable], [:Base, :get]], [], [[:PlutoRunner, Symbol("@bind")]])
-        @test_broken testee(:(Main.PlutoRunner.@bind a b), [:b, :PlutoRunner, :Base, :Core], [:a], [[:Base, :get], [:Core, :applicable], [:PlutoRunner, :Bond], [:PlutoRunner, Symbol("@bind")]], [], verbose=false)
-        @test testee(:(let @bind a b end), [:b, :PlutoRunner, :Base, :Core], [:a], [[:PlutoRunner, :Bond], [:Core, :applicable], [:Base, :get]], [], [Symbol("@bind")])
+        @test testee(:(@bind a b), [:b, :PlutoRunner, :Base, :Core], [:a], [[:PlutoRunner, :create_bond], [:Core, :applicable], [:Base, :get]], [], [Symbol("@bind")])
+        @test testee(:(PlutoRunner.@bind a b), [:b, :PlutoRunner, :Base, :Core], [:a], [[:PlutoRunner, :create_bond], [:Core, :applicable], [:Base, :get]], [], [[:PlutoRunner, Symbol("@bind")]])
+        @test_broken testee(:(Main.PlutoRunner.@bind a b), [:b, :PlutoRunner, :Base, :Core], [:a], [[:Base, :get], [:Core, :applicable], [:PlutoRunner, :create_bond], [:PlutoRunner, Symbol("@bind")]], [], verbose=false)
+        @test testee(:(let @bind a b end), [:b, :PlutoRunner, :Base, :Core], [:a], [[:PlutoRunner, :create_bond], [:Core, :applicable], [:Base, :get]], [], [Symbol("@bind")])
 
         @test testee(:(@asdf a = x1 b = x2 c = x3), [], [], [], [], [Symbol("@asdf")]) # https://github.com/fonsp/Pluto.jl/issues/670
 
@@ -468,8 +468,8 @@ Some of these @test_broken lines are commented out to prevent printing to the te
         @test testee(:(Pack.@asdf a[1,k[j]] := log(x[i]/y[j])), [], [], [], [], [[:Pack, Symbol("@asdf")]])
 
         @test testee(:(`hey $(a = 1) $(b)`), [:b], [], [:cmd_gen], [], [Symbol("@cmd")])
-        @test testee(:(md"hey $(@bind a b) $(a)"), [:b, :PlutoRunner, :Base, :Core], [:a], [[:PlutoRunner, :Bond], [:Core, :applicable], [:Base, :get], :getindex], [], [Symbol("@md_str"), Symbol("@bind")])
-        @test testee(:(md"hey $(a) $(@bind a b)"), [:a, :b, :PlutoRunner, :Base, :Core], [:a], [[:PlutoRunner, :Bond], [:Core, :applicable], [:Base, :get], :getindex], [], [Symbol("@md_str"), Symbol("@bind")])
+        @test testee(:(md"hey $(@bind a b) $(a)"), [:b, :PlutoRunner, :Base, :Core], [:a], [[:PlutoRunner, :create_bond], [:Core, :applicable], [:Base, :get], :getindex], [], [Symbol("@md_str"), Symbol("@bind")])
+        @test testee(:(md"hey $(a) $(@bind a b)"), [:a, :b, :PlutoRunner, :Base, :Core], [:a], [[:PlutoRunner, :create_bond], [:Core, :applicable], [:Base, :get], :getindex], [], [Symbol("@md_str"), Symbol("@bind")])
         @test testee(:(html"a $(b = c)"), [], [], [], [], [Symbol("@html_str")])
         @test testee(:(md"a $(b = c) $(b)"), [:c], [:b], [:getindex], [], [Symbol("@md_str")])
         @test testee(:(md"\* $r"), [:r], [], [:getindex], [], [Symbol("@md_str")])

--- a/test/RichOutput.jl
+++ b/test/RichOutput.jl
@@ -198,7 +198,6 @@ import Pluto: update_run!, WorkspaceManager, ClientSession, ServerSession, Noteb
         end
     end
 
-    
     @testset "Table viewer" begin
         🍭.options.evaluation.workspace_use_distributed = true
         notebook = Notebook([

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ include("./helpers.jl")
 # tests that start new processes:
 include("./WorkspaceManager.jl")
 include("./packages/Basic.jl")
+include("./Bonds.jl")
 VERSION > v"1.6.99" || include("./RichOutput.jl")
 include("./React.jl")
 include("./Dynamic.jl")


### PR DESCRIPTION
We have a new package https://github.com/JuliaPluto/AbstractPlutoDingetjes.jl that will be used by packages like PlutoUI to declare:
- The initial bond value (this is currently done with `Base.get` but that's hacky and not future-proof
- A pretransformation of bond values before assigning them to the bound variable, see https://github.com/JuliaPluto/PlutoUI.jl/issues/3#issuecomment-629724036
- The set of possible values, needed for https://github.com/JuliaPluto/PlutoSliderServer.jl/pull/29
- Validation of the bond value, needed to make PlutoSliderServer.jl more secure


https://user-images.githubusercontent.com/6933510/139685113-1f4fc1e3-90a2-45c8-a760-8e87cd741543.mov


TODO:
- [x] Wait for https://github.com/JuliaRegistries/General/pull/47710 before merging
- [x] Implement the pretransform
- [x] Tests for those things inside a Pluto notebook
- [x] Tests for those things when running the notebook outside of pluto
