### PR TITLE
allow .. as an identifier, fixes #1875

### DIFF
--- a/src/analysis/ExpressionExplorer.jl
+++ b/src/analysis/ExpressionExplorer.jl
@@ -271,7 +271,7 @@ end
 
 # this is stupid -- désolé
 function is_joined_funcname(joined::Symbol)
-    occursin('.', String(joined))
+    joined !== :.. #= .. is a valid identifier 😐 =# && occursin('.', String(joined))
 end
 
 assign_to_kw(e::Expr) = e.head == :(=) ? Expr(:kw, e.args...) : e

--- a/test/React.jl
+++ b/test/React.jl
@@ -159,6 +159,16 @@ import Distributed
         end
     end
 
+    @testset ".. as an identifier" begin
+        notebook = Notebook(Cell.([
+           ".. = 1",
+           "..",
+        ]))
+        update_run!(🍭, notebook, notebook.cells)
+
+        @test all(noerror, notebook.cells)
+        @test notebook.cells[end].output.body == "1"
+    end
 
     # PlutoTest.jl is only working on Julia version >= 1.6
     VERSION >= v"1.6" && @testset "Test Firebasey" begin


### PR DESCRIPTION
ultimately, more work has to be done to support any variable name with a dot (like `var"my.var"`) but it should be enough for now
