### PR TITLE
Fix logging getting stuck when `maxlog` is specified and don't print `maxlog`, fixes #1902

### DIFF
--- a/src/evaluation/WorkspaceManager.jl
+++ b/src/evaluation/WorkspaceManager.jl
@@ -169,6 +169,10 @@ function start_relaying_logs((session, notebook)::SN, log_channel::Distributed.R
                 try
                     max_log = parse(Int, next_log["kwargs"][maybe_max_log][2] |> first)
 
+                    # Don't include maxlog in the log-message, in line
+                    # with how Julia handles it.
+                    deleteat!(next_log["kwargs"], maybe_max_log)
+
                     # Don't show message with id more than max_log times
                     if max_log isa Int && n_logs >= max_log
                         continue

--- a/src/evaluation/WorkspaceManager.jl
+++ b/src/evaluation/WorkspaceManager.jl
@@ -171,7 +171,7 @@ function start_relaying_logs((session, notebook)::SN, log_channel::Distributed.R
 
                     # Don't show message with id more than max_log times
                     if max_log isa Int && n_logs >= max_log
-                        return
+                        continue
                     end
                 catch
                 end

--- a/test/Logging.jl
+++ b/test/Logging.jl
@@ -26,6 +26,16 @@ using Pluto.WorkspaceManager: poll
             @test poll(5, 1/60) do
                 length(notebook.cells[begin].logs) == 2
             end
+
+            # Check that maxlog doesn't occur in the message
+            @test poll(5, 1/60) do
+                all(notebook.cells[begin].logs) do log
+                    all(log["kwargs"]) do kwarg
+                        kwarg[1] != "maxlog"
+                    end
+                end
+            end
+
             WorkspaceManager.unmake_workspace((🍭, notebook))
         end
 
@@ -47,6 +57,15 @@ using Pluto.WorkspaceManager: poll
                 ids = unique(getindex.(notebook.cells[begin].logs, "id"))
                 counts = [count(log -> log["id"] == id, notebook.cells[begin].logs) for id in ids]
                 counts == [2, 4]
+            end
+
+            # Check that maxlog doesn't occur in the message
+            @test poll(5, 1/60) do
+                all(notebook.cells[begin].logs) do log
+                    all(log["kwargs"]) do kwarg
+                        kwarg[1] != "maxlog"
+                    end
+                end
             end
 
             WorkspaceManager.unmake_workspace((🍭, notebook))


### PR DESCRIPTION
This is an attempt at fixing #1902.  It contains two commits. The first one fixes it so that it doesn't get stuck if multiple logs are encountered when `maxlog` is used on one of them. The second one removes the `maxlog` from the log-message, in line with how Julia handles it. It also adds tests for both of these behaviors.

This is the first time I'm contributing to Pluto so there are some things it would be good if they could be check.
1. At the moment it deletes the `maxlog` element from the log to not have it be printed in the log-message. I'm not sure if this is the right way to do it. I don't know if updating the log is okay, maybe it is used in other places as well? Maybe it is better to exclude `maxlog` from the message in the frontend instead of backend?
2. When writing the tests I mimicked the one existing test. However I don't understand the use of `poll` so I might have misused it.