### PR TITLE
🏃 Don't use body.classList for ctrl_down to avoid style recalc

### DIFF
--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -974,18 +974,28 @@ patch: ${JSON.stringify(
             this.patch_listeners.forEach((f) => f(patches))
         }
 
+        let ctrl_down_last_val = { current: false }
+        const set_ctrl_down = (value) => {
+            if (value !== ctrl_down_last_val.current) {
+                ctrl_down_last_val.current = value
+                document.body.querySelectorAll("pluto-variable-link").forEach((el) => {
+                    el.setAttribute("data-ctrl-down", value ? "true" : "false")
+                })
+            }
+        }
+
         document.addEventListener("keyup", (e) => {
-            document.body.classList.toggle("ctrl_down", has_ctrl_or_cmd_pressed(e))
+            set_ctrl_down(has_ctrl_or_cmd_pressed(e))
         })
         document.addEventListener("visibilitychange", (e) => {
-            document.body.classList.toggle("ctrl_down", false)
+            set_ctrl_down(false)
             setTimeout(() => {
-                document.body.classList.toggle("ctrl_down", false)
+                set_ctrl_down(false)
             }, 100)
         })
 
         document.addEventListener("keydown", (e) => {
-            document.body.classList.toggle("ctrl_down", has_ctrl_or_cmd_pressed(e))
+            set_ctrl_down(has_ctrl_or_cmd_pressed(e))
             // if (e.defaultPrevented) {
             //     return
             // }

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -2553,13 +2553,13 @@ Based on "Paraíso (Light)" by Jan T. Sott:
     }
 }
 
-body.ctrl_down [data-pluto-variable],
-body.ctrl_down [data-cell-variable] {
+[data-ctrl-down="true"][data-pluto-variable],
+[data-ctrl-down="true"][data-cell-variable] {
     text-decoration-color: #d177e6;
     cursor: pointer;
 }
-body.ctrl_down [data-pluto-variable]:hover,
-body.ctrl_down [data-pluto-variable]:hover * {
+[data-ctrl-down="true"][data-pluto-variable]:hover,
+[data-ctrl-down="true"][data-pluto-variable]:hover * {
     /* This basically `color: #af5bc3`, but it works for emoji too!! */
     color: transparent !important;
     text-shadow: 0 0 #af5bc3;
@@ -2570,7 +2570,7 @@ body.ctrl_down [data-pluto-variable]:hover * {
     /* Can give this cool styles later as well, but not for now nahhh */
     text-decoration: none;
 }
-body.ctrl_down [data-cell-variable]:hover * {
+[data-ctrl-down="true"][data-cell-variable]:hover * {
     /* This basically `color: #af5bc3`, but it works for emoji too!! */
     color: transparent !important;
     text-shadow: 0 0 #af5bc3;


### PR DESCRIPTION
We had this feedback on slack:

![image](https://user-images.githubusercontent.com/6933510/155212293-302e7bff-c5e0-42da-bb71-caf261009b82.png)

This PR addresses this problem!

When running this giant notebook: https://fonsp-disorganised-mess.netlify.app/big.html with 6x CPU throttle in devtools, pressing and releasing Cmd caused a **500ms synchronous style recalculation**, really bad!

Here is the profile of quickly pressing Cmd once:

<img width="763" alt="image" src="https://user-images.githubusercontent.com/6933510/155213780-3cf323a6-61c5-4cb4-b040-1349fcc1038c.png">

This was because we were adding/removing the `ctrl_down` class on `<body>`. As it turns out: adding/removing *any* class on body causes an expensive style calculation. Oops!

## First attempt: 
I used a `data` attribute on body instead. This does not trigger a recalculation on its own (👍), but using that data attribute as a selector in CSS `body[data-ctrl-down="true"]` re-introduces the performance problem. 👎

## Second attempt:
Instead of attaching the attribute to body, we do `document.querySelectorAll("pluto-variable-link")` and set the attribute on all links directly! 

This is very fast (because querySelectorAll with a simple selector is fast because of 🌟browser magic🌟), and solves the problem! Note that CM6 only renders code that is inside the viewport, so even in a big notebook, there will never be that many `pluto-variable-link`. 

It has some issues like "holding control and then scrolling a lot reveals links that are not highlighted" but it felt fine.

## Result

Same situation (pressing Cmd once, massive notebook, 6x slowdown):

<img width="766" alt="image" src="https://user-images.githubusercontent.com/6933510/155214137-e396a185-47cb-4226-9511-27476c16419a.png">
