### PR TITLE
Show bonds "greyed out" when not connected

### DIFF
--- a/frontend/common/Bond.js
+++ b/frontend/common/Bond.js
@@ -157,7 +157,7 @@ export const add_bonds_disabled_message_handler = (bond_nodes, invalidation) => 
                         detail: {
                             type: "info",
                             source_element: e.target,
-                            body: html`${`This is a static document. `}
+                            body: html`${`You are viewing a static document. `}
                                 <a
                                     href="#"
                                     onClick=${(e) => {

--- a/frontend/common/Bond.js
+++ b/frontend/common/Bond.js
@@ -157,7 +157,7 @@ export const add_bonds_disabled_message_handler = (bond_nodes, invalidation) => 
                         detail: {
                             type: "info",
                             source_element: e.target,
-                            body: html`This is a static document.
+                            body: html`${`This is a static document. `}
                                 <a
                                     href="#"
                                     onClick=${(e) => {
@@ -167,7 +167,7 @@ export const add_bonds_disabled_message_handler = (bond_nodes, invalidation) => 
                                     }}
                                     >Run this notebook</a
                                 >
-                                to enable interactivity.`,
+                                ${` to enable interactivity.`}`,
                         },
                     })
                 )

--- a/frontend/common/Bond.js
+++ b/frontend/common/Bond.js
@@ -2,6 +2,7 @@
 // import Generators_input from "https://unpkg.com/@observablehq/stdlib@3.3.1/src/generators/input.js"
 
 import _ from "../imports/lodash.js"
+import { html } from "../imports/Preact.js"
 import observablehq from "./SetupCellEnvironment.js"
 
 /**
@@ -125,8 +126,12 @@ const set_input_value = (input, new_value) => {
     }
 }
 
-export const set_bound_elements_to_their_value = (node, bond_values) => {
-    for (let bond_node of node.querySelectorAll("bond")) {
+/**
+ * @param {NodeListOf<Element>} bond_nodes
+ * @param {{[name: string]: any}} bond_values
+ */
+export const set_bound_elements_to_their_value = (bond_nodes, bond_values) => {
+    bond_nodes.forEach((bond_node) => {
         let bond_name = bond_node.getAttribute("def")
         if (bond_node.firstElementChild != null && bond_values[bond_name] != null) {
             let val = bond_values[bond_name].value
@@ -136,19 +141,60 @@ export const set_bound_elements_to_their_value = (node, bond_values) => {
                 console.error(`Error while setting input value`, bond_node.firstElementChild, `to value`, val, `: `, error)
             }
         }
-    }
+    })
 }
 
 /**
- * @param {Element} node
+ * @param {NodeListOf<Element>} bond_nodes
+ * @param {Promise<void>} invalidation
+ */
+export const add_bonds_disabled_message_handler = (bond_nodes, invalidation) => {
+    bond_nodes.forEach((bond_node) => {
+        const listener = (e) => {
+            if (e.target.closest(".bonds_disabled.offer_binder")) {
+                window.dispatchEvent(
+                    new CustomEvent("open pluto popup", {
+                        detail: {
+                            type: "info",
+                            source_element: e.target,
+                            body: html`This is a static document.
+                                <a
+                                    href="#"
+                                    onClick=${(e) => {
+                                        //@ts-ignore
+                                        window.open_edit_or_run_popup()
+                                        e.preventDefault()
+                                    }}
+                                    >Run this notebook</a
+                                >
+                                to enable interactivity.`,
+                        },
+                    })
+                )
+            }
+        }
+        bond_node.addEventListener("click", listener)
+        invalidation.then(() => {
+            bond_node.removeEventListener("click", listener)
+        })
+    })
+}
+
+/**
+ * @param {NodeListOf<Element>} bond_nodes
  * @param {(name: string, value: any) => Promise} on_bond_change
  * @param {{[name: string]: any}} known_values Object of variable names that already have a value in the state, which we may not want to send the initial bond value for. When reloading the page, bonds are set to their values from the state, and we don't want to trigger a change event for those.
+ * @param {Promise<void>} invalidation
  */
