### PR TITLE
Logs: format (ex, backtrace) as error

### DIFF
--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -2464,6 +2464,12 @@ a.stdout-info {
     }
 }
 
+pluto-log-dot jlerror {
+    display: block;
+    background: var(--main-bg-color);
+    padding: 0.6rem;
+    border-radius: 0.5rem;
+}
 pluto-log-dot jltree,
 pluto-log-dot jlpair {
     font-size: 0.6rem;

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -2022,7 +2022,7 @@ function Logging.handle_message(::PlutoLogger, level, msg, _module, group, id, f
             "file" => string(file),
             "cell_id" => currently_running_cell_id[],
             "line" => line isa Union{Int32,Int64} ? line : nothing,
-            "kwargs" => Tuple{String,Any}[(string(k), format_output_default(v)) for (k, v) in kwargs],
+            "kwargs" => Tuple{String,Any}[(string(k), format_log_value(v)) for (k, v) in kwargs],
             )
         )
         
@@ -2033,6 +2033,9 @@ function Logging.handle_message(::PlutoLogger, level, msg, _module, group, id, f
         showerror(stderr, e, stacktrace(catch_backtrace()))
     end
 end
+
+format_log_value(v) = format_output_default(v)
+format_log_value(v::Tuple{<:Exception,Vector{<:Any}}) = format_output(CapturedException(v...))
 
 const stdout_log_level = Logging.LogLevel(-555) # https://en.wikipedia.org/wiki/555_timer_IC
 function with_io_to_logs(f::Function; enabled::Bool=true, loglevel::Logging.LogLevel=Logging.LogLevel(1))


### PR DESCRIPTION
# Before
<img width="896" alt="Schermafbeelding 2022-03-02 om 20 02 56" src="https://user-images.githubusercontent.com/6933510/156430445-87e2fa2a-4993-419a-8f89-30f86cc5da3e.png">


# After
<img width="861" alt="Schermafbeelding 2022-03-02 om 20 00 28" src="https://user-images.githubusercontent.com/6933510/156430038-89e9ea5b-a70f-4fa7-88b6-6e1fbce03843.png">

(The stacktrace is clickable!)

This is a convention in logging (just like #1858) , also supported by the REPL. 