### PR TITLE
local variable autocomplete

### DIFF
--- a/frontend/components/CellInput/pluto_autocomplete.js
+++ b/frontend/components/CellInput/pluto_autocomplete.js
@@ -174,12 +174,15 @@ let override_text_to_apply_in_field_expression = (text) => {
  * @param {number} context_pos
  */
 const generate_scopestate_completions = function* (definitions, proposed, context_pos) {
+    let i = 0
     for (let [name, { valid_from }] of definitions.entries()) {
         if (!proposed.has(name) && valid_from < context_pos) {
             yield {
-                label: "Scopestate = " + name,
-                apply: name,
+                label: name,
+                type: "c_Any",
+                boost: 99 - i,
             }
+            i += 1
         }
     }
 }

--- a/frontend/components/CellInput/pluto_autocomplete.js
+++ b/frontend/components/CellInput/pluto_autocomplete.js
@@ -17,7 +17,7 @@ import { get_selected_doc_from_state } from "./LiveDocsFromCursor.js"
 import { cl } from "../../common/ClassTable.js"
 import { ScopeStateField } from "./scopestate_statefield.js"
 
-let { autocompletion, completionKeymap } = autocomplete
+let { autocompletion, completionKeymap, completionStatus } = autocomplete
 
 // These should be imported from  @codemirror/autocomplete
 let completionState = autocompletion()[0]
@@ -338,7 +338,12 @@ export let pluto_autocomplete = ({ request_autocomplete, on_update_doc_query }) 
             let autocompletion_state = update.state.field(completionState, false)
             let is_tab_completion = update.state.field(tabCompletionState, false)
 
-            if (autocompletion_state?.open != null && is_tab_completion && autocompletion_state.open.options.length === 1) {
+            if (
+                autocompletion_state?.open != null &&
+                is_tab_completion &&
+                completionStatus(update.state) === "active" &&
+                autocompletion_state.open.options.length === 1
+            ) {
                 acceptCompletion(update.view, autocompletion_state.open.options[0])
             }
         }),

--- a/frontend/components/CellInput/pluto_autocomplete.js
+++ b/frontend/components/CellInput/pluto_autocomplete.js
@@ -211,7 +211,7 @@ const juliahints_cool_generator = (/** @type {PlutoRequestAutocomplete} */ reque
                         [`completion_${completion_type}`]: completion_type != null,
                         c_from_notebook: is_from_notebook,
                     }),
-                    boost: 99 - i / results.length,
+                    boost: 50 - i / results.length,
                 }
             }),
             // This is a small thing that I really want:
@@ -249,8 +249,11 @@ const local_variables_completion = (ctx) => {
         from,
         to,
         options: scopestate.locals
-            .filter(({ validity, name }) => name.startsWith(text) && from > validity.from && to <= validity.to)
-            .map(({ name }) => ({ label: name })),
+            .filter(
+                ({ validity, name }) =>
+                    name.startsWith(text) /** <- NOTE: A smarter matching strategy can be used here */ && from > validity.from && to <= validity.to
+            )
+            .map(({ name }, i) => ({ label: name, type: "c_Any", boost: 99 - i })),
     }
 }
 
@@ -294,7 +297,6 @@ export let pluto_autocomplete = ({ request_autocomplete, on_update_doc_query }) 
             override: [
                 unfiltered_julia_generator(memoize_last_request_autocomplete),
                 juliahints_cool_generator(memoize_last_request_autocomplete),
-                // TODO completion for local variables
                 local_variables_completion,
             ],
             defaultKeymap: false, // We add these manually later, so we can override them if necessary

--- a/frontend/components/CellInput/scopestate_statefield.js
+++ b/frontend/components/CellInput/scopestate_statefield.js
@@ -370,17 +370,19 @@ let raise_scope = (nested_scope, scopestate, nested_scope_validity = null) => {
         locals: [
             ...(nested_scope_validity === null
                 ? []
-                : Array.from(nested_scope.definitions).map(([name, definition]) => ({
-                      name,
-                      definition,
-                      validity: {
-                          // FIXME: Using definition.to is not quite right here, because the
-                          // name is not valid until the assignment expression is done and will
-                          // currently be autocompleted on the right hand side of its own assignment :'(
-                          from: definition.to,
-                          to: nested_scope_validity,
-                      },
-                  }))),
+                : Array.from(nested_scope.definitions)
+                      .filter(([name, _]) => !scopestate.definitions.has(name))
+                      .map(([name, definition]) => ({
+                          name,
+                          definition,
+                          validity: {
+                              // FIXME: Using definition.to is not quite right here, because the
+                              // name is not valid until the assignment expression is done and will
+                              // currently be autocompleted on the right hand side of its own assignment :'(
+                              from: definition.to,
+                              to: nested_scope_validity,
+                          },
+                      }))),
             ...nested_scope.locals,
             ...scopestate.locals,
         ],


### PR DESCRIPTION
This collects all local variables in a new scopestate field along with their "validity" range (range in which they are valid). Can be used for autocompletion of local variable and enhanced linting in #1859 (also potentially renaming of variables). @dralletje, what do you think about this approach ? (lezer-matcher is insane btw :exploding_head:)

![autocomplete_locals](https://user-images.githubusercontent.com/9824244/154343665-7bab47d1-98c4-4cee-9cfe-1a03e6c64899.gif)