-export const add_bonds_listener = (node, on_bond_change, known_values) => {
+export const add_bonds_listener = (bond_nodes, on_bond_change, known_values, invalidation) => {
     // the <bond> node will be invalidated when the cell re-evaluates. when this happens, we need to stop processing input events
     let node_is_invalidated = false
 
-    node.querySelectorAll("bond").forEach(async (bond_node) => {
+    invalidation.then(() => {
+        node_is_invalidated = true
+    })
+
+    bond_nodes.forEach(async (bond_node) => {
         const name = bond_node.getAttribute("def")
         const initial_value = get_input_value(bond_node.firstElementChild)
 
@@ -176,10 +222,6 @@ export const add_bonds_listener = (node, on_bond_change, known_values) => {
             await on_bond_change(name, to_send).catch(console.error)
         }
     })
-
-    return function dispose_bond_listener() {
-        node_is_invalidated = true
-    }
 }
 
 /**

--- a/frontend/components/BinderButton.js
+++ b/frontend/components/BinderButton.js
@@ -7,6 +7,11 @@ export const BinderButton = ({ offer_binder, start_binder, notebookfile }) => {
     const notebookfile_ref = useRef("")
     notebookfile_ref.current = notebookfile
 
+    //@ts-ignore
+    window.open_edit_or_run_popup = () => {
+        setPopupOpen(true)
+    }
+
     useEffect(() => {
         const handlekeyup = (e) => {
             e.key === "Escape" && setPopupOpen(false)

--- a/frontend/components/CellOutput.js
+++ b/frontend/components/CellOutput.js
@@ -3,7 +3,7 @@ import { html, Component, useRef, useLayoutEffect, useContext, useEffect, useMem
 import { ErrorMessage } from "./ErrorMessage.js"
 import { TreeView, TableView, DivElement } from "./TreeView.js"
 
-import { add_bonds_listener, set_bound_elements_to_their_value } from "../common/Bond.js"
+import { add_bonds_disabled_message_handler, add_bonds_listener, set_bound_elements_to_their_value } from "../common/Bond.js"
 import { cl } from "../common/ClassTable.js"
 
 import { observablehq_for_cells } from "../common/SetupCellEnvironment.js"
@@ -412,7 +412,7 @@ export let RawHTMLContainer = ({ body, className = "", persist_js_state = false,
     let container = useRef(/** @type {HTMLElement} */ (null))
 
     useLayoutEffect(() => {
-        set_bound_elements_to_their_value(container.current, pluto_bonds)
+        set_bound_elements_to_their_value(container.current.querySelectorAll("bond"), pluto_bonds)
     }, [body, persist_js_state, pluto_actions, pluto_bonds])
 
     useLayoutEffect(() => {
@@ -449,9 +449,10 @@ export let RawHTMLContainer = ({ body, className = "", persist_js_state = false,
                 })
 
                 if (pluto_actions != null) {
-                    set_bound_elements_to_their_value(container.current, pluto_bonds)
-                    let remove_bonds_listener = add_bonds_listener(container.current, pluto_actions.set_bond, pluto_bonds)
-                    invalidation.then(remove_bonds_listener)
+                    const bond_nodes = container.current.querySelectorAll("bond")
+                    set_bound_elements_to_their_value(bond_nodes, pluto_bonds)
+                    add_bonds_listener(bond_nodes, pluto_actions.set_bond, pluto_bonds, invalidation)
+                    add_bonds_disabled_message_handler(bond_nodes, invalidation)
                 }
 
                 // Convert LaTeX to svg

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -83,6 +83,7 @@ const statusmap = (state, launch_params) => ({
     nbpkg_restart_recommended: state.notebook.nbpkg?.restart_recommended_msg != null,
     nbpkg_disabled: state.notebook.nbpkg?.enabled === false,
     static_preview: state.static_preview,
+    bonds_disabled: !(state.connected || state.initializing || launch_params.slider_server_url != null),
     binder: launch_params.binder_url != null && state.backend_launch_phase != null,
     code_differs: state.notebook.cell_order.some(
         (cell_id) => state.cell_inputs_local[cell_id] != null && state.notebook.cell_inputs[cell_id].code !== state.cell_inputs_local[cell_id].code

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -84,6 +84,7 @@ const statusmap = (/** @type {EditorState} */ state, /** @type {LaunchParameters
     nbpkg_disabled: state.notebook.nbpkg?.enabled === false,
     static_preview: state.static_preview,
     bonds_disabled: !(state.connected || state.initializing || launch_params.slider_server_url != null),
+    offer_binder: state.backend_launch_phase === BackendLaunchPhase.wait_for_user && launch_params.binder_url != null,
     binder: launch_params.binder_url != null && state.backend_launch_phase != null,
     code_differs: state.notebook.cell_order.some(
         (cell_id) => state.cell_inputs_local[cell_id] != null && state.notebook.cell_inputs[cell_id].code !== state.cell_inputs_local[cell_id].code
@@ -1267,9 +1268,6 @@ patch: ${JSON.stringify(
             >${text}</a
         >`
 
-        const wfu = this.state.backend_launch_phase === BackendLaunchPhase.wait_for_user
-        const offer_binder = wfu && launch_params.binder_url != null
-
         return html`
             ${this.state.disable_ui === false && html`<${HijackExternalLinksToOpenInNewTab} />`}
             
@@ -1370,9 +1368,9 @@ patch: ${JSON.stringify(
                     />
                     
                     ${
-                        offer_binder
+                        status.offer_binder
                             ? html`<${BinderButton}
-                                  offer_binder=${offer_binder}
+                                  offer_binder=${status.offer_binder}
                                   start_binder=${() =>
                                       start_binder({
                                           setStatePromise: this.setStatePromise,

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -656,7 +656,6 @@ pluto-filepicker button:disabled {
     cursor: not-allowed;
 }
 
-
 button.start_stop_recording,
 button.toggle_export {
     border: none;
@@ -1052,6 +1051,11 @@ pluto-output div.raw-html-wrapper {
 
 pluto-output:not(.rich_output) > div > pre {
     display: flex;
+}
+
+.bonds_disabled.offer_binder bond {
+    opacity: 0.6;
+    filter: grayscale(1);
 }
 
 /* as embedded display: */


### PR DESCRIPTION
When viewing a static HTML without a PlutoSliderServer, it can be confusing that there are sliders that don't work. This PR explains why, and recommends running the notebook.

I decided to use CSS (`filter: grayscale(1)`) without actually disabling input (which would be by setting the `disabled` attribute on the first child) because that might be too invasive, and it has some tricky edge cases.

# Before

![Schermafbeelding 2022-04-21 om 19 36 04](https://user-images.githubusercontent.com/6933510/164518519-2f3d404b-0918-480f-9e2f-0ec74b0a4a8c.png)

# After

https://user-images.githubusercontent.com/6933510/164518546-50c9bdb8-b03c-42fc-b31a-079b41c132f3.mov


