### PR TITLE
Upgrade General registry to 1.7 format on launch

### DIFF
--- a/src/webserver/WebServer.jl
+++ b/src/webserver/WebServer.jl
@@ -2,6 +2,7 @@ import MsgPack
 import UUIDs: UUID
 import HTTP
 import Sockets
+import .PkgCompat
 
 include("./WebSocketFix.jl")
 
@@ -268,6 +269,12 @@ function run(session::ServerSession, pluto_router)
 
     if PLUTO_VERSION >= v"0.18.0" && frontend_directory() == "frontend"
         @info "It looks like you are developing the Pluto package, using the unbundled frontend..."
+    end
+    
+    # Start this in the background, so that the first notebook launch (which will trigger registry update) will be faster
+    @asynclog withtoken(pkg_token) do
+        PkgCompat.install_default_registries_if_needed()
+        PkgCompat.update_registries(; force=false)
     end
 
     shutdown_server[] = () -> @sync begin


### PR DESCRIPTION
I posted this message to zulip when Julia 1.7 was released:

> Hi Windows users! The time to start a new notebook is ***much* faster on Julia 1.7** (>60 seconds to 5 seconds), which was released yesterday, so I recommend upgrading!
> 
> The speedup comes from the [much faster registry update process](https://julialang.org/blog/2021/11/julia-1.7-highlights/#improved_performance_for_handling_registries_on_windows_and_distributed_file_systems). To get this benefit, you need to remove the old registry on your computer, and Julia 1.7 will automatically download and use the new one:
> ```julia
> julia> general_path = joinpath(DEPOT_PATH[1], "registries", "General")
> "/Users/fons/.julia/registries/General"
> 
> julia> rm(general_path; recursive=true)
> ```
> That's it! Now install Pluto as usual ([instructions](https://github.com/fonsp/Pluto.jl#lets-do-it)), and the new registry format will be used. This operation is harmless, because no personal information is stored in the registry, and Julia automatically downloads the folder if it's missing.
> 
> Please let me know if the startup time has improved for you!

---

Windows users reported that this indeed gave a big speedup, but unfortunately, only a small number of users will see this message. **This PR will check for this situation, and do the upgrade automatically!**

# Implementation

I noticed that Julia 1.7 will not automatically download the new General registry if the old one is available, but running `]registry add` will! *(See "Details" below)* This PR essentially calls `]registry add` automatically on Pluto's launch, if:
- you are on Julia 1.7 or above, and
- `DEPOT/registries/General/` exists, and
- `DEPOT/registries/General.toml` does not exist

<details>
<summary>Details</summary>


```
➜  registries ls
General       PlutoPackages
➜  registries julia17
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.7.0 (2021-11-30)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

(@v1.7) pkg> add HypertextLiteral
    Updating registry at `~/.julia/registries/General`
    Updating registry at `~/.julia/registries/PlutoPackages`
    Updating git-repo `https://pluto-packages.dral.eu/PlutoPackages.git`
   Resolving package versions...
  No Changes to `~/.julia/environments/v1.7/Project.toml`
  No Changes to `~/.julia/environments/v1.7/Manifest.toml`

(@v1.7) pkg> 
➜  registries ls
General       PlutoPackages
➜  registries julia17
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.7.0 (2021-11-30)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

(@v1.7) pkg> registry add
  Installing known registries into `~/.julia`

(@v1.7) pkg> 
➜  registries ls     
General        General.tar.gz General.toml   PlutoPackages
```

</details>
