### PR TITLE
Send queued bond changes when last script finishes

### DIFF
--- a/frontend/common/PlutoContext.js
+++ b/frontend/common/PlutoContext.js
@@ -3,3 +3,20 @@ import { createContext } from "../imports/Preact.js"
 export let PlutoContext = createContext()
 export let PlutoBondsContext = createContext(/** @type {{ [key: string]: { value: any } }} */ (null))
 export let PlutoJSInitializingContext = createContext()
+
+// Create a class like the built-in `Set` class, but with a callback that is fired when the set becomes empty.
+export class SetWithEmptyCallback extends Set {
+    constructor(callback) {
+        super()
+        this.callback = callback
+    }
+
+    delete(value) {
+        let result = super.delete(value)
+        if (result && this.size === 0) {
+            this.callback()
+        }
+        return result
+    }
+}
+// THANKS COPILOT ❤️


### PR DESCRIPTION
Part of #1892 .

`is_notebook_idle()` checks (among other things) if no scripts are currently running. Queued bond updates are sent from `componentDidUpdate` in Editor.js, *if `is_notebook_idle()` returns `false`*. 

This creates an edge case where an async script takes a little while to run, and by the time it finishes, bond updates have queued up, but there is nothing triggering `componentDidUpdate` to send them. Bonds are then "stuck" until you interact with the notebook in another way (like typing somewhere).

# Solution

A callback that is fired when the last script is finished. On this callback, queued bond values are sent (if idle).