### PR TITLE
Don't resend published objects from PlutoRunner if unchanged

### DIFF
--- a/src/evaluation/WorkspaceManager.jl
+++ b/src/evaluation/WorkspaceManager.jl
@@ -284,6 +284,7 @@ function eval_format_fetch_in_workspace(
     function_wrapped_info::Union{Nothing,Tuple}=nothing,
     forced_expr_id::Union{PlutoRunner.ObjectID,Nothing}=nothing,
     user_requested_run::Bool=true,
+    known_published_objects::Vector{String}=String[],
 )::NamedTuple{(:output_formatted, :errored, :interrupted, :process_exited, :runtime, :published_objects, :has_pluto_hook_features),Tuple{PlutoRunner.MimedOutput,Bool,Bool,Bool,Union{UInt64,Nothing},Dict{String,Any},Bool}}
 
     workspace = get_workspace(session_notebook)
@@ -319,7 +320,7 @@ function eval_format_fetch_in_workspace(
     end
 
     early_result === nothing ?
-        format_fetch_in_workspace(workspace, cell_id, ends_with_semicolon) :
+        format_fetch_in_workspace(workspace, cell_id, ends_with_semicolon, known_published_objects) :
         early_result
 end
 
@@ -335,6 +336,7 @@ function format_fetch_in_workspace(
     session_notebook::Union{SN,Workspace}, 
     cell_id, 
     ends_with_semicolon, 
+    known_published_objects::Vector{String}=String[],
     showmore_id::Union{PlutoRunner.ObjectDimPair,Nothing}=nothing,
 )::NamedTuple{(:output_formatted, :errored, :interrupted, :process_exited, :runtime, :published_objects, :has_pluto_hook_features),Tuple{PlutoRunner.MimedOutput,Bool,Bool,Bool,Union{UInt64,Nothing},Dict{String,Any},Bool}}
     workspace = get_workspace(session_notebook)
@@ -345,6 +347,7 @@ function format_fetch_in_workspace(
             Distributed.remotecall_eval(Main, workspace.pid, :(PlutoRunner.formatted_result_of(
                 $cell_id, 
                 $ends_with_semicolon, 
+                $known_published_objects,
                 $showmore_id,
                 getfield(Main, $(QuoteNode(workspace.module_name))),
                 )))

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -757,6 +757,7 @@ const tree_display_extra_items = Dict{UUID,Dict{ObjectDimPair,Int64}}()
 function formatted_result_of(
     cell_id::UUID, 
     ends_with_semicolon::Bool, 
+    known_published_objects::Vector{String}=String[],
     showmore::Union{ObjectDimPair,Nothing}=nothing, 
     workspace::Module=Main,
 )::NamedTuple{(:output_formatted, :errored, :interrupted, :process_exited, :runtime, :published_objects, :has_pluto_hook_features),Tuple{PlutoRunner.MimedOutput,Bool,Bool,Bool,Union{UInt64,Nothing},Dict{String,Any},Bool}}
@@ -780,13 +781,22 @@ function formatted_result_of(
     else
         ("", MIME"text/plain"())
     end
+    
+    published_objects = get(cell_published_objects, cell_id, Dict{String,Any}())
+    
+    for k in known_published_objects
+        if haskey(published_objects, k)
+            published_objects[k] = nothing
+        end
+    end
+    
     return (
         output_formatted = output_formatted,
         errored = errored, 
         interrupted = false, 
         process_exited = false, 
         runtime = get(cell_runtimes, cell_id, nothing),
-        published_objects = get(cell_published_objects, cell_id, Dict{String,Any}()),
+        published_objects = published_objects,
         has_pluto_hook_features = has_pluto_hook_features,
     )
 end

--- a/src/webserver/Dynamic.jl
+++ b/src/webserver/Dynamic.jl
@@ -459,6 +459,7 @@ responses[:reshow_cell] = function response_reshow_cell(🙋::ClientRequest)
         (🙋.session, 🙋.notebook), 
         cell.cell_id, 
         ends_with_semicolon(cell.code), 
+        collect(keys(cell.published_objects)),
         (parse(PlutoRunner.ObjectID, 🙋.body["objectid"], base=16), convert(Int64, 🙋.body["dim"])),
     )
     set_output!(cell, run, ExprAnalysisCache(🙋.notebook, cell); persist_js_state=true)

--- a/test/Dynamic.jl
+++ b/test/Dynamic.jl
@@ -194,6 +194,8 @@ end
             Cell("3"),
             Cell("PlutoRunner.publish_to_js(Ref(4))"),
             Cell("PlutoRunner.publish_to_js((ref=4,))"),
+            Cell("x = Dict(:a => 6)"),
+            Cell("PlutoRunner.publish_to_js(x)"),
         ])
         fakeclient.connected_notebook = notebook
 
@@ -211,14 +213,46 @@ end
             "xx" => UInt8[6,7,8],
         )
         @test p[b] == "cool"
-
+        
+        old_pa = p[a]
+        old_pb = p[b]
+        update_save_run!(🍭, notebook, notebook.cells)
+        p = notebook.cells[2].published_objects
+        a, b = Meta.parse(notebook.cells[2].output.body) |> eval
+        @test p[a] == old_pa
+        @test p[b] == old_pb
+        
+        @test !isempty(notebook.cells[2].published_objects)
+        
         setcode(notebook.cells[2], "2")
         update_save_run!(🍭, notebook, notebook.cells)
         @test isempty(notebook.cells[2].published_objects)
 
         @test notebook.cells[4].errored
         @test !notebook.cells[5].errored
-
+        @test !isempty(notebook.cells[5].published_objects)
+        
+        
+        p = notebook.cells[7].published_objects
+        @test length(p) == 1
+        old_x = values(p) |> first
+        @test old_x == Dict(:a => 6)
+        
+        update_save_run!(🍭, notebook, notebook.cells[7])
+        p = notebook.cells[7].published_objects
+        new_x = values(p) |> first
+        @test new_x == old_x
+        @test new_x === old_x # did not change, because we don't resync the same object
+        
+        update_save_run!(🍭, notebook, notebook.cells[6])
+        p = notebook.cells[7].published_objects
+        new_x = values(p) |> first
+        @test new_x == old_x
+        @test new_x !== old_x # changed, because a new (mutable) Dict was created
+        
+        @test isempty(notebook.cells[2].published_objects)
+        @test !isempty(notebook.cells[5].published_objects)
+        
         WorkspaceManager.unmake_workspace((🍭, notebook))
     end
 end


### PR DESCRIPTION
Idea from @dralletje :

We diff the published objects between server and frontend, that's great, but we still send it back from PlutoRunner to the server via distributed every time the cell evaluates, making it less suitable for "longish-term storage". Fixed now!

See also #1719 

This is useful for https://fonsp-disorganised-mess.netlify.app/importing%20local%20js%20modules