### PR TITLE
fix a bug where the stdout popup throws an error

### DIFF
--- a/frontend/components/Popup.js
+++ b/frontend/components/Popup.js
@@ -81,7 +81,7 @@ const PkgPopup = ({ notebook, recent_event, clear_recent_event }) => {
         let still_valid = true
         if (recent_event == null) {
             set_pkg_status(null)
-        } else {
+        } else if (recent_event?.type === "nbpkg") {
             ;(pluto_actions.get_avaible_versions({ package_name: recent_event.package_name, notebook_id: notebook.notebook_id }) ?? Promise.resolve([])).then(
                 (versions) => {
                     if (still_valid) {


### PR DESCRIPTION

![pkg_popup](https://user-images.githubusercontent.com/9824244/156938606-f246049f-54f5-423c-9151-61b3849a4ac5.gif)


the pkg popup is instantiated for every event so it handles event from the stdout popup.

https://github.com/fonsp/Pluto.jl/blob/d90e71334bd7f6ec832843881ebd35322a2b0cf4/frontend/components/Popup.js#L57-L61

this is a minimal fix, but maybe it can be safer to instantiate two different popups?