### PR TITLE
Disable CM highlighting in live docs / cell output

### DIFF
--- a/frontend/components/CellOutput.js
+++ b/frontend/components/CellOutput.js
@@ -488,6 +488,9 @@ export let RawHTMLContainer = ({ body, className = "", persist_js_state = false,
     return html`<div class="raw-html-wrapper ${className}" ref=${container}></div>`
 }
 
+// https://github.com/fonsp/Pluto.jl/issues/1692
+const ENABLE_CM_HIGHLIGHTING = false
+
 /** @param {HTMLElement} code_element */
 export let highlight = (code_element, language) => {
     language = language.toLowerCase()
@@ -495,6 +498,7 @@ export let highlight = (code_element, language) => {
 
     if (code_element.children.length === 0) {
         if (
+            ENABLE_CM_HIGHLIGHTING &&
             language === "julia" &&
             // CodeMirror does not want to render inside a `<details>`...
             // I tried to debug this, it does not happen on a clean webpage with the same CM versions:


### PR DESCRIPTION
To workaround/fix #1692 

(This will just use highlightjs, with somewhat similar colors)