### PR TITLE
`POST /notebookupload`: allow specifying a filename

### DIFF
--- a/src/notebook/PathHelpers.jl
+++ b/src/notebook/PathHelpers.jl
@@ -44,6 +44,9 @@ const nouns = [
 	"conjecture"
 ]
 
+"""
+Generate a filename like `"Cute discovery"`. Does not end with `.jl`.
+"""
 function cutename()
     titlecase(rand(adjectives)) * " " * rand(nouns)
 end

--- a/src/webserver/SessionActions.jl
+++ b/src/webserver/SessionActions.jl
@@ -153,12 +153,21 @@ function add(session::ServerSession, nb::Notebook; run_async::Bool=true)
 end
 precompile(add, (ServerSession, Notebook))
 
-function save_upload(content::Vector{UInt8})
-    save_path = emptynotebook().path
-    Base.open(save_path, "w") do io
-        write(io, content)
-    end
+"""
+Generate a non-existing new notebook filename, and write `contents` to that file. Return the generated filename.
 
+# Example
+```julia
+save_upload(some_notebook_data; filename_base="hello") == "~/.julia/pluto_notebooks/hello 5.jl"
+```
+"""
+function save_upload(contents::Union{String,Vector{UInt8}}; filename_base::Union{Nothing,AbstractString}=nothing)
+    save_path = numbered_until_new(
+        joinpath(
+            new_notebooks_directory(), 
+            something(filename_base, cutename())
+        ); suffix=".jl")
+    write(save_path, contents)
     save_path
 end
 

--- a/src/webserver/Static.jl
+++ b/src/webserver/Static.jl
@@ -323,7 +323,10 @@ function http_router_for(session::ServerSession)
         required=security.require_secret_for_access || 
         security.require_secret_for_open_links
     ) do request::HTTP.Request
-        save_path = SessionActions.save_upload(request.body)
+        uri = HTTP.URI(request.target)
+        query = HTTP.queryparams(uri)
+        
+        save_path = SessionActions.save_upload(request.body; filename_base=get(query, "name", nothing))
         try_launch_notebook_response(
             SessionActions.open,
             save_path;


### PR DESCRIPTION
You can now do `POST /notebookupload?name=hello%20world` and it will create a file like `hello world 3.jl` instead of `Cute analysis 7.jl`