### PR TITLE
launch_params: allow specific `integrity` for notebookfile and statefile urls

### DIFF
--- a/frontend/common/Binder.js
+++ b/frontend/common/Binder.js
@@ -126,7 +126,7 @@ export const start_binder = async ({ setStatePromise, connect, launch_params }) 
         if (launch_params.notebookfile.startsWith("data:")) {
             open_response = await fetch(with_token(new URL("notebookupload", binder_session_url)), {
                 method: "POST",
-                body: await (await fetch(launch_params.notebookfile)).arrayBuffer(),
+                body: await (await fetch(new Request(launch_params.notebookfile, { integrity: launch_params.notebookfile_integrity }))).arrayBuffer(),
             })
         } else {
             for (const [p1, p2] of [

--- a/frontend/common/PlutoHash.js
+++ b/frontend/common/PlutoHash.js
@@ -1,3 +1,4 @@
+//@ts-ignore
 import { sha256 } from "https://cdn.jsdelivr.net/gh/JuliaPluto/js-sha256@v0.9.0-es6/src/sha256.mjs"
 
 export const base64_arraybuffer = async (/** @type {BufferSource} */ data) => {

--- a/frontend/common/SliderServerClient.js
+++ b/frontend/common/SliderServerClient.js
@@ -23,7 +23,7 @@ export const nothing_actions = ({ actions }) =>
     )
 
 export const slider_server_actions = ({ setStatePromise, launch_params, actions, get_original_state, get_current_state, apply_notebook_patches }) => {
-    const notebookfile_hash = fetch(launch_params.notebookfile)
+    const notebookfile_hash = fetch(new Request(launch_params.notebookfile, { integrity: launch_params.notebookfile_integrity }))
         .then(assert_response_ok)
         .then((r) => r.arrayBuffer())
         .then(plutohash_arraybuffer)

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -179,13 +179,16 @@ const first_true_key = (obj) => {
  * @type {{
  *  notebook_id: string?,
  *  statefile: string?,
+ *  statefile_integrity: string?,
  *  notebookfile: string?,
+ *  notebookfile_integrity: string?,
  *  disable_ui: boolean,
  *  preamble_html: string?,
  *  isolated_cell_ids: string[]?,
  *  binder_url: string?,
  *  slider_server_url: string?,
  *  recording_url: string?,
+ *  recording_url_integrity: string?,
  *  recording_audio_url: string?,
  * }}
  */
@@ -1355,8 +1358,7 @@ patch: ${JSON.stringify(
                         export_url=${this.export_url}
                     />
                     <${RecordingPlaybackUI} 
-                        recording_url=${launch_params.recording_url}
-                        audio_src=${launch_params.recording_audio_url}
+                        launch_params=${launch_params}
                         initializing=${this.state.initializing}
                         apply_notebook_patches=${this.apply_notebook_patches}
                         reset_notebook_state=${() =>

--- a/frontend/components/RecordingUI.js
+++ b/frontend/components/RecordingUI.js
@@ -201,12 +201,27 @@ let get_scroll_top = ({ cell_id, relative_distance }) => {
     return cell.offsetTop + relative_distance * cell.offsetHeight - window.innerHeight / 2
 }
 
-export const RecordingPlaybackUI = ({ recording_url, audio_src, initializing, apply_notebook_patches, reset_notebook_state }) => {
+/**
+ *
+ * @param {{
+ *  launch_params: import("./Editor.js").LaunchParameters,
+ *  initializing: boolean,
+ *  [key: string]: any,
+ * }} props
+ * @returns
+ */
+export const RecordingPlaybackUI = ({ launch_params, initializing, apply_notebook_patches, reset_notebook_state }) => {
+    const { recording_url, recording_url_integrity, recording_audio_url } = launch_params
+
     let loaded_recording = useMemo(
         () =>
             Promise.resolve().then(async () => {
                 if (recording_url) {
-                    return unpack(new Uint8Array(await (await fetch(recording_url).then(assert_response_ok)).arrayBuffer()))
+                    return unpack(
+                        new Uint8Array(
+                            await (await fetch(new Request(recording_url, { integrity: recording_url_integrity })).then(assert_response_ok)).arrayBuffer()
+                        )
+                    )
                 } else {
                     return null
                 }
@@ -416,7 +431,7 @@ export const RecordingPlaybackUI = ({ recording_url, audio_src, initializing, ap
                             </div>
                         </div>`
                       : null}
-                  ${frame} <${AudioPlayer} audio_element_ref=${audio_element_ref} src=${audio_src} loaded_recording=${loaded_recording} />`
+                  ${frame} <${AudioPlayer} audio_element_ref=${audio_element_ref} src=${recording_audio_url} loaded_recording=${loaded_recording} />`
             : null}
     `
 }

--- a/frontend/editor.js
+++ b/frontend/editor.js
@@ -34,7 +34,11 @@ const launch_params = {
     //@ts-ignore
     statefile: url_params.get("statefile") ?? window.pluto_statefile,
     //@ts-ignore
+    statefile_integrity: url_params.get("statefile_integrity") ?? window.pluto_statefile_integrity,
+    //@ts-ignore
     notebookfile: url_params.get("notebookfile") ?? window.pluto_notebookfile,
+    //@ts-ignore
+    notebookfile_integrity: url_params.get("notebookfile_integrity") ?? window.pluto_notebookfile_integrity,
     //@ts-ignore
     disable_ui: !!(url_params.get("disable_ui") ?? window.pluto_disable_ui),
     //@ts-ignore
@@ -47,6 +51,8 @@ const launch_params = {
     slider_server_url: url_params.get("slider_server_url") ?? window.pluto_slider_server_url,
     //@ts-ignore
     recording_url: url_params.get("recording_url") ?? window.pluto_recording_url,
+    //@ts-ignore
+    recording_url_integrity: url_params.get("recording_url_integrity") ?? window.pluto_recording_url_integrity,
     //@ts-ignore
     recording_audio_url: url_params.get("recording_audio_url") ?? window.pluto_recording_audio_url,
 }
@@ -105,7 +111,7 @@ const EditorLoader = ({ launch_params }) => {
     useEffect(() => {
         if (!ready_for_editor && static_preview) {
             ;(async () => {
-                const r = await fetch(launch_params.statefile)
+                const r = await fetch(new Request(launch_params.statefile, { integrity: launch_params.statefile_integrity }))
                 const data = await read_Uint8Array_with_progress(r, set_statefile_download_progress)
                 const state = unpack(data)
                 initial_notebook_state_ref.current = state


### PR DESCRIPTION
(See #1315 about what `integrity` checks are.)

You can now specify the `integrity` for some of the launch parameters, e.g.

```julia
window.pluto_notebookfile = "https://cdn.jsdelivr.net/gh/JuliaPluto/featured@50640fc/classic%20samples/JavaScript.jl"
window.pluto_notebookfile_integrity = "sha256-a6tkMGqDXdih5SJ9KTkdP+yqoQ+QLJYwOGptPvKqltA="
window.pluto_statefile = "https://cdn.jsdelivr.net/gh/JuliaPluto/featured@50640fc/classic%20samples/JavaScript.plutostate"
window.pluto_statefile_integrity = "sha256-UhdXO2pcEue/IVnDBErtpJYC+jRPD8Fa/PmO1Dw3nCI="
```

(this example actually works!)

When these settings are missing, everything works as it did before the PR.

# Why
You generally don't need this, except when you are using an external host for these files that you don't want to trust. Since the notebookfile will run on your computer, changing the file could give access.

In #2048, we will host our Featured notebook files and precomputed statefiles on the web. Eventually, we want to serve these Features from plutojl.org (which will allow us to publish new features continuously, without updating Pluto), but in the meantime, we are using cdn.jsdelivr.net as our host. As discussed in #1315, this would introduce a new "trusted" group: jsdelivr, unless we specify the integrity.

> Note: integrity is ignored when launching a binder backend because it uses the `open?url=` endpoint of the Pluto server running on binder. This is fine, because it's not running locally. In #2048, the notebook file is downloaded on the frontend, with integrity check, before running locally.