### PR TITLE
improve support for benchmarktools

### DIFF
--- a/src/analysis/ExpressionExplorer.jl
+++ b/src/analysis/ExpressionExplorer.jl
@@ -496,8 +496,6 @@ function explore!(ex::Expr, scopestate::ScopeState)::SymbolsState
                 end
             end
 
-            # Explore code inside function arguments:
-            union!(symstate, explore!(Expr(:block, ex.args[2:end]...), scopestate))
             return symstate
         else
             return explore!(Expr(:block, ex.args...), scopestate)

--- a/test/ExpressionExplorer.jl
+++ b/test/ExpressionExplorer.jl
@@ -588,6 +588,16 @@ Some of these @test_broken lines are commented out to prevent printing to the te
             references=[:x],
         )
     end
+    @testset "Special reactivity rules" begin
+        @test testee(
+            :(BenchmarkTools.generate_benchmark_definition(Main, Symbol[], Any[], Symbol[], (), $(Expr(:copyast, QuoteNode(:(f(x, y, z))))), $(Expr(:copyast, QuoteNode(:(A + B)))), $(Expr(:copyast, QuoteNode(nothing))), BenchmarkTools.parameters())),
+            [:Main, :BenchmarkTools, :Any, :Symbol, :x, :y, :z, :A, :B], [], [[:BenchmarkTools, :generate_benchmark_definition], [:BenchmarkTools, :parameters], :f, :+], []
+        )
+        @test testee(
+            :(Base.macroexpand(Main, $(QuoteNode(:(@enum a b c))))),
+            [:Main, :Base], [], [[:Base, :macroexpand]], [], [Symbol("@enum")]
+        )
+    end
     @testset "Extracting `using` and `import`" begin
         expr = quote
             using A

--- a/test/MacroAnalysis.jl
+++ b/test/MacroAnalysis.jl
@@ -679,7 +679,7 @@ import Pluto: PlutoRunner, Notebook, WorkspaceManager, Cell, ServerSession, Clie
         module_from_cell2 = cell(2).output.body[:elements][1][2][1]
         module_from_cell3 = cell(3).output.body
 
-        @test_broken module_from_cell2 == module_from_cell3
+        @test module_from_cell2 == module_from_cell3
     end
 
     @testset "Definitions" begin


### PR DESCRIPTION
Note that the reactivity rule is not exact because benchmarktools uses eval in the module. 

Fixes #1664 