### PR TITLE
prefetch and prerender editor.html from index.html

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -29,6 +29,9 @@
 
     <script src="index.js" type="module" defer></script>
     <script src="warn_old_browsers.js"></script>
+    <link rel="prefetch" as="stylesheet" type="text/html" href="editor.css">
+    <link rel="prefetch" as="script" type="text/javascript" href="editor.js">
+    <link rel="prerender" href="editor.html">
 </head>
 
 <body class="loading nosessions">


### PR DESCRIPTION
The editor.js and editor.css prefetches are working well according to devtools, and parcel is handling them correctly (after bundling, they point to the same hashed filename as editor.html does).

The prerender is not showing up in devtools, but I'm guessing that it is working.

A big thing is that we want to prefetch to .woff assets from index.html, but I'm not sure if this PR is achieving that. (Because `prefetch` is not recursive, and I can't easily inspect `prerender`.) A problem might be that those fonts are lazy-loaded, so just loading the stylesheets does not trigger loading the font files. Maybe explicit `prefetch`es for all the font files?