### PR TITLE
New heuristic to skip intermediate bond values

### DIFF
--- a/frontend/common/Bond.js
+++ b/frontend/common/Bond.js
@@ -155,7 +155,8 @@ export const add_bonds_listener = (node, on_bond_change, known_values) => {
 
         // see the docs on Generators.input from observablehq/stdlib
         let skippped_first = false
-        for (let val of input_generator(bond_node.firstElementChild)) {
+        const bound_element_node = bond_node.firstElementChild
+        for (let val of input_generator(bound_element_node)) {
             if (node_is_invalidated) break
 
             if (skippped_first === false) {

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -651,15 +651,16 @@ patch: ${JSON.stringify(
                 const message = update.message
                 switch (update.type) {
                     case "notebook_diff":
+                        const on_applied = () => (this.waiting_for_bond_to_trigger_execution = false)
                         if (message?.response?.from_reset) {
                             console.log("Trying to reset state after failure")
                             try {
-                                apply_notebook_patches(message.patches, initial_notebook())
+                                apply_notebook_patches(message.patches, initial_notebook()).then(on_applied)
                             } catch (exception) {
                                 alert("Oopsie!! please refresh your browser and everything will be alright!")
                             }
                         } else if (message.patches.length !== 0) {
-                            apply_notebook_patches(message.patches)
+                            apply_notebook_patches(message.patches).then(on_applied)
                         }
                         break
                     default:
@@ -779,12 +780,15 @@ patch: ${JSON.stringify(
         // Not completely happy with this yet, but it will do for now - DRAL
         /** Patches that are being delayed until all cells have finished running. */
         this.bonds_changes_to_apply_when_done = []
+        /** Whether we just set a bond value which will trigger a cell to run, but we are still waiting for the server to process the bond value (and run the cell). */
+        this.waiting_for_bond_to_trigger_execution = false
         /** Number of local updates that have not yet been applied to the server's state. */
         this.pending_local_updates = 0
         this.js_init_set = new Set()
         /** Is the notebook ready to execute code right now? (i.e. are no cells queued or running?) */
         this.notebook_is_idle = () => {
             return !(
+                this.waiting_for_bond_to_trigger_execution ||
                 this.pending_local_updates > 0 ||
                 // a cell is running:
                 Object.values(this.state.notebook.cell_results).some((cell) => cell.running || cell.queued) ||
@@ -795,6 +799,15 @@ patch: ${JSON.stringify(
         }
         this.is_process_ready = () =>
             this.state.notebook.process_status === ProcessStatus.starting || this.state.notebook.process_status === ProcessStatus.ready
+
+        let bond_will_trigger_evaluation = (/** @type {string|PropertyKey} */ sym) =>
+            Object.entries(this.state.notebook.cell_dependencies).some(([cell_id, deps]) => {
+                // if the other cell depends on the variable `sym`...
+                if (deps.upstream_cells_map.hasOwnProperty(sym)) {
+                    // and the cell is not disabled
+                    return !(this.state.notebook.cell_inputs[cell_id]?.running_disabled ?? true)
+                }
+            })
 
         let last_update_notebook_task = Promise.resolve()
         /** @param {(notebook: NotebookData) => void} mutate_fn */
@@ -809,13 +822,17 @@ patch: ${JSON.stringify(
                     mutate_fn(notebook)
                 })
 
-                // If "notebook is not idle" I seperate and store the bonds updates,
+                // If "notebook is not idle" we seperate and store the bonds updates,
                 // to send when the notebook is idle. This delays the updating of the bond for performance,
                 // but when the server can discard bond updates itself (now it executes them one by one, even if there is a newer update ready)
                 // this will no longer be necessary
-                // console.log(`this.notebook_is_idle():`, this.notebook_is_idle())
-                if (!this.notebook_is_idle()) {
-                    let changes_involving_bonds = changes.filter((x) => x.path[0] === "bonds")
+                let is_idle = this.notebook_is_idle()
+                let changes_involving_bonds = changes.filter((x) => x.path[0] === "bonds")
+                if (is_idle) {
+                    this.waiting_for_bond_to_trigger_execution ||= changes_involving_bonds.some(
+                        (x) => x.path.length >= 1 && bond_will_trigger_evaluation(x.path[1])
+                    )
+                } else {
                     this.bonds_changes_to_apply_when_done = [...this.bonds_changes_to_apply_when_done, ...changes_involving_bonds]
                     changes = changes.filter((x) => x.path[0] !== "bonds")
                 }

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -780,7 +780,7 @@ patch: ${JSON.stringify(
         // Not completely happy with this yet, but it will do for now - DRAL
         /** Patches that are being delayed until all cells have finished running. */
         this.bonds_changes_to_apply_when_done = []
-        /** Whether we just set a bond value which will trigger a cell to run, but we are still waiting for the server to process the bond value (and run the cell). */
+        /** Whether we just set a bond value which will trigger a cell to run, but we are still waiting for the server to process the bond value (and run the cell). See https://github.com/fonsp/Pluto.jl/issues/1891 for more info. */
         this.waiting_for_bond_to_trigger_execution = false
         /** Number of local updates that have not yet been applied to the server's state. */
         this.pending_local_updates = 0

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -661,6 +661,8 @@ patch: ${JSON.stringify(
                             }
                         } else if (message.patches.length !== 0) {
                             apply_notebook_patches(message.patches).then(on_applied)
+                        } else {
+                            on_applied()
                         }
                         break
                     default:

--- a/src/evaluation/RunBonds.jl
+++ b/src/evaluation/RunBonds.jl
@@ -1,4 +1,10 @@
-function set_bond_values_reactive(; session::ServerSession, notebook::Notebook, bound_sym_names::AbstractVector{Symbol}, is_first_values::AbstractVector{Bool}=[true for x in bound_sym_names], kwargs...)::Union{Task,TopologicalOrder}
+function set_bond_values_reactive(; 
+    session::ServerSession, notebook::Notebook, 
+    bound_sym_names::AbstractVector{Symbol}, 
+    is_first_values::AbstractVector{Bool}=[true for x in bound_sym_names], 
+    initiator=nothing,
+    kwargs...
+)::Union{Task,TopologicalOrder}
     # filter out the bonds that don't need to be set
     to_set = filter(zip(bound_sym_names, is_first_values) |> collect) do (bound_sym, is_first_value)
         new_value = notebook.bonds[bound_sym].value
@@ -25,6 +31,7 @@ function set_bond_values_reactive(; session::ServerSession, notebook::Notebook, 
     end .|> first
 
     if isempty(to_set) || !will_run_code(notebook)
+        send_notebook_changes!(ClientRequest(; session, notebook, initiator))
         return TopologicalOrder(notebook.topology, Cell[], Dict{Cell, ReactivityError}())
     end
 

--- a/src/webserver/Dynamic.jl
+++ b/src/webserver/Dynamic.jl
@@ -327,10 +327,11 @@ responses[:update_notebook] = function response_update_notebook(🙋::ClientRequ
                 bound_sym_names=bound_sym_names,
                 is_first_values=is_first_values,
                 run_async=true,
+                initiator=🙋.initiator,
             )
         end
     
-        send_notebook_changes!(🙋; commentary=Dict(:update_went_well => :👍))    
+        send_notebook_changes!(🙋; commentary=Dict(:update_went_well => :👍))
     catch ex
         @error "Update notebook failed"  🙋.body["updates"] exception=(ex, stacktrace(catch_backtrace()))
         response = Dict(


### PR DESCRIPTION
Fix #1891, see that issue for the introduction

# Example 1


https://user-images.githubusercontent.com/6933510/152384038-0fa496c9-f36e-4fc4-a0a6-028db427b00e.mov

# Example 2

https://user-images.githubusercontent.com/6933510/152384071-add88175-325c-471c-b960-7b91847729e0.mov

# Cause of problem

Before this PR, we would hold back all intermediate bond updates while this function returns true:

https://github.com/fonsp/Pluto.jl/blob/d8bf85935778f0a831ddd7058ad2519639bfc772/frontend/components/Editor.js#L786-L795

In particular, we check that no cells are running or queued (`Object.values(this.state.notebook.cell_results).some((cell) => cell.running || cell.queued)`).

The problem is that **it takes some time for the server to process the bond values**, which will set the cell statuses to "queued" (in an async task). In the short time window after sending a bond value, but before a response from the server, `notebook_is_idle()` will always return `true`, and all bond updates start queueing in the server.

# Solution

This PR adds a new heuristic, `waiting_for_bond_to_trigger_execution`. Whenever you ask the server to run a bond value, it is set to `true` immediately, and only set back to `false` after a patch response from the server (which will *likely* be a response from the bond request).

Before setting `waiting_for_bond_to_trigger_execution` to `true`, we check whether any (enabled) cell depends on the bound symbol.

# TODO

- [x] (note to self) We might not need the frontend dependency stuff anymore bc the backend is always sending a patch after a bond request...