### PR TITLE
Global storage for published objects

### DIFF
--- a/frontend/components/Cell.js
+++ b/frontend/components/Cell.js
@@ -7,14 +7,17 @@ import { cl } from "../common/ClassTable.js"
 import { useDropHandler } from "./useDropHandler.js"
 import { PlutoContext } from "../common/PlutoContext.js"
 
-const useCellApi = (node_ref, published_objects, pluto_actions) => {
+const useCellApi = (node_ref, published_object_keys, pluto_actions) => {
     const [cell_api_ready, set_cell_api_ready] = useState(false)
-    const published_objects_ref = useRef(published_objects)
-    published_objects_ref.current = published_objects
-    
+    const published_object_keys_ref = useRef(published_object_keys)
+    published_object_keys_ref.current = published_object_keys
+
     useLayoutEffect(() => {
         Object.assign(node_ref.current, {
-            getPublishedObject: (id) => published_objects_ref.current[id],
+            getPublishedObject: (id) => {
+                if (!published_object_keys_ref.current.includes(id)) throw `getPublishedObject: ${id} not found`
+                return pluto_actions.get_published_object(id)
+            },
             _internal_pluto_actions: pluto_actions,
         })
 
@@ -39,7 +42,7 @@ const useCellApi = (node_ref, published_objects, pluto_actions) => {
  * */
 export const Cell = ({
     cell_input: { cell_id, code, code_folded, running_disabled },
-    cell_result: { queued, running, runtime, errored, output, published_objects, depends_on_disabled_cells },
+    cell_result: { queued, running, runtime, errored, output, published_object_keys, depends_on_disabled_cells },
     cell_dependencies,
     cell_input_local,
     notebook_id,
@@ -114,7 +117,7 @@ export const Cell = ({
     should_set_waiting_to_run_ref.current = !running_disabled && !depends_on_disabled_cells
     const set_waiting_to_run_smart = (x) => set_waiting_to_run(x && should_set_waiting_to_run_ref.current)
 
-    const cell_api_ready = useCellApi(node_ref, published_objects, pluto_actions)
+    const cell_api_ready = useCellApi(node_ref, published_object_keys, pluto_actions)
 
     return html`
         <pluto-cell
@@ -238,15 +241,10 @@ export const Cell = ({
     `
 }
 
-
-export const IsolatedCell = ({
-    cell_id,
-    cell_results: { output, published_objects },
-    hidden
-}) => {
+export const IsolatedCell = ({ cell_id, cell_results: { output, published_object_keys }, hidden }) => {
     const node_ref = useRef(null)
     let pluto_actions = useContext(PlutoContext)
-    const cell_api_ready = useCellApi(node_ref, published_objects, pluto_actions)
+    const cell_api_ready = useCellApi(node_ref, published_object_keys, pluto_actions)
 
     return html`
         <pluto-cell ref=${node_ref} id=${cell_id} class=${hidden ? "hidden-cell" : "isolated-cell"}>

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -129,7 +129,7 @@ const first_true_key = (obj) => {
  *      rootassignee: ?string,
  *      has_pluto_hook_features: boolean,
  *  },
- *  published_objects: object,
+ *  published_object_keys: [string],
  * }}
  */
 
@@ -158,6 +158,7 @@ const first_true_key = (obj) => {
  *  cell_dependencies: { [uuid: string]: CellDependencyData },
  *  cell_order: Array<string>,
  *  cell_execution_order: Array<string>,
+ *  published_objects: { [objectid: string]: any},
  *  bonds: { [name: string]: any },
  *  nbpkg: Object,
  * }}
@@ -202,6 +203,7 @@ const initial_notebook = () => ({
     cell_dependencies: {},
     cell_order: [],
     cell_execution_order: [],
+    published_objects: {},
     bonds: {},
     nbpkg: null,
 })
@@ -246,6 +248,7 @@ export class Editor extends Component {
         this.actions = {
             get_notebook: () => this?.state?.notebook || {},
             send: (...args) => this.client.send(...args),
+            get_published_object: (objectid) => this.state.notebook.published_objects[objectid],
             //@ts-ignore
             update_notebook: (...args) => this.update_notebook(...args),
             set_doc_query: (query) => this.setState({ desired_doc_query: query }),

--- a/src/webserver/Dynamic.jl
+++ b/src/webserver/Dynamic.jl
@@ -135,7 +135,7 @@ function notebook_to_js(notebook::Notebook)
                     "persist_js_state" => cell.output.persist_js_state,
                     "has_pluto_hook_features" => cell.output.has_pluto_hook_features,
                 ),
-                "published_objects" => cell.published_objects,
+                "published_object_keys" => keys(cell.published_objects),
                 "queued" => cell.queued,
                 "running" => cell.running,
                 "errored" => cell.errored,
@@ -143,6 +143,7 @@ function notebook_to_js(notebook::Notebook)
             )
         for (id, cell) in notebook.cells_dict),
         "cell_order" => notebook.cell_order,
+        "published_objects" => merge!(Dict{String,Any}(), (c.published_objects for c in values(notebook.cells_dict))...),
         "bonds" => Dict{String,Dict{String,Any}}(
             String(key) => Dict(
                 "value" => bondvalue.value, 


### PR DESCRIPTION
If two cells use `publish_to_js` on `===`-exactly the same object, it will now only be sent to the frontend once :)

This is useful for https://fonsp-disorganised-mess.netlify.app/importing%20local%20js%20modules