### PR TITLE
Use `precompile` for `SessionActions.open`

### DIFF
--- a/src/webserver/SessionActions.jl
+++ b/src/webserver/SessionActions.jl
@@ -137,6 +137,7 @@ function add(session::ServerSession, nb::Notebook; run_async::Bool=true)
     
     nb
 end
+precompile(SessionActions.open, (ServerSession, String))
 
 function save_upload(content::Vector{UInt8})
     save_path = emptynotebook().path


### PR DESCRIPTION
This PR is another shot at precompilation, see also #1392. I propose here to use `precompile` directly instead of running a minimal code example. This one line of code reduces the time for `SessionActions.open` by 3 seconds on my system while only introducing 0.2 seconds at `using Pluto` (details below)

For most packages, adding `precompile` manually doesn't really work, because for many packages, the inference looks something like this:

![image](https://user-images.githubusercontent.com/20724914/154863731-01f93b75-6e5d-4277-9d18-af7bae6b9faa.png)

(Source: https://github.com/SciML/ModelingToolkit.jl/pull/1215#issuecomment-901415271).

However, for `SessionActions.open`, it looks more like this:

![image](https://user-images.githubusercontent.com/20724914/154863815-6e38062c-4a2f-494d-a353-42a61a6f88d8.png)

What these pictures tell is that for `SessionActions.open`, inference is pretty straightforward. Once `SessionActions.open` is inferred, all methods that it calls can be inferred too. For the ModelingToolkit on the other hand, "many calls are being made by runtime dispatch: each separate flame is a fresh entrance into inference." ([SnoopCompile docs](https://timholy.github.io/SnoopCompile.jl/stable/snoopi_deep_analysis/)).

This makes sense. Pluto is an application where many methods were written with specific types in mind. There is no point in dispatching on multiple types of notebooks or whatever like what numerical packages do with dispatching on different number types. After adding
```
precompile(SessionActions.open, (ServerSession, String))
```
the call graph looks as follows:

![image](https://user-images.githubusercontent.com/20724914/154864240-1305d644-30a0-405e-836f-527e57c0f517.png)

And the time is reduced by 3 seconds (see below for details). With this PR, I would suggest adding a few of these `precompile` calls at strategic places. Note that the `precompile` function compiles the given method but does **not** execute it which explains why this PR has less negative impact on `@time using Pluto` than earlier attempts.

Okay, then a few last things which might come up if you read this.

Firstly, one could wonder "why can't I just make the type signature contain only concrete types? Then there is only one possible method instance, so Julia can precompile that automatically." Well, that was not implemented because it increased the likelihood that people would put concrete types all over the place and that would be causing less generic Julia code (lower composability of packages), see https://github.com/JuliaLang/julia/issues/12897#issuecomment-136552141.

Secondly, one could wonder "why not use SnoopCompile to generate a bunch of precompile directives?". That would indeed also be possible, but would be harder to maintain. The SnoopCompile directives are normally put in `src/precompile.jl`. Now, when updating the signature of a method, package developers have to remember to check `src/precompile.jl` whether the precompile directives have to be updated as well. In the approach that I propose in this PR, the precompile directive is directly below the method definition so it should be easier to keep the two in-sync.

## Before

```julia
$ julia --project

pkg> precompile
[...]

julia> @time using Pluto
  0.705556 seconds (1.01 M allocations: 71.043 MiB, 76.06% compilation time)

julia> session = Pluto.ServerSession();

julia> path = "/home/rik/Downloads/tmp_simple_notebook.jl";

julia> @time Pluto.SessionActions.open(session, path);
11.303100 seconds (23.56 M allocations: 1.242 GiB, 5.09% gc time, 99.91% compilation time)
```

## After

```julia
$ julia --project

pkg> precompile
[...]

julia> @time using Pluto
  0.946054 seconds (1.45 M allocations: 98.672 MiB, 2.80% gc time, 55.25% compilation time)

julia> session = Pluto.ServerSession();

julia> path = "/home/rik/Downloads/tmp_simple_notebook.jl";

julia> @time Pluto.SessionActions.open(session, path);
  8.472655 seconds (16.53 M allocations: 906.598 MiB, 3.31% gc time, 96.59% compilation time)
```