### PR TITLE
Make `DivElement` HTML-showable

### DIFF
--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -1965,6 +1965,14 @@ tree_data(@nospecialize(e::DivElement), context::IOContext) = Dict{Symbol, Any}(
 )
 pluto_showable(::MIME"application/vnd.pluto.divelement+object", ::DivElement) = true
 
+function Base.show(io::IO, m::MIME"text/html", e::DivElement)
+    extra_args = e.class === nothing ? tuple() : (:class => e.class,)
+    withtag(io, :div, :style => e.style, extra_args...) do
+        foreach(e.children) do child
+            show(io, m, embed_display(child))
+        end
+    end
+end
 
 ###
 # LOGGING


### PR DESCRIPTION
So that you can use it inside other things! For example:

```julia
function ScrubbableMatrix2(A::Matrix{<:Real})
	# Create a new widgets that combines existing ones
	PlutoUI.combine() do Child
		
		# Create a matrix of scrubbables
		# (Note that each `Scrubbable` is wrapped in the `Child` function!)
		scrubbables = map(A) do x
			Child(Scrubbable(x))
		end

		# use Layout to display them in a grid
		Layout.grid(
			scrubbables;
			scrubbable_matrix_style...
		)
	end
end
```

`Layout.grid` returns a `DivElement`, and without this PR, it can not be rendered to HTML.