### PR TITLE
bundler: don't allow empty response

### DIFF
--- a/frontend-bundler/parcel-resolver-like-a-browser/https-resolver.js
+++ b/frontend-bundler/parcel-resolver-like-a-browser/https-resolver.js
@@ -68,6 +68,10 @@ module.exports = new Resolver({
                 // and converting binary assets into strings and then passing them doesn't work 🤷‍♀️.
                 let buffer = await response.buffer()
 
+                if (buffer.length === 0) {
+                    throw new Error(`${specifier} returned an empty reponse.`)
+                }
+
                 await mkdirp(folder)
                 await fs.writeFile(fullpath, buffer)
             }

--- a/frontend-bundler/parcel-resolver-like-a-browser/https-resolver.js
+++ b/frontend-bundler/parcel-resolver-like-a-browser/https-resolver.js
@@ -68,12 +68,19 @@ module.exports = new Resolver({
                 // and converting binary assets into strings and then passing them doesn't work 🤷‍♀️.
                 let buffer = await response.buffer()
 
-                if (buffer.length === 0) {
+                const response_length = buffer.length
+
+                if (response_length === 0) {
                     throw new Error(`${specifier} returned an empty reponse.`)
                 }
 
                 await mkdirp(folder)
-                await fs.writeFile(fullpath, buffer)
+                const write_result = await fs.writeFile(fullpath, buffer)
+
+                // Verify that the file was written correctly:
+                if (write_result !== undefined || (await fs.readFile(fullpath)).length !== response_length) {
+                    throw new Error(`Failed to write file ${fullpath}`)
+                }
             }
 
             return { filePath: fullpath }


### PR DESCRIPTION
We recently had two 'bad bundles' in releases 0.19.1 and 0.19.2, see #2045 and #2059. The bundle error in #2045 was caught by our tests (but I did not see the failure, my bad), but #2059 created a styling issue, which is not covered by our tests.

After some debugging, it looks like both failures were caused by `cdn.jsdelivr.net` returning a **200 response with no content**. This led to these bad files:
- `0.19.1`: https://github.com/fonsp/Pluto.jl/blob/v0.19.1/frontend-dist/editor.38d394c2.js
- `0.19.2`: https://github.com/fonsp/Pluto.jl/blob/v0.19.2/frontend-dist/caret-forward-circle-outline.38d394c2.svg

This PR checks for an empty file and throws an error, causing the bundle to fail.