### PR TITLE
(technically api breaking) Remove the `notebook` field of `NewNotebookEvent`

### DIFF
--- a/src/notebook/Events.jl
+++ b/src/notebook/Events.jl
@@ -85,7 +85,6 @@ end
 
 # Triggered when we open a new notebook
 struct NewNotebookEvent <: PlutoEvent
-    notebook::Notebook
 end
 
 # Triggered when a user opens a notebook

--- a/src/webserver/SessionActions.jl
+++ b/src/webserver/SessionActions.jl
@@ -21,7 +21,7 @@ end
 function open_url(session::ServerSession, url::AbstractString; kwargs...)
     random_notebook = emptynotebook()
     path = download_cool(url, random_notebook.path)
-    result = try_event_call(session, NewNotebookEvent(random_notebook))
+    result = try_event_call(session, NewNotebookEvent())
     nb = if result isa UUID
         open(session, path; notebook_id=result, kwargs...)
     else
@@ -202,7 +202,7 @@ function new(session::ServerSession; run_async=true, notebook_id::UUID=uuid1())
         end
     end
     # Run NewNotebookEvent handler before assigning ID
-    isid = try_event_call(session, NewNotebookEvent(nb))
+    isid = try_event_call(session, NewNotebookEvent())
     nb.notebook_id = isnothing(isid) ? notebook_id : isid
 
     update_save_run!(session, nb, nb.cells; run_async=run_async, prerender_text=true)


### PR DESCRIPTION
I found it confusing to pass in a notebook, even though this event is fired _before/during_ its creation, and the event result will set the notebook id.