### PR TITLE
Add a precompile statement to `PlutoRunner` and some minor refactorings

### DIFF
--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -570,8 +570,6 @@ function run_expression(
     
     cell_results[cell_id], cell_runtimes[cell_id] = result, runtime
 end
-# Saves about 30 MiB allocations for
-# module Foo end; @time @eval Pluto.PlutoRunner.run_expression(Foo, :(1 + 1), Pluto.uuid1(), nothing);
 precompile(run_expression, (Module, Expr, UUID, Nothing))
 
 # Channel to trigger implicits run
@@ -723,8 +721,6 @@ function delete_toplevel_methods(f::Function, cell_id::UUID)::Bool
     end
     return !isempty(methods(f).ms)
 end
-# Saves about 10 MiB allocations on f() = 3; PlutoRunner.delete_toplevel_methods(f, Pluto.uuid1())
-precompile(delete_toplevel_methods, (Function, UUID))
 
 # function try_delete_toplevel_methods(workspace::Module, name::Symbol)
 #     try_delete_toplevel_methods(workspace, [name])

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -514,7 +514,7 @@ function run_expression(
     # We add the time it took to macroexpand to the time for the first call,
     # but we make sure we don't mention it on subsequent calls
     expansion_runtime = if expanded_cache.did_mention_expansion_time === false
-        did_mention_expansion_time = false
+        did_mention_expansion_time = true
         cell_expanded_exprs[cell_id] = CachedMacroExpansion(
             expanded_cache.original_expr_hash,
             expanded_cache.expanded_expr,

--- a/test/compiletimes.jl
+++ b/test/compiletimes.jl
@@ -5,6 +5,9 @@
 
 @timeit TOUT "Pluto.Notebook" nb = @eval Pluto.Notebook([cell])
 
+module Foo end
+@timeit TOUT "PlutoRunner.run_expression" @eval Pluto.PlutoRunner.run_expression(Foo, :(1 + 1), Pluto.uuid1(), nothing);
+
 function wait_for_ready(notebook::Pluto.Notebook)
     while notebook.process_status != Pluto.ProcessStatus.ready
         sleep(0.1)

--- a/test/compiletimes.jl
+++ b/test/compiletimes.jl
@@ -27,7 +27,7 @@ wait_for_ready(nb)
 # However, it's very tricky to measure this via the `Pluto.run` below.
 @timeit TOUT "Configuration.from_flat_kwargs" @eval Pluto.Configuration.from_flat_kwargs()
 
-# Precompile 
+# Compile HTTP get.
 HTTP.get("http://github.com")
 
 @timeit TOUT "Pluto.run" server_task = @eval let


### PR DESCRIPTION
Some small changes to make the PlutoRunner slightly more snappy.

Changes:

- Drop `Base.@kwdef` to make the code simpler and avoid having to compile a kwarg method.
- Fix some type inferability problems by adding type assertions. This is tested against Julia 1.8-beta3.
- Narrow down the type of `old_logger` a bit. This doesn't help in performance, but probably helps in readability.
- Add a `precompile` statement for `run_expression`.

## Time to first X

On Linux with Julia 1.8-beta3.

### Before (`master`)

```julia
$ julia --project -ie 'using Pluto'
[...]

julia> module Foo end
Main.Foo

julia> @time @eval Pluto.PlutoRunner.run_expression(Foo, :(1 + 1), Pluto.uuid1(), nothing);
[...]
  1.653029 seconds (2.94 M allocations: 152.834 MiB, 13.22% gc time, 99.80% compilation time)
```

### After (this PR)

```julia
$ julia --project -ie 'using Pluto'
[...]

julia> module Foo end
Main.Foo

julia> @time @eval Pluto.PlutoRunner.run_expression(Foo, :(1 + 1), Pluto.uuid1(), nothing);
[...]
  1.287273 seconds (1.60 M allocations: 82.489 MiB, 2.78% gc time, 99.70% compilation time)
```

