### PR TITLE
Use uname -r instead of accessing a file to detect WSL

### DIFF
--- a/src/webserver/WebServer.jl
+++ b/src/webserver/WebServer.jl
@@ -14,9 +14,12 @@ include("./WebSocketFix.jl")
 
 # from https://github.com/JuliaLang/julia/pull/36425
 function detectwsl()
-    Sys.islinux() &&
-    isfile("/proc/sys/kernel/osrelease") &&
-    occursin(r"Microsoft|WSL"i, read("/proc/sys/kernel/osrelease", String))
+    try
+        Sys.islinux() &&
+        occursin(r"Microsoft|WSL"i, readchomp(`uname -r`))
+    catch
+        false
+    end
 end
 
 function open_in_default_browser(url::AbstractString)::Bool


### PR DESCRIPTION
Tested on (Windows 11, WSL2 Ubuntu 20.04)

In rare cases, the file `"/proc/sys/kernel/osrelease"` seems to be locked and Pluto refuses to run as this read on line 19 is synchronous.

Note that this indicates a more system-wide issue that was solved with system restart.