### PR TITLE
`load_notebook`: keep cells with no entry in `Cell order`

### DIFF
--- a/src/notebook/Notebook.jl
+++ b/src/notebook/Notebook.jl
@@ -265,7 +265,16 @@ function load_notebook_nobackup(io, path)::Notebook
         PkgCompat.create_empty_ctx()
     end
 
-    appeared_order = setdiff(cell_order ∩ keys(collected_cells), [_ptoml_cell_id, _mtoml_cell_id])
+    appeared_order = setdiff!(
+        union!(
+            # don't include cells that only appear in the order, but no code was given
+            intersect!(cell_order, keys(collected_cells)),
+            # add cells that appeared in code, but not in the order.
+            keys(collected_cells)
+        ), 
+        # remove Pkg cells
+        (_ptoml_cell_id, _mtoml_cell_id)
+    )
     appeared_cells_dict = filter(collected_cells) do (k, v)
         k ∈ appeared_order
     end


### PR DESCRIPTION
If a cell appears in the notebook file, but not in the cell order, it will be added automatically. This should help recover after a bad git merge.

For example, take this (manually corrupted) file:

```julia
### A Pluto.jl notebook ###
# v0.17.3

using Markdown
using InteractiveUtils

# ╔═╡ cdd40e28-61be-11ec-28fd-111111111111
x = 1

# ╔═╡ cdd40e28-61be-11ec-28fd-222222222222
y = 2

# ╔═╡ cdd40e28-61be-11ec-28fd-333333333333
z = 3

# ╔═╡ Cell order:
# ╠═cdd40e28-61be-11ec-28fd-111111111111
# ╠═cdd40e28-61be-11ec-28fd-333333333333
# ╠═cdd40e28-61be-11ec-28fd-444444444444
```

Before this PR, it would load without error, and the `y = 2` cell would disappear. After this PR, any limbo cells like `y = 2` are added to the end of the notebook.