### PR TITLE
Very Draft: Local state global sync

### DIFF
--- a/frontend/components/Cell.js
+++ b/frontend/components/Cell.js
@@ -169,7 +169,7 @@ export const Cell = ({
             </button>
             ${cell_api_ready ? html`<${CellOutput} errored=${errored} ...${output} cell_id=${cell_id} />` : html``}
             <${CellInput}
-                local_code=${cell_input_local?.code ?? code}
+                cell_input_local=${cell_input_local}
                 remote_code=${code}
                 cell_dependencies=${cell_dependencies}
                 variables_in_all_notebook=${variables_in_all_notebook}

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -128,7 +128,7 @@ let line_and_ch_to_cm6_position = (/** @type {import("../imports/CodemirrorPluto
  * }} props
  */
 export const CellInput = ({
-    local_code,
+    cell_input_local,
     remote_code,
     disable_input,
     focus_after_creation,
@@ -150,11 +150,12 @@ export const CellInput = ({
     variables_in_all_notebook,
 }) => {
     let pluto_actions = useContext(PlutoContext)
-
+    const client_id = pluto_actions.get_client_id()
+    const { code: local_code, local_code_owner_uuid, time_arrow } = cell_input_local || {}
     const newcm_ref = useRef(/** @type {EditorView} */ (null))
     const dom_node_ref = useRef(/** @type {HTMLElement} */ (null))
     const remote_code_ref = useRef(null)
-    const own_local_code_ref = useRef(null)
+    const suppress_next_event = useRef(time_arrow || 0)
     const on_change_ref = useRef(null)
     on_change_ref.current = on_change
 
@@ -168,8 +169,8 @@ export const CellInput = ({
         useMemo(() => {
             return EditorView.updateListener.of((update) => {
                 if (update.docChanged) {
-                    const text = own_local_code_ref.current = update.state.doc.toString()
-                    on_change(text)
+                    if (suppress_next_event.current === true) on_change(update.state.doc.toString())
+                    else suppress_next_event.current = true
                 }
             })
         }, [on_change])
@@ -473,14 +474,15 @@ export const CellInput = ({
     }, [remote_code])
 
     useEffect(() => {
-        if (newcm_ref.current == null) return // Not sure when and why this gave an error, but now it doesn't
-
         const current_value = getValue6(newcm_ref.current) ?? ""
-        
-        if (current_value !== local_code && own_local_code_ref.current !== local_code ) {
+        const will_update_code = local_code_owner_uuid !== client_id && current_value !== local_code && suppress_next_event.current < time_arrow
+        if (will_update_code) {
+            // This is terrible, but it's basically, if we're updating the local code,
+            // the next event shouldn't fire at all.
+            suppress_next_event.current = false
             setValue6(newcm_ref.current, local_code)
         }
-    }, [local_code])
+    }, [local_code, time_arrow])
 
     useEffect(() => {
         const cm = newcm_ref.current

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -154,6 +154,7 @@ export const CellInput = ({
     const newcm_ref = useRef(/** @type {EditorView} */ (null))
     const dom_node_ref = useRef(/** @type {HTMLElement} */ (null))
     const remote_code_ref = useRef(null)
+    const own_local_code_ref = useRef(null)
     const on_change_ref = useRef(null)
     on_change_ref.current = on_change
 
@@ -167,7 +168,8 @@ export const CellInput = ({
         useMemo(() => {
             return EditorView.updateListener.of((update) => {
                 if (update.docChanged) {
-                    on_change(update.state.doc.toString())
+                    const text = own_local_code_ref.current = update.state.doc.toString()
+                    on_change(text)
                 }
             })
         }, [on_change])
@@ -469,6 +471,16 @@ export const CellInput = ({
             setValue6(newcm_ref.current, remote_code)
         }
     }, [remote_code])
+
+    useEffect(() => {
+        if (newcm_ref.current == null) return // Not sure when and why this gave an error, but now it doesn't
+
+        const current_value = getValue6(newcm_ref.current) ?? ""
+        
+        if (current_value !== local_code && own_local_code_ref.current !== local_code ) {
+            setValue6(newcm_ref.current, local_code)
+        }
+    }, [local_code])
 
     useEffect(() => {
         const cm = newcm_ref.current

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -155,7 +155,7 @@ export const CellInput = ({
     const newcm_ref = useRef(/** @type {EditorView} */ (null))
     const dom_node_ref = useRef(/** @type {HTMLElement} */ (null))
     const remote_code_ref = useRef(null)
-    const suppress_next_event = useRef(time_arrow || 0)
+    const suppress_next_event = useRef(false)
     const on_change_ref = useRef(null)
     on_change_ref.current = on_change
 
@@ -475,14 +475,14 @@ export const CellInput = ({
 
     useEffect(() => {
         const current_value = getValue6(newcm_ref.current) ?? ""
-        const will_update_code = local_code_owner_uuid !== client_id && current_value !== local_code && suppress_next_event.current < time_arrow
+        const will_update_code = local_code_owner_uuid !== client_id && current_value !== local_code
         if (will_update_code) {
             // This is terrible, but it's basically, if we're updating the local code,
             // the next event shouldn't fire at all.
             suppress_next_event.current = false
             setValue6(newcm_ref.current, local_code)
         }
-    }, [local_code, time_arrow])
+    }, [local_code])
 
     useEffect(() => {
         const cm = newcm_ref.current

--- a/frontend/components/Notebook.js
+++ b/frontend/components/Notebook.js
@@ -102,7 +102,6 @@ const render_cell_outputs_minimum = 20
  * */
 export const Notebook = ({
     notebook,
-    cell_inputs_local,
     on_update_doc_query,
     on_cell_input,
     on_focus_neighbor,
@@ -151,7 +150,11 @@ export const Notebook = ({
                         }}
                         cell_input=${notebook.cell_inputs[cell_id]}
                         cell_dependencies=${notebook.cell_dependencies[cell_id] ?? {}}
-                        cell_input_local=${{code: notebook.cell_inputs[cell_id].local_code}}
+                        cell_input_local=${{
+                            code: notebook.cell_inputs[cell_id].local_code,
+                            local_code_owner_uuid: notebook.cell_inputs[cell_id].local_code_owner_uuid,
+                            time_arrow: notebook.cell_inputs[cell_id].time_arrow,
+                        }}
                         notebook_id=${notebook.notebook_id}
                         on_update_doc_query=${on_update_doc_query}
                         on_cell_input=${on_cell_input}

--- a/frontend/components/Notebook.js
+++ b/frontend/components/Notebook.js
@@ -151,7 +151,7 @@ export const Notebook = ({
                         }}
                         cell_input=${notebook.cell_inputs[cell_id]}
                         cell_dependencies=${notebook.cell_dependencies[cell_id] ?? {}}
-                        cell_input_local=${cell_inputs_local[cell_id]}
+                        cell_input_local=${{code: notebook.cell_inputs[cell_id].local_code}}
                         notebook_id=${notebook.notebook_id}
                         on_update_doc_query=${on_update_doc_query}
                         on_cell_input=${on_cell_input}

--- a/frontend/components/Welcome.js
+++ b/frontend/components/Welcome.js
@@ -7,6 +7,9 @@ import { cl } from "../common/ClassTable.js"
 import { PasteHandler } from "./PasteHandler.js"
 import { alert, confirm } from "../common/alert_confirm.js"
 
+const get_path = (p) => (typeof p === "object" ? p.path : p) ?? ""
+const get_url = (p) => (typeof p === "object" ? p.url : p) ?? ""
+
 const create_empty_notebook = (path, notebook_id = null) => {
     return {
         transitioning: false, // between running and being shut down
@@ -15,13 +18,17 @@ const create_empty_notebook = (path, notebook_id = null) => {
     }
 }
 
-const split_at_level = (path, level) => path.split(/\/|\\/).slice(-level).join("/")
+const split_at_level = (path = "", level = 1) => {
+    return get_path(path).split(/\/|\\/)?.slice(-level)?.join("/")
+}
 
-const shortest_path = (path, allpaths) => {
+const shortest_path = (maybepath, allpaths) => {
+    const path = get_path(maybepath)
+    const paths = allpaths.map(get_path)
     let level = 1
-    for (const otherpath of allpaths) {
+    for (const otherpath of paths) {
         if (otherpath !== path) {
-            while (split_at_level(path, level) === split_at_level(otherpath, level)) {
+            while (split_at_level(String(path), level) === split_at_level(String(otherpath), level)) {
                 level++
             }
         }
@@ -88,8 +95,8 @@ export const process_path_or_url = async (path_or_url) => {
 }
 
 // /open will execute a script from your hard drive, so we include a token in the URL to prevent a mean person from getting a bad file on your computer _using another hypothetical intrusion_, and executing it using Pluto
-export const link_open_path = (path) => "open?" + new URLSearchParams({ path: path }).toString()
-export const link_open_url = (url) => "open?" + new URLSearchParams({ url: url }).toString()
+export const link_open_path = (path) => "open?" + new URLSearchParams({ path: get_path(path) }).toString()
+export const link_open_url = (url) => "open?" + new URLSearchParams({ url: get_url(url) }).toString()
 export const link_edit = (notebook_id) => "edit?id=" + notebook_id
 
 export class Welcome extends Component {
@@ -304,7 +311,7 @@ export class Welcome extends Component {
                     </button>
                     <a
                         href=${running ? link_edit(nb.notebook_id) : link_open_path(nb.path)}
-                        title=${nb.path}
+                        title=${get_path(nb.path)}
                         onClick=${(e) => {
                             document.body.classList.add("loading")
                             this.set_notebook_state(nb.path, {

--- a/frontend/imports/CodemirrorPlutoSetup.js
+++ b/frontend/imports/CodemirrorPlutoSetup.js
@@ -44,7 +44,8 @@ import {
     indentUnit,
     combineConfig,
     NodeProp,
-} from "https://cdn.jsdelivr.net/gh/JuliaPluto/codemirror-pluto-setup@0.19.2/dist/index.es.min.js"
+    Annotation,
+} from "https://cdn.jsdelivr.net/gh/JuliaPluto/codemirror-pluto-setup@582d0ba6d0e6ed485549eb89c2869c0fe0c8b142/dist/index.es.min.js"
 
 export {
     EditorState,
@@ -92,4 +93,5 @@ export {
     indentUnit,
     combineConfig,
     NodeProp,
+    Annotation,
 }

--- a/src/notebook/Cell.jl
+++ b/src/notebook/Cell.jl
@@ -28,6 +28,7 @@ Base.@kwdef mutable struct Cell
     cell_id::UUID=uuid1()
 
     code::String=""
+    local_code::String=""
     code_folded::Bool=false
     
     output::CellOutput=CellOutput()

--- a/src/notebook/Cell.jl
+++ b/src/notebook/Cell.jl
@@ -29,6 +29,8 @@ Base.@kwdef mutable struct Cell
 
     code::String=""
     local_code::String=""
+    local_code_owner_uuid::String=""
+    time_arrow::Integer=0
     code_folded::Bool=false
     
     output::CellOutput=CellOutput()

--- a/src/notebook/Notebook.jl
+++ b/src/notebook/Notebook.jl
@@ -25,7 +25,7 @@ Base.@kwdef mutable struct Notebook
     "Cells are ordered in a `Notebook`, and this order can be changed by the user. Cells will always have a constant UUID."
     cells_dict::Dict{UUID,Cell}
     cell_order::Array{UUID,1}
-    
+
     path::String
     notebook_id::UUID=uuid1()
     topology::NotebookTopology=NotebookTopology()

--- a/src/notebook/Notebook.jl
+++ b/src/notebook/Notebook.jl
@@ -103,7 +103,7 @@ In the produced file, cells are not saved in the notebook order. If `notebook.to
 
 Have a look at our [JuliaCon 2020 presentation](https://youtu.be/IAF8DjrQSSk?t=1085) to learn more!
 """
-function save_notebook(io, notebook::Notebook)
+function save_notebook(io, notebook::Notebook, serialize_temp=false)
     println(io, _notebook_header)
     println(io, "# ", PLUTO_VERSION_STR)
     # Anything between the version string and the first UUID delimiter will be ignored by the notebook loader.
@@ -111,7 +111,7 @@ function save_notebook(io, notebook::Notebook)
     println(io, "using Markdown")
     println(io, "using InteractiveUtils")
     # Super Advanced Code Analysis™ to add the @bind macro to the saved file if it's used somewhere.
-    if any(occursin("@bind", c.code) for c in notebook.cells)
+    if any(occursin("@bind", serialize_temp ? c.local_code : c.code) for c in notebook.cells)
         println(io, "")
         println(io, "# This Pluto notebook uses @bind for interactivity. When running this notebook outside of Pluto, the following 'mock version' of @bind gives bound variables a default value (instead of an error).")
         println(io, PlutoRunner.fake_bind)
@@ -123,7 +123,7 @@ function save_notebook(io, notebook::Notebook)
     for c in cells_ordered
         println(io, _cell_id_delimiter, string(c.cell_id))
         # write the cell code and prevent collisions with the cell delimiter
-        print(io, replace(c.code, _cell_id_delimiter => "# "))
+        print(io, replace(serialize_temp ? c.local_code : c.code, _cell_id_delimiter => "# "))
         print(io, _cell_suffix)
     end
 

--- a/src/notebook/Notebook.jl
+++ b/src/notebook/Notebook.jl
@@ -111,11 +111,9 @@ function save_notebook(io, notebook::Notebook, serialize_temp=false)
     println(io, "using Markdown")
     println(io, "using InteractiveUtils")
     # Super Advanced Code Analysis™ to add the @bind macro to the saved file if it's used somewhere.
-    if any(occursin("@bind", serialize_temp ? c.local_code : c.code) for c in notebook.cells)
-        println(io, "")
-        println(io, "# This Pluto notebook uses @bind for interactivity. When running this notebook outside of Pluto, the following 'mock version' of @bind gives bound variables a default value (instead of an error).")
-        println(io, PlutoRunner.fake_bind)
-    end
+    println(io, "")
+    println(io, "# This Pluto notebook uses @bind for interactivity. When running this notebook outside of Pluto, the following 'mock version' of @bind gives bound variables a default value (instead of an error).")
+    println(io, PlutoRunner.fake_bind)
     println(io)
 
     cells_ordered = collect(topological_order(notebook))

--- a/src/webserver/Dynamic.jl
+++ b/src/webserver/Dynamic.jl
@@ -101,9 +101,10 @@ function notebook_to_js(notebook::Notebook)
         "process_status" => notebook.process_status,
         "last_save_time" => notebook.last_save_time,
         "last_hot_reload_time" => notebook.last_hot_reload_time,
-        "cell_inputs" => Dict{UUID,Dict{String,Any}}(
+        "cell_inputs" => Dict{UUID, Dict{String,Any}}(
             id => Dict{String,Any}(
                 "cell_id" => cell.cell_id,
+                "local_code" => cell.local_code,
                 "code" => cell.code,
                 "code_folded" => cell.code_folded,
                 "running_disabled" => cell.running_disabled,

--- a/src/webserver/Dynamic.jl
+++ b/src/webserver/Dynamic.jl
@@ -105,6 +105,8 @@ function notebook_to_js(notebook::Notebook)
             id => Dict{String,Any}(
                 "cell_id" => cell.cell_id,
                 "local_code" => cell.local_code,
+                "local_code_owner_uuid" => cell.local_code_owner_uuid,
+                "time_arrow" => cell.time_arrow,
                 "code" => cell.code,
                 "code_folded" => cell.code_folded,
                 "running_disabled" => cell.running_disabled,


### PR DESCRIPTION
Developers only PR

Idea: Sync local code with backend and across open tabs.
This PR more for note taking than for review at this point, so tread carefully!

Current approach: 
- [X]  Extend `Cell` to have `local_code`. Currently this is `text` but may become `[string]` to support history?
- [X] Sync local_code between server & backend
- [ ] Add a cursor_list as `{cell_uuid: {user: int}}`. add a colorful cursor with a fancy name
- [ ] (todo) address control+Z ??

