### PR TITLE
Slightly tweak @htl intro in JS sample notebook

### DIFF
--- a/sample/JavaScript.jl
+++ b/sample/JavaScript.jl
@@ -102,9 +102,9 @@ md"""
 
 ## Using HTML, CSS and JavaScript
 
-To use web languages inside Pluto, we recomend the small package `HypertextLiteral.jl`, which provides a `@htl` macro.
+To use web languages inside Pluto, we recomend the small package [`HypertextLiteral.jl`](https://github.com/MechanicalRabbit/HypertextLiteral.jl), which provides a `@htl` macro.
 
-You wrap `@htl` around a string expression to mark it as an *HTML literal*. When a cell outputs an HTML-showable object, it is rendered directly in your browser.
+You wrap `@htl` around a string expression to mark it as an *HTML literal*, as we did in the example cell from earlier. When a cell outputs an HTML-showable object, it is rendered directly in your browser.
 """
 
 # ╔═╡ d967cdf9-3df9-40bb-9b08-09cae95a5ca7
@@ -177,7 +177,7 @@ html"""
 # ╔═╡ 8c03139f-a94b-40cc-859f-0d86f1c72143
 md"""
 
-😢 For this feature, we highly recommend the new package [HypertextLiteral.jl](https://github.com/MechanicalRabbit/HypertextLiteral.jl), which has an `@htl` macro that supports interpolation:
+😢 Luckily we can perform these kinds of interpolations (and much more) with the `@htl` macro, as we will see next.
 
 
 ### Interpolating into HTML -- HypertextLiteral.jl
@@ -1163,7 +1163,7 @@ deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[Random]]
-deps = ["Serialization"]
+deps = ["SHA", "Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[Reexport]]

--- a/sample/JavaScript.jl
+++ b/sample/JavaScript.jl
@@ -1163,7 +1163,7 @@ deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[Random]]
-deps = ["SHA", "Serialization"]
+deps = ["Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[Reexport]]

--- a/sample/JavaScript.jl
+++ b/sample/JavaScript.jl
@@ -102,7 +102,7 @@ md"""
 
 ## Using HTML, CSS and JavaScript
 
-To use web languages inside Pluto, we recomend the small package [`HypertextLiteral.jl`](https://github.com/MechanicalRabbit/HypertextLiteral.jl), which provides a `@htl` macro.
+To use web languages inside Pluto, we recommend the small package [`HypertextLiteral.jl`](https://github.com/MechanicalRabbit/HypertextLiteral.jl), which provides an `@htl` macro.
 
 You wrap `@htl` around a string expression to mark it as an *HTML literal*, as we did in the example cell from earlier. When a cell outputs an HTML-showable object, it is rendered directly in your browser.
 """


### PR DESCRIPTION
As a total noob to web programming, I thought these slight changes helped me follow the logical flow of the text a bit better. Pretty much whenever new topics are introduced, I like following the rule of thumb of just addressing it up front (e.g. with hyperlinks or whatever), and then calling back to it when it's mentioned for the second time.

No idea if that makes sense, but just thought I'd bring this up to see what folks thought!