### PR TITLE
Fix result nothing error

### DIFF
--- a/src/evaluation/Run.jl
+++ b/src/evaluation/Run.jl
@@ -352,7 +352,9 @@ function resolve_topology(
 				# set function_wrapped to the function wrapped analysis of the expanded expression.
 				new_codes[cell] = ExprAnalysisCache(unresolved_topology.codes[cell]; forced_expr_id, function_wrapped)
 			else
-				@debug "Expansion failed" err=result.error
+				if result isa Failure
+					@debug "Expansion failed" err=result.error
+				end
 				push!(still_unresolved_nodes, cell)
 			end
 	end

--- a/src/evaluation/Run.jl
+++ b/src/evaluation/Run.jl
@@ -266,6 +266,7 @@ end
 struct Failure <: Result
 	error
 end
+struct Skipped <: Result end
 
 """We still have 'unresolved' macrocalls, use the current and maybe previous workspace to do macro-expansions.
 
@@ -309,7 +310,7 @@ function resolve_topology(
 
 	function analyze_macrocell(cell::Cell)
 		if unresolved_topology.nodes[cell].macrocalls ⊆ ExpressionExplorer.can_macroexpand
-			return nothing
+			return Skipped()
 		end
 
 		result = macroexpand_cell(cell)


### PR DESCRIPTION
I was getting some errors in PlutoSliderServer:
https://github.com/JuliaPluto/static-export-template/runs/4311192413?check_suite_focus=true#step:5:447

This fixes the error, but maybe there was an oversight? Maybe https://github.com/fonsp/Pluto.jl/blob/71be998c71f1c488f4a486748ef8d4c73e6fdd4a/src/evaluation/Run.jl#L312 should return a third subtype `struct Skipped <: Result end` instead of `nothing`?