### PR TITLE
Fix #1987 and #1990

### DIFF
--- a/frontend/common/SetupMathJax.js
+++ b/frontend/common/SetupMathJax.js
@@ -1,6 +1,13 @@
 import "https://cdn.jsdelivr.net/npm/requestidlecallback-polyfill@1.0.2/index.js"
 
+let setup_done = false
+
 export const setup_mathjax = () => {
+    if (setup_done) {
+        return
+    }
+    setup_done = true
+
     const deprecated = () => console.warn("Pluto uses MathJax 3, but a MathJax 2 function was called.")
 
     // @ts-ignore

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -761,17 +761,6 @@ patch: ${JSON.stringify(
         }
         this.on_disable_ui()
 
-        if (this.state.static_preview) {
-            this.setState({
-                initializing: false,
-                binder_phase: this.state.offer_binder ? BinderPhase.wait_for_user : null,
-            })
-            // view stats on https://stats.plutojl.org/
-            count_stat(`article-view`)
-        } else {
-            this.connect()
-        }
-
         setInterval(() => {
             if (!this.state.static_preview && document.visibilityState === "visible") {
                 // view stats on https://stats.plutojl.org/
@@ -1115,6 +1104,20 @@ patch: ${JSON.stringify(
                 // and don't prevent the unload
             }
         })
+    }
+
+    componentDidMount() {
+        if (this.state.static_preview) {
+            console.log("setting state to initializing: false")
+            this.setState({
+                initializing: false,
+                binder_phase: this.state.offer_binder ? BinderPhase.wait_for_user : null,
+            })
+            // view stats on https://stats.plutojl.org/
+            count_stat(`article-view`)
+        } else {
+            this.connect()
+        }
     }
 
     componentDidUpdate(old_props, old_state) {

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -1108,7 +1108,6 @@ patch: ${JSON.stringify(
 
     componentDidMount() {
         if (this.state.static_preview) {
-            console.log("setting state to initializing: false")
             this.setState({
                 initializing: false,
                 binder_phase: this.state.offer_binder ? BinderPhase.wait_for_user : null,

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -1150,8 +1150,7 @@ patch: ${JSON.stringify(
         if (old_state.disable_ui !== this.state.disable_ui) {
             this.on_disable_ui()
         }
-        if (old_state.initializing && !this.state.initializing) {
-            console.info("Initialization done!")
+        if (!this.state.initializing) {
             setup_mathjax()
         }
 

--- a/frontend/editor.js
+++ b/frontend/editor.js
@@ -153,7 +153,7 @@ class PlutoEditorComponent extends HTMLElement {
     }
 
     connectedCallback() {
-        const new_launch_params = Object.fromEntries(Object.entries(launch_params).map(([k, v]) => [k, from_attribute(this, k) || v]))
+        const new_launch_params = Object.fromEntries(Object.entries(launch_params).map(([k, v]) => [k, from_attribute(this, k) ?? v]))
 
         render(html`<${EditorLoader} launch_params=${new_launch_params} />`, this)
     }

--- a/frontend/editor.js
+++ b/frontend/editor.js
@@ -153,7 +153,7 @@ class PlutoEditorComponent extends HTMLElement {
     }
 
     connectedCallback() {
-        const new_launch_params = Object.fromEntries(Object.entries(launch_params).map(([k, v]) => [k, from_attribute(this, k) ?? v]))
+        const new_launch_params = Object.fromEntries(Object.entries(launch_params).map(([k, v]) => [k, from_attribute(this, k) || v]))
 
         render(html`<${EditorLoader} launch_params=${new_launch_params} />`, this)
     }


### PR DESCRIPTION
These changes should fix the problems with lazy MathJax loading. Additionally this PR fixes a problem with the pluto-editor web component argument parser. See code comments for more info.

Closes #1987 
Closes #1990 