### PR TITLE
Hide banner in CI

### DIFF
--- a/src/Pluto.jl
+++ b/src/Pluto.jl
@@ -67,15 +67,7 @@ export reset_notebook_environment
 export update_notebook_environment
 export activate_notebook_environment
 
-function should_show_banner()::Bool
-    if "JULIA_PLUTO_SHOW_BANNER" in keys(ENV)
-        return ENV["JULIA_PLUTO_SHOW_BANNER"] !== "0"
-    else
-        return "CI" ∈ keys(ENV) && ENV["CI"] == "true"
-    end
-end
-
-if should_show_banner()
+if get(ENV, "JULIA_PLUTO_SHOW_BANNER", "1") != "0" && get(ENV, "CI", "🍄") != "true"
 @info """\n
     Welcome to Pluto $(PLUTO_VERSION_STR) 🎈
     Start a notebook server using:

--- a/src/Pluto.jl
+++ b/src/Pluto.jl
@@ -67,7 +67,16 @@ export reset_notebook_environment
 export update_notebook_environment
 export activate_notebook_environment
 
-if get(ENV, "JULIA_PLUTO_SHOW_BANNER", "1") !== "0"
+"Determine whether to show banner"
+function should_show_banner()::Bool
+    if "JULIA_PLUTO_SHOW_BANNER" in keys(ENV)
+        return ENV["JULIA_PLUTO_SHOW_BANNER"] !== "0"
+    else
+        return "CI" ̸∈ keys(ENV)
+    end
+end
+
+if should_show_banner()
 @info """\n
     Welcome to Pluto $(PLUTO_VERSION_STR) 🎈
     Start a notebook server using:

--- a/src/Pluto.jl
+++ b/src/Pluto.jl
@@ -67,12 +67,11 @@ export reset_notebook_environment
 export update_notebook_environment
 export activate_notebook_environment
 
-"Determine whether to show banner"
 function should_show_banner()::Bool
     if "JULIA_PLUTO_SHOW_BANNER" in keys(ENV)
         return ENV["JULIA_PLUTO_SHOW_BANNER"] !== "0"
     else
-        return "CI" ̸∈ keys(ENV)
+        return "CI" ∈ keys(ENV) && ENV["CI"] == "true"
     end
 end
 


### PR DESCRIPTION
When running Pluto in CI, it shows the banner in the logs by default. In most CI systems such as GitHub Runners, there is a CI environment variable set to "true" which we can use to disable banner printing there (https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables).