### PR TITLE
Bundle on every commit

### DIFF
--- a/.github/workflows/Bundle.yml
+++ b/.github/workflows/Bundle.yml
@@ -2,12 +2,7 @@ name: Bundle Web Assets
 
 on:
     push:
-        paths:
-            - "frontend/**"
-            - "frontend-bundler/**"
-            - ".github/workflows/Bundle.yml"
         branches:
-            - bundled
             - main
     workflow_dispatch:
 


### PR DESCRIPTION
Not just on commits to `frontend/` because:
We want to register a new Pluto version on the last commit on `release`, which should include all changes that we made on `main`. For example, if we update `Project.toml` to bump the version number, we should have a commit that has that new Project.toml, and the bundled assets.