### PR TITLE
Server-side events as configuration

### DIFF
--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -62,6 +62,7 @@ The HTTP server options. See [`SecurityOptions`](@ref) for additional settings.
     notebook::Union{Nothing,String,Vector{<:String}} = nothing
     init_with_file_viewer::Bool = false
     simulated_lag::Real = 0.0
+    on_event::Function = function(a) #= @info "$(typeof(a))" =# end
 end
 
 """

--- a/src/notebook/Events.jl
+++ b/src/notebook/Events.jl
@@ -39,7 +39,7 @@ abstract type PlutoEvent end
 
 function try_event_call(session, event::PlutoEvent)
     return try
-        session.options.server.event_listener(event)
+        session.options.server.on_event(event)
     catch e
         @warn "Couldn't run event listener" event exception=(e, catch_backtrace())
         nothing

--- a/src/notebook/Events.jl
+++ b/src/notebook/Events.jl
@@ -9,31 +9,30 @@ the FileSaveEvent may be triggered whenever pluto wants to make sure the file is
 which may be more often than the file is actually changed. Deduplicate on your own if
 you care about this.
 
-To use that, we assume you are running Pluto through a julia script and
-opening it as 
-
-julia > pluto_server_session = Pluto.ServerSession(;
-    secret = secret,
-    options = pluto_server_options,
-)
-
 Define your function to handle the events using multiple dispatch:
 
 First assign a handler for all the types you will not use, using the supertype:
 
-julia >    function myfn(a::PlutoEvent)
-        nothing
-    end
+```julia-repl
+julia> function myfn(a::PlutoEvent)
+            nothing
+        end
+```
+
 
 And then create a special function for each event you want to handle specially
 
-julia >    function myfn(a::FileSaveEvent)
-        HTTP.post("https://my.service.com/count_saves")
-    end
+```julia-repl
+julia> function myfn(a::FileSaveEvent)
+            HTTP.post("https://my.service.com/count_saves")
+        end
+```
 
-Finally, assign the listener to your session
+Finally, pass the listener to Pluto's configurations with a keyword argument
 
-julia > pluto_server_session.event_listener = yourfunction
+```julia-repl
+julia> Pluto.run(; on_event = myfn)
+```
 """
 abstract type PlutoEvent end
 

--- a/src/notebook/Events.jl
+++ b/src/notebook/Events.jl
@@ -39,7 +39,7 @@ abstract type PlutoEvent end
 
 function try_event_call(session, event::PlutoEvent)
     return try
-        session.event_listener(event)
+        session.options.server.event_listener(event)
     catch e
         @warn "Couldn't run event listener" event exception=(e, catch_backtrace())
         nothing

--- a/src/webserver/MsgPack.jl
+++ b/src/webserver/MsgPack.jl
@@ -31,6 +31,10 @@ MsgPack.msgpack_type(::Type{Configuration.CompilerOptions}) = MsgPack.StructType
 MsgPack.msgpack_type(::Type{Configuration.ServerOptions}) = MsgPack.StructType()
 MsgPack.msgpack_type(::Type{Configuration.SecurityOptions}) = MsgPack.StructType()
 
+# Don't try to send callback functions which can't be serialized (see ServerOptions.event_listener)
+MsgPack.msgpack_type(::Type{Function}) = MsgPack.NilType()
+MsgPack.to_msgpack(::MsgPack.NilType, ::Function) = nothing
+
 # We want typed integer arrays to arrive as JS typed integer arrays:
 const JSTypedIntSupport = [Int8, UInt8, Int16, UInt16, Int32, UInt32, Float32, Float64]
 JSTypedInt = Union{Int8,UInt8,Int16,UInt16,Int32,UInt32,Float32,Float64}

--- a/src/webserver/Session.jl
+++ b/src/webserver/Session.jl
@@ -47,7 +47,6 @@ Base.@kwdef mutable struct ServerSession
     secret::String = String(rand(('a':'z') ∪ ('A':'Z') ∪ ('0':'9'), 8))
     binder_token::Union{String,Nothing} = nothing
     options::Configuration.Options = Configuration.Options()
-    event_listener::Function = function(a::PlutoEvent) #= @info "$(typeof(a))" =# end
 end
 
 function save_notebook(session::ServerSession, notebook::Notebook)

--- a/src/webserver/WebServer.jl
+++ b/src/webserver/WebServer.jl
@@ -130,6 +130,7 @@ function run(session::ServerSession, pluto_router)
     hostIP = parse(Sockets.IPAddr, host)
     if port === nothing
         port, serversocket = Sockets.listenany(hostIP, UInt16(1234))
+        session.options.server.port = port
     else
         try
             serversocket = Sockets.listen(hostIP, UInt16(port))

--- a/src/webserver/WebServer.jl
+++ b/src/webserver/WebServer.jl
@@ -130,7 +130,6 @@ function run(session::ServerSession, pluto_router)
     hostIP = parse(Sockets.IPAddr, host)
     if port === nothing
         port, serversocket = Sockets.listenany(hostIP, UInt16(1234))
-        session.options.server.port = port
     else
         try
             serversocket = Sockets.listen(hostIP, UInt16(port))

--- a/test/Events.jl
+++ b/test/Events.jl
@@ -12,7 +12,8 @@ import UUIDs: UUID
         @info "this run!"
         push!(events, typeof(a))
     end
-    🍭 = ServerSession(; event_listener = test_listener)
+    🍭 = ServerSession()
+    🍭.options.server.on_event = test_listener
     🍭.options.evaluation.workspace_use_distributed = false
 
     fakeclient = ClientSession(:fake, nothing)


### PR DESCRIPTION
As discussed in the [developer call on 1/27](https://juliapluto.github.io/weekly-call-notes/2022/01-27/notes.html), here are a few changes related to server-side event listeners.

### List of changes
- Move event listener to configuration
    - Had to add a `MsgPack.to_msgpack` for functions that returns null so Pluto doesn't try to serialize the event listener function
- Update `Events.jl` docstring with updated instructions
- Rename `event_listener` to `on_event` since its shorter and maybe more descriptive?
- Assign configuration port if none was provided (see [comment below](https://github.com/fonsp/Pluto.jl/pull/1871#discussion_r795117452))

### Example Usage
```julia
import Pluto

# catches unwanted events
function myfn(a::PlutoEvent)
    nothing
end
# catches the notebook `save` event
function myfn(a::FileSaveEvent)
    HTTP.post("https://my.service.com/count_saves")
end

Pluto.run(; on_event=myfn)
```

### Backwards Compatibility
This PR _would_ technically break backwards compatibility. I don't think refactoring everything to kwargs is too bad, but if others think otherwise we can add the following method definition for `ServerSession` and everything should (I didn't test it) be backwards compatible.

```julia
function ServerSession(; event_listener::Function, kwargs...)
    s = ServerSession(; kwargs...)
    s.options.server.on_event = event_listener
    s
end
```

### TODO
- [ ] On server start event that sends port