### PR TITLE
Fix world age issues causing 404 on master

### DIFF
--- a/src/webserver/WebServer.jl
+++ b/src/webserver/WebServer.jl
@@ -117,11 +117,15 @@ end
 Specifiy the [`Pluto.ServerSession`](@ref) to run the web server on, which includes the configuration. Passing a session as argument allows you to start the web server with some notebooks already running. See [`SessionActions`](@ref) to learn more about manipulating a `ServerSession`.
 """
 function run(session::ServerSession)
+    pluto_router = http_router_for(session)
+    Base.invokelatest(run, session, pluto_router)
+end
+
+function run(session::ServerSession, pluto_router)
 
     notebook_at_startup = session.options.server.notebook
     open_notebook!(session, notebook_at_startup)
 
-    pluto_router = http_router_for(session)
     host = session.options.server.host
     port = session.options.server.port
 


### PR DESCRIPTION
The HTTP docs caution:
```
Note that due to being a macro (and the internal routing functionality), routes can only be registered
statically, i.e. at the top level of a module, and not dynamically, i.e. inside a function.
```

Pluto ignores this restriction causing 404 issues on nightly (#1672).
Before 1.8, Pluto was relying on undefined behavior causing tasks
to potentially start in a newer world than their definition point,
making this work by accident. This is the minimal fix to restore
Pluto to good functioning, but it's probably worth taking another
look at whether generating new routes every time this method is
invoked is really the intended behavior.