### PR TITLE
remove time warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,6 @@ julia> ]
 (v1.6) pkg> add Pluto
 ```
 
-_Using the package manager for the first time after installing Julia can take up to 15 minutes - hang in there!_
-
 _Tip for new Julia users: To return to the `julia>` prompt from the Pkg REPL,
 either press backspace when the input line is empty or press Ctrl+C._
 


### PR DESCRIPTION
This no longer seems necessary... ?

On 1.6 it is almost immediate for me, after fresh install (call it 20 seconds on a 2019 iMac). The warning suggests caution that isn't warranted. 