### PR TITLE
Improve readability and inferability inside `Pluto.run(session, router)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -39,8 +39,9 @@ julia = "^1.6"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [targets]
-test = ["DataFrames", "OffsetArrays", "Random", "Test", "TimerOutputs"]
+test = ["DataFrames", "OffsetArrays", "Random", "Sockets", "Test", "TimerOutputs"]

--- a/src/webserver/WebServer.jl
+++ b/src/webserver/WebServer.jl
@@ -119,7 +119,7 @@ end
 
 const is_first_run = Ref(true)
 
-"Return a port and serversocket to use while taking into acoount the `favourite_port`."
+"Return a port and serversocket to use while taking into account the `favourite_port`."
 function port_serversocket(hostIP::Sockets.IPAddr, favourite_port)
     local port, serversocket
     if favourite_port === nothing

--- a/src/webserver/WebServer.jl
+++ b/src/webserver/WebServer.jl
@@ -119,6 +119,22 @@ end
 
 const is_first_run = Ref(true)
 
+"Return a port and serversocket to use while taking into acoount the `favourite_port`."
+function port_serversocket(hostIP::Sockets.IPAddr, favourite_port)
+    local port, serversocket
+    if favourite_port === nothing
+        port, serversocket = Sockets.listenany(hostIP, UInt16(1234))
+    else
+        port = UInt16(favourite_port)
+        try
+            serversocket = Sockets.listen(hostIP, port)
+        catch e
+            error("Port with number $port is already in use. Use Pluto.run() to automatically select an available port.")
+        end
+    end
+    return port, serversocket
+end
+
 function run(session::ServerSession, pluto_router)
     if is_first_run[]
         is_first_run[] = false
@@ -135,23 +151,12 @@ function run(session::ServerSession, pluto_router)
     host = session.options.server.host
     hostIP = parse(Sockets.IPAddr, host)
     favourite_port = session.options.server.port
-    
-    local port, serversocket
-    if favourite_port === nothing
-        port, serversocket = Sockets.listenany(hostIP, UInt16(1234))
-    else
-        port = UInt16(favourite_port)
-        try
-            serversocket = Sockets.listen(hostIP, port)
-        catch e
-            @error "Port with number $port is already in use. Use Pluto.run() to automatically select an available port."
-            return
-        end
-    end
+
+    local port, serversocket = port_serversocket(hostIP, favourite_port)
 
     shutdown_server = Ref{Function}(() -> ())
 
-    servertask = @async HTTP.serve(hostIP, port, stream=true, server=serversocket) do http::HTTP.Stream
+    servertask = @async HTTP.serve(hostIP, port; stream=true, server=serversocket) do http::HTTP.Stream
         # messy messy code so that we can use the websocket on the same port as the HTTP server
         if HTTP.WebSockets.is_upgrade(http.message)
             secret_required = let

--- a/test/helpers.jl
+++ b/test/helpers.jl
@@ -6,6 +6,7 @@ macro timeit_include(path::AbstractString) :(@timeit TOUT $path include($path)) 
 @timeit TOUT "import Pluto" import Pluto
 import Pluto.ExpressionExplorer
 import Pluto.ExpressionExplorer: SymbolsState, compute_symbolreferences, FunctionNameSignaturePair, UsingsImports, compute_usings_imports
+using Sockets
 using Test
 using HTTP
 import Distributed

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,10 @@ include("helpers.jl")
 
 @timeit_include("compiletimes.jl")
 verify_no_running_processes()
+if get(ENV, "PLUTO_TEST_ONLY_COMPILETIMES", nothing) == "true"
+    show(TOUT; compact=true, sortby=:firstexec)
+    exit(0)
+end
 @timeit_include("Events.jl")
 verify_no_running_processes()
 @timeit_include("WorkspaceManager.jl")

--- a/test/webserver.jl
+++ b/test/webserver.jl
@@ -10,6 +10,9 @@ using Pluto.WorkspaceManager: WorkspaceManager, poll
 
 
 @testset "Exports" begin
+    @inferred Pluto.port_serversocket(Sockets.ip"0.0.0.0", nothing)
+    @inferred Pluto.port_serversocket(Sockets.ip"0.0.0.0", 13439)
+
     port = 13432
     host = "localhost"
     local_url(suffix) = "http://$host:$port/$suffix"

--- a/test/webserver.jl
+++ b/test/webserver.jl
@@ -11,7 +11,6 @@ using Pluto.WorkspaceManager: WorkspaceManager, poll
 
 @testset "Exports" begin
     @inferred Pluto.port_serversocket(Sockets.ip"0.0.0.0", nothing)
-    @inferred Pluto.port_serversocket(Sockets.ip"0.0.0.0", 13439)
 
     port = 13432
     host = "localhost"


### PR DESCRIPTION
This PR improves readability and inferability of `Pluto.run(session, router)`. Inside that method, the type of `port` wasn't inferred correctly according to `Cthulhu.@descend/@code_warntype`. With the change of this PR, the number of non concrete variables (red variables right at the top) inside `@code_warntype` is reduced from 8 to 4 on Julia 1.8-beta3. I think that the reason that it wasn't inferred is that it's a huge method and the compiler will at some point just give up when things are too difficult.

This improved inferability potentially allowed a larger part of the method to be compiled during

```julia
precompile(run, (ServerSession, HTTP.Handlers.Router{Symbol("##001")}))
```

which seems to be the case because `Pluto.run` went from 623MiB to 558MiB when running `test/compiletimes.jl` in Julia 1.8-beta3. For more info about finding these types of issues and why they affect precompilation, see https://huijzer.xyz/posts/inference/.