### PR TITLE
clear livedocs once the user has closed them

### DIFF
--- a/frontend/components/LiveDocs.js
+++ b/frontend/components/LiveDocs.js
@@ -132,6 +132,7 @@ export let LiveDocs = ({ desired_doc_query, on_update_doc_query, notebook }) => 
                             set_state((state) => ({ ...state, hidden: true }))
                             e.stopPropagation()
                             setTimeout(() => live_doc_search_ref.current && live_doc_search_ref.current.focus(), 0)
+                            location.reload()
                         }}><span></span></button>
                     `}
                 </header>


### PR DESCRIPTION
Now once the user has closed the livedocs, the screen automatically refreshes and upon reopening, a fresh session continues.
fixes #1730 
video proof :


https://user-images.githubusercontent.com/78342516/144714794-4f20b01d-a847-4ca2-b2ce-1a942dd797ed.mp4

