### PR TITLE
🧩 `<pluto-editor>` component that can be placed inside layout

### DIFF
--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -1217,7 +1217,7 @@ patch: ${JSON.stringify(
                     <${PlutoJSInitializingContext.Provider} value=${this.js_init_set}>
                     <${Scroller} active=${this.state.scroller} />
                     <${ProgressBar} notebook=${this.state.notebook} binder_phase=${this.state.binder_phase} status=${status}/>
-                    <header className=${export_menu_open ? "show_export" : ""}>
+                    <header id="pluto-nav" className=${export_menu_open ? "show_export" : ""}>
                         <${ExportBanner}
                             notebookfile_url=${this.export_url("notebookfile")}
                             notebookexport_url=${this.export_url("notebookexport")}

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -928,13 +928,15 @@ main > preamble {
 
 main > preamble #saveall-container {
     margin-left: auto;
-    right: min(0px, 700px + 25px - 100vw);
-    position: relative;
+}
+pluto-editor.fullscreen main > preamble #saveall-container {
+    transform: translateX(max(0px, 100vw - 700px - 25px));
+    /* position: relative; */
 }
 
 @media screen and (min-width: calc(700px + 25px + 6px + 500px)) {
-    main > preamble #saveall-container {
-        right: -500px;
+    pluto-editor.fullscreen main > preamble #saveall-container {
+        transform: translateX(500px);
     }
 }
 

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -52,10 +52,17 @@ body {
     overflow-x: hidden;
     position: relative;
     min-height: 100vh;
-    display: flex;
     flex-direction: column;
     align-items: center;
     background-color: var(--main-bg-color);
+}
+
+pluto-editor {
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    min-width: 0;
 }
 
 main {
@@ -81,14 +88,15 @@ body:not(.disable_ui) {
 /* | main=25px+700px+6px=731px | pluto-helpbox=350px - 500px | */
 /* min-width: 731px+ */
 
+/* CAN WE HAVE CONTAINER QUERIES PLESSSSS */
 @media screen and (min-width: calc(700px + 25px + 6px)) and (max-width: calc(700px + 25px + 6px + 500px)) {
-    body:not(.disable_ui) main {
+    body:not(.disable_ui) pluto-editor.fullscreen main {
         margin-left: 0px;
         align-self: flex-start;
     }
 }
 @media screen and (min-width: calc(700px + 25px + 6px + 500px)) and (max-width: calc(700px + 25px + 6px + 500px + 500px)) {
-    body:not(.disable_ui) main {
+    body:not(.disable_ui) pluto-editor.fullscreen main {
         margin-right: 500px;
         align-self: flex-end;
     }

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -446,7 +446,7 @@ pluto-output mjx-assistive-mml {
 
 /* HEADER */
 
-body > header {
+header#pluto-nav {
     /* position: absolute;
     top: 0px; */
     width: 100%;
@@ -461,7 +461,7 @@ body > header {
     font-size: 0.75rem;
 }
 
-body > header.show_export {
+header#pluto-nav.show_export {
     position: sticky;
     top: 0;
     transform: translateY(130px);
@@ -717,10 +717,10 @@ nav#at_the_top:after {
     }
 }
 
-body.binder > header > nav#at_the_top > pluto-filepicker > * {
+body.binder header#pluto-nav > nav#at_the_top > pluto-filepicker > * {
     display: none;
 }
-body.binder > header > nav#at_the_top > pluto-filepicker > a {
+body.binder header#pluto-nav > nav#at_the_top > pluto-filepicker > a {
     display: block;
     font-size: 16px;
     font-family: var(--julia-mono-font-stack);
@@ -728,33 +728,33 @@ body.binder > header > nav#at_the_top > pluto-filepicker > a {
     text-decoration: none;
 }
 
-body.nbpkg_restart_recommended > header,
-body.nbpkg_restart_required > header,
-body.binder.loading > header,
-body.process_dead > header,
-body.disconnected > header {
+body.nbpkg_restart_recommended header#pluto-nav,
+body.nbpkg_restart_required header#pluto-nav,
+body.binder.loading header#pluto-nav,
+body.process_dead header#pluto-nav,
+body.disconnected header#pluto-nav {
     position: sticky;
     top: 0;
     backdrop-filter: blur(10px);
     -webkit-backdrop-filter: blur(10px);
 }
 
-body.nbpkg_restart_recommended > header {
+body.nbpkg_restart_recommended header#pluto-nav {
     background-color: var(--restart-recc-header-color);
 }
-body.nbpkg_restart_required > header {
+body.nbpkg_restart_required header#pluto-nav {
     background-color: var(--restart-req-header-color);
 }
-body.process_dead > header {
+body.process_dead header#pluto-nav {
     background-color: var(--dead-process-header-color);
 }
-body.loading > header {
+body.loading header#pluto-nav {
     background-color: var(--loading-header-color);
 }
-body.disconnected > header {
+body.disconnected header#pluto-nav {
     background-color: var(--disconnected-header-color);
 }
-body.binder.loading > header {
+body.binder.loading header#pluto-nav {
     background-color: var(--binder-loading-header-color);
 }
 
@@ -838,8 +838,8 @@ body.is_recording .outline-frame.recording {
     box-shadow: inset 0px 0px 20px 20px #919bff2b;
 }
 
-body.recording_waiting_to_start > header,
-body.is_recording > header {
+body.recording_waiting_to_start header#pluto-nav,
+body.is_recording header#pluto-nav {
     display: none;
 }
 
@@ -2153,7 +2153,7 @@ footer input {
     border-right: none;
 }
 
-body > header pluto-filepicker button,
+header#pluto-nav pluto-filepicker button,
 footer button {
     margin: 0px;
     background: var(--footer-filepicker-focus-color);
@@ -2509,7 +2509,7 @@ body.presentation #helpbox-wrapper {
     display: none !important;
 }
 
-body > nav#slide_controls {
+nav#slide_controls {
     display: none;
 }
 body.presentation > nav#slide_controls {
@@ -2520,23 +2520,23 @@ body.presentation > nav#slide_controls {
     z-index: 100;
 }
 
-body > nav#slide_controls > button {
+nav#slide_controls > button {
     position: static;
     padding: 5px;
 }
 
-body > nav#slide_controls > button > span::after {
+nav#slide_controls > button > span::after {
     content: " " !important;
     display: block;
     height: 30px;
     width: 30px;
     background-size: 30px 30px;
 }
