### PR TITLE
Improve accuracy of compilation benchmarks and add one for `Pluto.run`

### DIFF
--- a/src/webserver/WebServer.jl
+++ b/src/webserver/WebServer.jl
@@ -69,7 +69,7 @@ function run(; kwargs...)
 end
 
 function run(options::Configuration.Options)
-    session = ServerSession(;options=options)
+    session = ServerSession(; options)
     run(session)
 end
 

--- a/test/compiletimes.jl
+++ b/test/compiletimes.jl
@@ -29,16 +29,15 @@ wait_for_ready(nb)
 
 HTTP.get("http://github.com")
 
-# This part doesn't terminate on any Windows system.
-# @timeit TOUT "Pluto.run" server_task = @eval let
-#     port = 13435
-#     options = Pluto.Configuration.from_flat_kwargs(; port, launch_browser=false, workspace_use_distributed=false, require_secret_for_access=false, require_secret_for_open_links=false)
-#     🍭 = Pluto.ServerSession(; options)
-#     server_task = @async Pluto.run(🍭)
-#
-#     # Give the async task time to start.
-#     sleep(1)
-#
-#     HTTP.get("http://localhost:$port/edit").status == 200
-#     server_task
-# end
+@timeit TOUT "Pluto.run" server_task = @eval let
+    port = 13435
+    options = Pluto.Configuration.from_flat_kwargs(; port, launch_browser=false, workspace_use_distributed=false, require_secret_for_access=false, require_secret_for_open_links=false)
+    🍭 = Pluto.ServerSession(; options)
+    server_task = @async Pluto.run(🍭)
+
+    # Give the async task time to start.
+    sleep(1)
+
+    HTTP.get("http://localhost:$port/edit").status == 200
+    server_task
+end

--- a/test/compiletimes.jl
+++ b/test/compiletimes.jl
@@ -28,7 +28,7 @@ wait_for_ready(nb)
     🍭 = Pluto.ServerSession(; options)
     server_task = @async Pluto.run(🍭)
 
-    retry(; delays=ExponentialBackOff(n=5, first_delay=0.5)) do
+    retry(; delays=fill(0.1, 20)) do
         HTTP.get("http://localhost:$port/edit").status == 200
     end
     server_task

--- a/test/compiletimes.jl
+++ b/test/compiletimes.jl
@@ -27,6 +27,7 @@ wait_for_ready(nb)
 # However, it's very tricky to measure this via the `Pluto.run` below.
 @timeit TOUT "Configuration.from_flat_kwargs" @eval Pluto.Configuration.from_flat_kwargs()
 
+# Precompile 
 HTTP.get("http://github.com")
 
 @timeit TOUT "Pluto.run" server_task = @eval let

--- a/test/compiletimes.jl
+++ b/test/compiletimes.jl
@@ -1,5 +1,9 @@
 # Collect Time To Finish Task (TTFT)
 
+@timeit TOUT "Pluto.Cell" cell = Pluto.Cell("1 + 1")
+
+@timeit TOUT "Pluto.Notebook" nb = Pluto.Notebook([cell])
+
 function wait_for_ready(notebook::Pluto.Notebook)
     while notebook.process_status != Pluto.ProcessStatus.ready
         sleep(0.1)
@@ -17,3 +21,17 @@ path = joinpath(pkgdir(Pluto), "sample", "Basic.jl")
 wait_for_ready(nb)
 
 @timeit TOUT "SessionActions.shutdown" Pluto.SessionActions.shutdown(🍭, nb; async=true)
+
+@timeit TOUT "Pluto.run" server_task = let
+    port = 13435
+    options = Pluto.Configuration.from_flat_kwargs(; port, launch_browser=false, workspace_use_distributed=true, require_secret_for_access=false, require_secret_for_open_links=false)
+    🍭 = Pluto.ServerSession(; options)
+    server_task = @async Pluto.run(🍭)
+
+    retry(; delays=ExponentialBackOff(n=5, first_delay=0.5)) do
+        HTTP.get("http://localhost:$port/edit").status == 200
+    end
+    server_task
+end
+
+schedule(server_task, InterruptException(); error=true)

--- a/test/compiletimes.jl
+++ b/test/compiletimes.jl
@@ -27,19 +27,3 @@ wait_for_ready(nb)
 # However, it's very tricky to measure this via the `Pluto.run` below.
 @timeit TOUT "Configuration.from_flat_kwargs" @eval Pluto.Configuration.from_flat_kwargs()
 
