### PR TITLE
wider line number gutter (fix #1826)

### DIFF
--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -2618,7 +2618,7 @@ pluto-input .cm-editor .cm-content {
 }
 
 .cm-editor .cm-gutter {
-    min-width: 29px;
+    min-width: 31px;
     min-height: 23px;
 }
 

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -2635,24 +2635,24 @@ pluto-cell.code_differs .cm-editor .cm-gutters {
 }
 
 .cm-editor .cm-lineNumbers .cm-gutterElement {
-    color: var(--cm-line-numbers-color);
+    color: transparent;
 }
 
 .cm-editor .cm-lineNumbers .cm-gutterElement::after {
     content: "⋅";
     font-size: 0.75rem;
-}
-
-.cm-editor .cm-lineNumbers .cm-gutterElement {
-    font-size: 0px;
+    color: var(--cm-line-numbers-color);
+    position: absolute;
+    right: 3px;
+    pointer-events: none;
 }
 
 .cm-editor .cm-lineNumbers .cm-gutterElement:hover {
-    font-size: 0.75rem;
+    color: var(--cm-line-numbers-color);
 }
 
 .cm-editor .cm-lineNumbers .cm-gutterElement:hover::after {
-    font-size: 0px;
+    color: transparent;
 }
 
 .cm-completionIcon-c_Number::before {


### PR DESCRIPTION
Increase `min-width` of `.cm-gutter` from `29px` to `31px` to support up to 999 lines without change of gutter width.