### PR TITLE
Remove trailing and leading single/double quotes from path

### DIFF
--- a/frontend/components/Welcome.js
+++ b/frontend/components/Welcome.js
@@ -74,6 +74,11 @@ export const process_path_or_url = async (path_or_url) => {
             path_or_url: u.href,
         }
     } catch (ex) {
+        /* Remove eventual double quotes from the path */
+        const last_char = path_or_url[path_or_url.length-1]
+        if (last_char == '"' || last_char == "'") {
+            path_or_url = path_or_url.replace(/^['"]/,"").replace(/['"]$/,"")
+        } 
         return {
             type: "path",
             path_or_url: path_or_url,

--- a/frontend/components/Welcome.js
+++ b/frontend/components/Welcome.js
@@ -215,7 +215,6 @@ export class Welcome extends Component {
 
         this.on_open_path = async (new_path) => {
             const processed = await process_path_or_url(new_path)
-            console.log(processed)
             if (processed.type === "path") {
                 document.body.classList.add("loading")
                 window.location.href = link_open_path(processed.path_or_url)

--- a/frontend/components/Welcome.js
+++ b/frontend/components/Welcome.js
@@ -74,10 +74,11 @@ export const process_path_or_url = async (path_or_url) => {
             path_or_url: u.href,
         }
     } catch (ex) {
-        /* Remove eventual double quotes from the path */
+        /* Remove eventual single/double quotes from the path if they surround it, see
+         * https://github.com/fonsp/Pluto.jl/issues/1639 */
         const last_char = path_or_url[path_or_url.length-1]
-        if (last_char == '"' || last_char == "'") {
-            path_or_url = path_or_url.replace(/^['"]/,"").replace(/['"]$/,"")
+        if (last_char == path_or_url[0] && (last_char == '"' || last_char == "'")) {
+            path_or_url = path_or_url.substring(1,path_or_url.length-1) /* Remove first and last character */
         } 
         return {
             type: "path",

--- a/frontend/components/Welcome.js
+++ b/frontend/components/Welcome.js
@@ -75,11 +75,10 @@ export const process_path_or_url = async (path_or_url) => {
         }
     } catch (ex) {
         /* Remove eventual single/double quotes from the path if they surround it, see
-         * https://github.com/fonsp/Pluto.jl/issues/1639 */
-        const last_char = path_or_url[path_or_url.length-1]
-        if (last_char == path_or_url[0] && (last_char == '"' || last_char == "'")) {
-            path_or_url = path_or_url.substring(1,path_or_url.length-1) /* Remove first and last character */
-        } 
+          https://github.com/fonsp/Pluto.jl/issues/1639 */
+        if (path_or_url[path_or_url.length - 1] === '"' && path_or_url[0] === '"') {
+            path_or_url = path_or_url.slice(1, -1) /* Remove first and last character */
+        }
         return {
             type: "path",
             path_or_url: path_or_url,
@@ -216,6 +215,7 @@ export class Welcome extends Component {
 
         this.on_open_path = async (new_path) => {
             const processed = await process_path_or_url(new_path)
+            console.log(processed)
             if (processed.type === "path") {
                 document.body.classList.add("loading")
                 window.location.href = link_open_path(processed.path_or_url)


### PR DESCRIPTION
Fixes https://github.com/fonsp/Pluto.jl/issues/1639

Should not break existing valid names containing quotes as it only remove the trailing and leading character if there is a quote after the notebook extension