### PR TITLE
Restrict notebook communication topology

### DIFF
--- a/src/evaluation/WorkspaceManager.jl
+++ b/src/evaluation/WorkspaceManager.jl
@@ -180,7 +180,7 @@ function create_workspaceprocess(;compiler_options=CompilerOptions())::Integer
     # run on proc 1 in case Pluto is being used inside a notebook process
     # Workaround for "only process 1 can add/remove workers"
     pid = Distributed.remotecall_eval(Main, 1, quote
-        $(Distributed_expr).addprocs(1; exeflags=$(_convert_to_flags(compiler_options))) |> first
+        $(Distributed_expr).addprocs(1; topology=:master_worker, exeflags=$(_convert_to_flags(compiler_options))) |> first
     end)
 
     for expr in process_preamble


### PR DESCRIPTION
Instigated by https://github.com/fonsp/Pluto.jl/issues/300

In case Pluto wants this, some tests would have to change, because they verify that notebooks can talk to each other.
Maybe workers are intended to be able to talk to each other.