-body > nav#slide_controls > button.prev > span::after {
+nav#slide_controls > button.prev > span::after {
     background-image: url(https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/arrow-back-outline.svg);
     filter: var(--image-filters);
 }
-body > nav#slide_controls > button.next > span::after {
+nav#slide_controls > button.next > span::after {
     background-image: url(https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/arrow-forward-outline.svg);
     filter: var(--image-filters);
 }

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -2098,7 +2098,7 @@ pluto-helpbox > section hr {
 
 footer {
     width: 100%;
-    height: 3.5rem;
+    min-height: 3.5rem;
     font-family: "Roboto Mono", monospace;
     font-size: 0.75rem;
     background-color: var(--footer-bg-color);
@@ -2107,10 +2107,11 @@ footer {
 }
 
 footer form {
-    height: 1.5rem;
+    min-height: 1.5rem;
     opacity: 1;
     transition: opacity 5s;
     display: flex;
+    flex-wrap: wrap;
 }
 
 footer form > * {

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -52,8 +52,6 @@ body {
     overflow-x: hidden;
     position: relative;
     min-height: 100vh;
-    flex-direction: column;
-    align-items: center;
     background-color: var(--main-bg-color);
 }
 

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -1002,7 +1002,6 @@ pluto-output {
     padding-right: 10px;
     align-items: baseline;
     overflow-x: auto;
-
     background-color: var(--pluto-output-bg-color);
 }
 
@@ -1203,18 +1202,26 @@ pluto-shoulder {
     position: absolute;
     /* top: 0px; */
     /* bottom: 0px; */
-    left: -2000px;
-    width: 2000px;
+    --invisible-border: calc(0.5 * var(--pluto-cell-spacing));
+    --shoulder-width: calc(28px + var(--invisible-border));
+    --border-radius: calc(5px + var(--invisible-border));
+
+    left: calc(0px - var(--shoulder-width));
+    width: var(--shoulder-width);
+    border-radius: var(--border-radius) 0px 0px var(--border-radius);
     cursor: move;
     display: flex;
     flex-direction: row;
     justify-content: flex-end;
     align-items: flex-start;
-    /* Add an invisible border around the shoulder, to make it easier to click on. (The are between two cells is divided in two, each half belongs to the closest pluto-cell.) */
-    top: calc(0px - 0.5 * var(--pluto-cell-spacing));
-    bottom: calc(0px - 0.5 * var(--pluto-cell-spacing));
-    border-top: calc(0.5 * var(--pluto-cell-spacing)) solid rgba(0, 0, 0, 0);
-    border-bottom: calc(0.5 * var(--pluto-cell-spacing)) solid rgba(0, 0, 0, 0);
+    /* Add an invisible border around the shoulder, to make it easier to click on. (The area between two cells is divided in two, each half belongs to the closest pluto-cell.) */
+    top: calc(0px - var(--invisible-border));
+    bottom: calc(0px - var(--invisible-border));
+    border: var(--invisible-border) solid rgba(0, 0, 0, 0);
+    border-right: none;
+}
+pluto-editor.fullscreen pluto-shoulder {
+    --shoulder-width: 2000px;
 }
 
 pluto-shoulder:hover {

--- a/frontend/editor.html
+++ b/frontend/editor.html
@@ -50,5 +50,9 @@
     <script type="text/javascript" id="MathJax-script" not-the-src-yet="https://cdn.jsdelivr.net/npm/mathjax@3.1.2/es5/tex-svg-full.js" async></script>
 </head>
 
-<body class="loading no-MαθJax"></body>
+<body class="loading no-MαθJax">
+
+<pluto-editor class="fullscreen"></pluto-editor>
+
+</body>
 </html>

--- a/frontend/editor.html
+++ b/frontend/editor.html
@@ -51,8 +51,8 @@
 </head>
 
 <body class="loading no-MαθJax">
-
+<div style="display: flex; min-height: 100vh;">
 <pluto-editor class="fullscreen"></pluto-editor>
-
+</div>
 </body>
 </html>

--- a/frontend/editor.js
+++ b/frontend/editor.js
@@ -117,4 +117,4 @@ const EditorLoader = ({ launch_params }) => {
 }
 
 // it's like a Rube Goldberg machine
-render(html`<${EditorLoader} launch_params=${launch_params} />`, document.body)
+document.body.querySelectorAll("pluto-editor").forEach((el) => render(html`<${EditorLoader} launch_params=${launch_params} />`, el))

--- a/frontend/editor.js
+++ b/frontend/editor.js
@@ -131,6 +131,22 @@ const EditorLoader = ({ launch_params }) => {
 
 // Create a web component for EditorLoader that takes in additional launch parameters as attributes
 // possible attribute names are `Object.keys(launch_params)`
+
+// This means that you can do stuff like:
+/* 
+<pluto-editor disable_ui notebookfile="https://juliapluto.github.io/weekly-call-notes/2022/02-10/notes.jl" statefile="https://juliapluto.github.io/weekly-call-notes/2022/02-10/notes.plutostate"  ></pluto-editor>
+        
+<pluto-editor disable_ui notebookfile="https://juliapluto.github.io/weekly-call-notes/2022/02-10/notes.jl" statefile="https://juliapluto.github.io/weekly-call-notes/2022/02-10/notes.plutostate"  ></pluto-editor> 
+*/
+
+// or:
+
+/* 
+<pluto-editor notebook_id="fcc1b498-a141-11ec-342a-593db1016648"></pluto-editor>
+
+<pluto-editor notebook_id="21ebc942-a1ed-11ec-2505-7b242b18daf3"></pluto-editor>
+*/
+
 class PlutoEditorComponent extends HTMLElement {
     constructor() {
         super()

--- a/frontend/editor.js
+++ b/frontend/editor.js
@@ -53,6 +53,19 @@ const launch_params = {
 }
 console.log("Launch parameters: ", launch_params)
 
+const truthy = (x) => x === "" || x === "true"
+
+const from_attribute = (element, name) => {
+    const val = element.getAttribute(name)
+    if (name === "disable_ui") {
+        return truthy(val)
+    } else if (name === "isolated_cell_id") {
+        return val == null ? null : val.split(",")
+    } else {
+        return val
+    }
+}
+
 /**
  *
  * @returns {import("./components/Editor.js").NotebookData}
@@ -116,5 +129,17 @@ const EditorLoader = ({ launch_params }) => {
           `
 }
 
-// it's like a Rube Goldberg machine
-document.body.querySelectorAll("pluto-editor").forEach((el) => render(html`<${EditorLoader} launch_params=${launch_params} />`, el))
+// Create a web component for EditorLoader that takes in additional launch parameters as attributes
+// possible attribute names are `Object.keys(launch_params)`
+class PlutoEditorComponent extends HTMLElement {
+    constructor() {
+        super()
+    }
+
+    connectedCallback() {
+        const new_launch_params = Object.fromEntries(Object.entries(launch_params).map(([k, v]) => [k, from_attribute(this, k) ?? v]))
+
+        render(html`<${EditorLoader} launch_params=${new_launch_params} />`, this)
+    }
+}
+customElements.define("pluto-editor", PlutoEditorComponent)

--- a/frontend/hide-ui.css
+++ b/frontend/hide-ui.css
@@ -3,7 +3,7 @@ main {
     cursor: auto;
 }
 
-body > header,
+body header#pluto-nav,
 preamble > button,
 pluto-cell > button,
 pluto-input > button,


### PR DESCRIPTION
After this PR, the `editor.html` will look like:

```html
<body class="loading no-MαθJax">

<pluto-editor class="fullscreen"></pluto-editor>

</body>
```

(and the result is exactly as it was before this PR)

If you change it into this:

```html
<body class="loading no-MαθJax">
    
    <div style="
        display: flex; 
        flex-direction: row;
        min-height: 100vh;
        align-items: stretch;
        ">
        
        <div style="
        font-family: system-ui;
        flex: 0 1 16rem;
        background: #282936;
        color: white;
        font-weight: 600;
        z-index: 23400;
        ">
            <ul>
                <li>Home</li>
                <li>About</li>
                <li>Contact</li>
                <li>Chapter 1</li>
                <li>Chapter 1</li>
                <li>Chapter 1</li>
                <li>Chapter 1</li>
                <li>Final stuff</li>
            </ul>
        </div>
        
        <pluto-editor></pluto-editor>
        
    </div>
</body>
```

Then the editor will render inside the `pluto-editor` element! This PR builds on top of #1974 and #1975  and adds the CSS tweaks necessary to make our editor composable like that!

![image](https://user-images.githubusercontent.com/6933510/157996028-66181958-d449-4445-ba49-c56b2ac7cb03.png)

The goal is to make the sidebar-left-notebook-right layout possible without putting the notebook in an iframe, like we currently do in https://computationalthinking.mit.edu/Spring21/inverse_climate_model/

It also adds makes a difference between `<pluto-editor>` and `<pluto-editor class=fullscreen>`. fullscreen is what you are used to. In not-fullscreen-mode, the cell drag shoulders are only 20px wide instead of stretching out of the screen on the left, and the editor is always centered horizontally.

<img src="https://user-images.githubusercontent.com/6933510/157996059-ee9c89e4-9ee0-41ec-bbb4-19d7e73cd850.png" width=200>


---

Now here's something funny! If you then change
```html
<pluto-editor></pluto-editor>
```
into
```html
<pluto-editor></pluto-editor>
<pluto-editor></pluto-editor>
```
then you get this:

https://user-images.githubusercontent.com/6933510/157995819-1a7ef26b-eea8-4b7f-b6b2-07c74cee29d6.mov


# Future

Hey..... what if `<pluto-editor>` was an actual custom web component? Right now it takes in launch parameters from the URL (like the notebook ID to connect to) or from the `window.pluto_...` variables, but those can be props! Then you can embed Pluto notebooks on random pages!

# todo

- [x] cell rectangle select broken
- [x] new notebook does not fill screen vertically
- [x] "Save changes" button disappeared