### PR TITLE
make soft edges break on dependencies cycle

### DIFF
--- a/src/analysis/Errors.jl
+++ b/src/analysis/Errors.jl
@@ -9,8 +9,8 @@ end
 
 function CyclicReferenceError(topology::NotebookTopology, cycle::Cell...)
 	referenced_during_cycle = union((topology.nodes[c].references for c in cycle)...)
-	assigned_during_cycle = union((topology.nodes[c].definitions ∪ topology.nodes[c].funcdefs_without_signatures for c in cycle)...)
-	
+	assigned_during_cycle = union((topology.nodes[c].definitions ∪ topology.nodes[c].soft_definitions ∪ topology.nodes[c].funcdefs_without_signatures for c in cycle)...)
+
 	CyclicReferenceError(referenced_during_cycle ∩ assigned_during_cycle)
 end
 

--- a/src/analysis/ExpressionExplorer.jl
+++ b/src/analysis/ExpressionExplorer.jl
@@ -530,24 +530,26 @@ function explore!(ex::Expr, scopestate::ScopeState)::SymbolsState
         innerscopestate.inglobalscope = false
 
         funcname, innersymstate = explore_funcdef!(funcroot, innerscopestate)
-        # Macro are called using @funcname, but defined with funcname. We need to change that in our scopestate
-        # (The `!= 0` is for when the function named couldn't be parsed)
-        if ex.head == :macro && length(funcname) != 0
-            setdiff!(innerscopestate.hiddenglobals, funcname)
-            funcname = Symbol[Symbol("@$(funcname[1])")]
-            push!(innerscopestate.hiddenglobals, funcname...)
-        end
-
-        union!(innersymstate, explore!(Expr(:block, ex.args[2:end]...), innerscopestate))
-        
-        funcnamesig = FunctionNameSignaturePair(funcname, canonalize(funcroot))
 
         if length(funcname) == 1
             push!(scopestate.definedfuncs, funcname[end])
             push!(scopestate.hiddenglobals, funcname[end])
         elseif length(funcname) > 1
             push!(symstate.references, funcname[end - 1]) # reference the module of the extended function
+            push!(scopestate.hiddenglobals, funcname[end - 1])
         end
+
+        # Macro are called using @funcname, but defined with funcname. We need to change that in our scopestate
+        # (The `!= 0` is for when the function named couldn't be parsed)
+        if ex.head == :macro && length(funcname) != 0
+            setdiff!(innerscopestate.hiddenglobals, funcname)
+            funcname = Symbol[Symbol("@$(funcname[1])")]
+            push!(innerscopestate.hiddenglobals, only(funcname))
+        end
+
+        union!(innersymstate, explore!(Expr(:block, ex.args[2:end]...), innerscopestate))
+        
+        funcnamesig = FunctionNameSignaturePair(funcname, canonalize(funcroot))
 
         if will_assign_global(funcname, scopestate)
             symstate.funcdefs[funcnamesig] = innersymstate

--- a/src/analysis/ReactiveNode.jl
+++ b/src/analysis/ReactiveNode.jl
@@ -55,12 +55,12 @@ function ReactiveNode(symstate::SymbolsState)
 		push!(result.funcdefs_without_signatures, join_funcname_parts(namesig.name))
 
 		generated_names = generate_funcnames(namesig.name)
-
-		# new_sigs = map(name -> FunctionNameSignaturePair(name, namesig.canonicalized_head), generated_names)
-		# union!(result.funcdefs_with_signatures, new_sigs)
-
 		generated_names_syms = Set{Symbol}(join_funcname_parts.(generated_names))
+
+		# add the generated names so that they are added as soft definitions
+		# this means that they will not be used if a cycle is created
 		union!(result.soft_definitions, generated_names_syms)
+
 		filter!(!∈(generated_names_syms), result.references) # don't reference defined functions (simulated recursive calls)
 	end
 

--- a/src/analysis/ReactiveNode.jl
+++ b/src/analysis/ReactiveNode.jl
@@ -55,12 +55,12 @@ function ReactiveNode(symstate::SymbolsState)
 		push!(result.funcdefs_without_signatures, join_funcname_parts(namesig.name))
 
 		generated_names = generate_funcnames(namesig.name)
-		new_sigs = map(name -> FunctionNameSignaturePair(name, namesig.canonicalized_head), generated_names)
 
-		union!(result.funcdefs_with_signatures, new_sigs)
+		# new_sigs = map(name -> FunctionNameSignaturePair(name, namesig.canonicalized_head), generated_names)
+		# union!(result.funcdefs_with_signatures, new_sigs)
 
 		generated_names_syms = Set{Symbol}(join_funcname_parts.(generated_names))
-		union!(result.funcdefs_without_signatures, generated_names_syms)
+		union!(result.soft_definitions, generated_names_syms)
 		filter!(!∈(generated_names_syms), result.references) # don't reference defined functions (simulated recursive calls)
 	end
 

--- a/src/analysis/topological_order.jl
+++ b/src/analysis/topological_order.jl
@@ -32,7 +32,7 @@ function topological_order(notebook::Notebook, topology::NotebookTopology, roots
 
 		# used for cleanups of wrong cycles
 		current_entries_num = length(entries)
-		current_exits_num = length(exists)
+		current_exits_num = length(exits)
 
 		assigners = where_assigned(notebook, topology, cell)
 		if !allow_multiple_defs && length(assigners) > 1


### PR DESCRIPTION
This prevents soft definitions from creating dependencies cycles by "breaking" the soft definition dependency if a cycle is created.

<details>


![soft_cycle](https://user-images.githubusercontent.com/9824244/141850785-2ea53d20-07b5-46a2-b35c-44d49f6c09c1.gif)

</details>

This currently needs more edge cases tests.

Fixes #1579, fixes #1622