### PR TITLE
MathJax.js: even lazier load

### DIFF
--- a/frontend/common/SetupMathJax.js
+++ b/frontend/common/SetupMathJax.js
@@ -1,50 +1,69 @@
-// @ts-nocheck
-const deprecated = () => console.warn("Pluto uses MathJax 3, but a MathJax 2 function was called.")
+import "https://cdn.jsdelivr.net/npm/requestidlecallback-polyfill@1.0.2/index.js"
 
-window.MathJax = {
-    options: {
-        ignoreHtmlClass: "no-MαθJax",
-        processHtmlClass: "tex",
-    },
-    startup: {
-        typeset: true, // because we load MathJax asynchronously
-        ready: () => {
-            window.MathJax.startup.defaultReady()
+export const setup_mathjax = () => {
+    const deprecated = () => console.warn("Pluto uses MathJax 3, but a MathJax 2 function was called.")
 
-            // plotly uses MathJax 2, so we have this shim to make it work kindof
-            window.MathJax.Hub = {
-                Queue: function () {
-                    for (var i = 0, m = arguments.length; i < m; i++) {
-                        var fn = window.MathJax.Callback(arguments[i])
-                        window.MathJax.startup.promise = window.MathJax.startup.promise.then(fn)
-                    }
-                    return window.MathJax.startup.promise
-                },
-                Typeset: function (elements, callback) {
-                    var promise = window.MathJax.typesetPromise(elements)
-                    if (callback) {
-                        promise = promise.then(callback)
-                    }
-                    return promise
-                },
-                Register: {
-                    MessageHook: deprecated,
-                    StartupHook: deprecated,
-                    LoadHook: deprecated,
-                },
-                Config: deprecated,
-                Configured: deprecated,
-                setRenderer: deprecated,
-            }
+    // @ts-ignore
+    window.MathJax = {
+        options: {
+            ignoreHtmlClass: "no-MαθJax",
+            processHtmlClass: "tex",
         },
-    },
-    tex: {
-        inlineMath: [
-            ["$", "$"],
-            ["\\(", "\\)"],
-        ],
-    },
-    svg: {
-        fontCache: "global",
-    },
+        startup: {
+            typeset: true, // because we load MathJax asynchronously
+            ready: () => {
+                // @ts-ignore
+                window.MathJax.startup.defaultReady()
+
+                // plotly uses MathJax 2, so we have this shim to make it work kindof
+                // @ts-ignore
+                window.MathJax.Hub = {
+                    Queue: function () {
+                        for (var i = 0, m = arguments.length; i < m; i++) {
+                            // @ts-ignore
+                            var fn = window.MathJax.Callback(arguments[i])
+                            // @ts-ignore
+                            window.MathJax.startup.promise = window.MathJax.startup.promise.then(fn)
+                        }
+                        // @ts-ignore
+                        return window.MathJax.startup.promise
+                    },
+                    Typeset: function (elements, callback) {
+                        // @ts-ignore
+                        var promise = window.MathJax.typesetPromise(elements)
+                        if (callback) {
+                            promise = promise.then(callback)
+                        }
+                        return promise
+                    },
+                    Register: {
+                        MessageHook: deprecated,
+                        StartupHook: deprecated,
+                        LoadHook: deprecated,
+                    },
+                    Config: deprecated,
+                    Configured: deprecated,
+                    setRenderer: deprecated,
+                }
+            },
+        },
+        tex: {
+            inlineMath: [
+                ["$", "$"],
+                ["\\(", "\\)"],
+            ],
+        },
+        svg: {
+            fontCache: "global",
+        },
+    }
+
+    requestIdleCallback(
+        () => {
+            console.log("Loading mathjax!!")
+            const script = document.head.querySelector("#MathJax-script")
+            script.setAttribute("src", script.getAttribute("not-the-src-yet"))
+        },
+        { timeout: 2000 }
+    )
 }

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -25,6 +25,7 @@ import { PlutoContext, PlutoBondsContext, PlutoJSInitializingContext, SetWithEmp
 import { unpack } from "../common/MsgPack.js"
 import { PkgTerminalView } from "./PkgTerminalView.js"
 import { start_binder, BinderPhase, count_stat } from "../common/Binder.js"
+import { setup_mathjax } from "../common/SetupMathJax.js"
 import { read_Uint8Array_with_progress, FetchProgress } from "./FetchProgress.js"
 import { BinderButton } from "./BinderButton.js"
 import { slider_server_actions, nothing_actions } from "../common/SliderServerClient.js"
@@ -1164,6 +1165,10 @@ patch: ${JSON.stringify(
 
         if (old_state.disable_ui !== this.state.disable_ui) {
             this.on_disable_ui()
+        }
+        if (old_state.initializing && !this.state.initializing) {
+            console.info("Initialization done!")
+            setup_mathjax()
         }
 
         if (old_state.notebook.nbpkg?.restart_recommended_msg !== new_state.notebook.nbpkg?.restart_recommended_msg) {

--- a/frontend/editor.html
+++ b/frontend/editor.html
@@ -46,8 +46,8 @@
     <script src="./editor.js" type="module" defer></script>
     <script src="./warn_old_browsers.js"></script>
 
-    <script src="./common/SetupMathJax.js"></script>
-    <script type="text/javascript" id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@3.1.2/es5/tex-svg-full.js" async></script>
+    <!-- This script will be enabled by JS after the notebook has initialized to prevent taking up bandwidth during the initial load. -->
+    <script type="text/javascript" id="MathJax-script" not-the-src-yet="https://cdn.jsdelivr.net/npm/mathjax@3.1.2/es5/tex-svg-full.js" async></script>
 </head>
 
 <body class="loading no-MαθJax"></body>


### PR DESCRIPTION
The `First Paint` time of an HTML export (Tower of Hanoi) goes from 9s to 7s (with Fast 3G throttle, network cache disabled) with this PR.

This PR waits for the `initializing` state to be false (i.e. the statefile has been loaded and is being rendered) before attaching the mathjax `<script>` to DOM.

My reasoning is: MathJax is a massive lib, and currently, it is being loaded in parallel to our main JS assets, taking up bandwidth. Notice mathjax loading during the editor.js waterfall:

![image](https://user-images.githubusercontent.com/6933510/155338326-414a1c94-0cd1-4f59-9443-e3acea780733.png)
