### PR TITLE
🐝 Fix sliderserver-binder combination

### DIFF
--- a/frontend/common/SliderServerClient.js
+++ b/frontend/common/SliderServerClient.js
@@ -16,7 +16,9 @@ export const nothing_actions = ({ actions }) =>
                 ? // the original action
                   v
                 : // a no-op action
-                  () => {},
+                  (...args) => {
+                      console.info("Ignoring action", k, { args })
+                  },
         ])
     )
 

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -1153,7 +1153,7 @@ patch: ${JSON.stringify(
             console.info(`Binder phase: ${phase} at ${new Date().toLocaleTimeString()}`)
         }
 
-        if (old_state.disable_ui !== this.state.disable_ui) {
+        if (old_state.disable_ui !== this.state.disable_ui || old_state.connected !== this.state.connected) {
             this.on_disable_ui()
         }
         if (!this.state.initializing) {


### PR DESCRIPTION
Fix https://github.com/JuliaPluto/PlutoSliderServer.jl/issues/52

# Problem

See the above issue,


https://user-images.githubusercontent.com/6933510/164315010-23130e75-f63a-42e6-a575-b356a4329940.mov


# How I found the problem

Lots of editing features were disabled. Adding a breakpoint to one of them (the fold button), showed that it called the `nothing_actions`:

https://user-images.githubusercontent.com/6933510/164322037-dc53f81b-9f90-4f6d-95d4-d2e1d499fc2d.mov

When UI is disabled (e.g. in regular HTML export), we replace `this.actions` in Editor.js with "fake actions", which don't do anything. This is how we disable lots of editor features without too much specialized code.

When connected to a binder backend, `this.actions` should be reset to the original set of actions, but this wasn't working because of an error in my react logic. (This is the class-component-version of forgetting a dependency in a `useEffect` hook.) This PR fixes that!