-HTTP.get("http://github.com")
-
-@timeit TOUT "Pluto.run" server_task = @eval let
-    port = 13435
-    options = Pluto.Configuration.from_flat_kwargs(; port, launch_browser=false, workspace_use_distributed=false, require_secret_for_access=false, require_secret_for_open_links=false)
-    🍭 = Pluto.ServerSession(; options)
-    server_task = @async Pluto.run(🍭)
-
-    # Give the async task time to start.
-    sleep(1)
-
-    HTTP.get("http://localhost:$port/edit").status == 200
-    server_task
-end
-
-schedule(server_task, InterruptException(); error=true)

--- a/test/compiletimes.jl
+++ b/test/compiletimes.jl
@@ -27,3 +27,18 @@ wait_for_ready(nb)
 # However, it's very tricky to measure this via the `Pluto.run` below.
 @timeit TOUT "Configuration.from_flat_kwargs" @eval Pluto.Configuration.from_flat_kwargs()
 
+HTTP.get("http://github.com")
+
+# This part doesn't terminate on any Windows system.
+# @timeit TOUT "Pluto.run" server_task = @eval let
+#     port = 13435
+#     options = Pluto.Configuration.from_flat_kwargs(; port, launch_browser=false, workspace_use_distributed=false, require_secret_for_access=false, require_secret_for_open_links=false)
+#     🍭 = Pluto.ServerSession(; options)
+#     server_task = @async Pluto.run(🍭)
+#
+#     # Give the async task time to start.
+#     sleep(1)
+#
+#     HTTP.get("http://localhost:$port/edit").status == 200
+#     server_task
+# end

--- a/test/compiletimes.jl
+++ b/test/compiletimes.jl
@@ -31,7 +31,7 @@ HTTP.get("http://github.com")
 
 @timeit TOUT "Pluto.run" server_task = @eval let
     port = 13435
-    options = Pluto.Configuration.from_flat_kwargs(; port, launch_browser=false, workspace_use_distributed=true, require_secret_for_access=false, require_secret_for_open_links=false)
+    options = Pluto.Configuration.from_flat_kwargs(; port, launch_browser=false, workspace_use_distributed=false, require_secret_for_access=false, require_secret_for_open_links=false)
     🍭 = Pluto.ServerSession(; options)
     server_task = @async Pluto.run(🍭)
 

--- a/test/helpers.jl
+++ b/test/helpers.jl
@@ -7,6 +7,7 @@ macro timeit_include(path::AbstractString) :(@timeit TOUT $path include($path)) 
 import Pluto.ExpressionExplorer
 import Pluto.ExpressionExplorer: SymbolsState, compute_symbolreferences, FunctionNameSignaturePair, UsingsImports, compute_usings_imports
 using Test
+using HTTP
 import Distributed
 
 function Base.show(io::IO, s::SymbolsState)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,6 @@ include("helpers.jl")
 verify_no_running_processes()
 show(TOUT; compact=true, sortby=:firstexec)
 exit(0)
-
 @timeit_include("Events.jl")
 verify_no_running_processes()
 @timeit_include("WorkspaceManager.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,8 +4,6 @@ include("helpers.jl")
 
 @timeit_include("compiletimes.jl")
 verify_no_running_processes()
-show(TOUT; compact=true, sortby=:firstexec)
-exit(0)
 @timeit_include("Events.jl")
 verify_no_running_processes()
 @timeit_include("WorkspaceManager.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,9 @@ include("helpers.jl")
 
 @timeit_include("compiletimes.jl")
 verify_no_running_processes()
+show(TOUT; compact=true, sortby=:firstexec)
+exit(0)
+
 @timeit_include("Events.jl")
 verify_no_running_processes()
 @timeit_include("WorkspaceManager.jl")


### PR DESCRIPTION
Small follow up on https://github.com/fonsp/Pluto.jl/pull/1959. This shows how long `Pluto.run` actually takes before responding in the browser. Also `@time @eval` is now used instead of just `@time`. Using `@time @eval` is necessary for accurate benchmarks. For details, see the docstring of `@time`:

> In some cases the system will look inside the `@time` expression and compile some of the called code before execution of the top-level expression begins. When that happens, some compilation time will not be counted. To include this time you can run `@time @eval ....`