### PR TITLE
Add Base.length to DefaultDict

### DIFF
--- a/src/analysis/Topology.jl
+++ b/src/analysis/Topology.jl
@@ -62,5 +62,5 @@ Base.setindex!(aid::DefaultDict, args...) = Base.setindex!(aid.container, args..
 Base.delete!(aid::DefaultDict, args...) = Base.delete!(aid.container, args...)
 Base.keys(aid::DefaultDict) = Base.keys(aid.container)
 Base.values(aid::DefaultDict) = Base.values(aid.container)
-Base.length(aid::Pluto.DefaultDict) = Base.length(aid.container)
+Base.length(aid::DefaultDict) = Base.length(aid.container)
 Base.iterate(aid::DefaultDict, args...) = Base.iterate(aid.container, args...)

--- a/src/analysis/Topology.jl
+++ b/src/analysis/Topology.jl
@@ -62,4 +62,5 @@ Base.setindex!(aid::DefaultDict, args...) = Base.setindex!(aid.container, args..
 Base.delete!(aid::DefaultDict, args...) = Base.delete!(aid.container, args...)
 Base.keys(aid::DefaultDict) = Base.keys(aid.container)
 Base.values(aid::DefaultDict) = Base.values(aid.container)
+Base.length(aid::Pluto.DefaultDict) = Base.length(aid.container)
 Base.iterate(aid::DefaultDict, args...) = Base.iterate(aid.container, args...)


### PR DESCRIPTION
I was going through a notebook's data structure interactively in the REPL and got:
```julia
julia> c
Pluto.DefaultDict{Pluto.Cell, Pluto.ExprAnalysisCache}Error showing value of type Pluto.DefaultDict{Pluto.Cell, Pluto.ExprAnalysisCache}:
ERROR: MethodError: no method matching length(::Pluto.DefaultDict{Pluto.Cell, Pluto.ExprAnalysisCache})
Closest candidates are:
  length(::Union{Base.KeySet, Base.ValueIterator}) at abstractdict.jl:58
  length(::Union{LinearAlgebra.Adjoint{T, S}, LinearAlgebra.Transpose{T, S}} where {T, S}) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/adjtrans.jl:195
  length(::SubString) at strings/substring.jl:66
  ...
Stacktrace:
  [1] summary(io::IOContext{Base.TTY}, t::Pluto.DefaultDict{Pluto.Cell, Pluto.ExprAnalysisCache})
    @ Base ./abstractdict.jl:36
  [2] show(io::IOContext{Base.TTY}, #unused#::MIME{Symbol("text/plain")}, t::Pluto.DefaultDict{Pluto.Cell, Pluto.ExprAnalysisCache}
    @ Base ./show.jl:91
  [3] (::REPL.var"#38#39"{REPL.REPLDisplay{REPL.LineEditREPL}, MIME{Symbol("text/plain")}, Base.RefValue{Any}})(io::Any)
    @ REPL /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/REPL/src/REPL.jl:220
  [4] with_repl_linfo(f::Any, repl::REPL.LineEditREPL)
    @ REPL /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/REPL/src/REPL.jl:462
  [5] display(d::REPL.REPLDisplay, mime::MIME{Symbol("text/plain")}, x::Any)
    @ REPL /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/REPL/src/REPL.jl:213**
```

Appears fixed via:
```julia
julia> Base.length(aid::Pluto.DefaultDict) = Base.length(aid.container)

julia> c = nb.topology.codes
Pluto.DefaultDict{Pluto.Cell, Pluto.ExprAnalysisCache} with 1 entry:
  Cell(UUID("c91d3b62-6d84-11ec-2898-f170cc… => ExprAnalysisCache("", :($(Expr(:toplevel, :(#= line 1 =#), quote…
```