### PR TITLE
Set `Base.Experimental.@max_methods 1`

### DIFF
--- a/src/Pluto.jl
+++ b/src/Pluto.jl
@@ -10,6 +10,10 @@ https://github.com/fonsp/Pluto.jl/wiki
 """
 module Pluto
 
+if isdefined(Base, :Experimental) && isdefined(Base.Experimental, Symbol("@max_methods"))
+    @eval Base.Experimental.@max_methods 1
+end
+
 import RelocatableFolders: @path
 const ROOT_DIR = normpath(joinpath(@__DIR__, ".."))
 const FRONTEND_DIR = @path(joinpath(ROOT_DIR, "frontend"))

--- a/test/compiletimes.jl
+++ b/test/compiletimes.jl
@@ -1,9 +1,10 @@
-# Collect Time To Finish Task (TTFT)
-
-# Using `@eval` to avoid missing compile time, see the `@time` docstring for more info.
-@timeit TOUT "Pluto.Cell" cell = @eval Pluto.Cell("1 + 1")
-
-@timeit TOUT "Pluto.Notebook" nb = @eval Pluto.Notebook([cell])
+# Collect Time To First X (TTFX)
+#
+# A few notes about these compile times benchmarks.
+#   1. These benchmarks are meant to show where the biggest problems are and to be able to trace back where some regression was introduced.
+#   2. The benchmarks use `@eval` to avoid missing compile time, see the `@time` docstring for more info.
+#   3. Only add benchmarks for methods which take more than 1 seconds on the first run to reduce noise.
+#   4. Note that some benchmarks depend on disk and network speeds too, so focus on the number of allocations since those are more robust.
 
 module Foo end
 @timeit TOUT "PlutoRunner.run_expression" @eval Pluto.PlutoRunner.run_expression(Foo, :(1 + 1), Pluto.uuid1(), nothing);
@@ -20,15 +21,11 @@ end
 
 path = joinpath(pkgdir(Pluto), "sample", "Basic.jl")
 
-@timeit TOUT "SessionActions.open" nb = @eval Pluto.SessionActions.open(🍭, path; run_async=true)
+@timeit TOUT "SessionActions.open" nb = @eval Pluto.SessionActions.open(🍭, path; run_async=false)
 
 wait_for_ready(nb)
 
-@timeit TOUT "SessionActions.shutdown" @eval Pluto.SessionActions.shutdown(🍭, nb; async=true)
-
-# According to SnoopCompile, this is a big part of the time for `Pluto.run()`.
-# However, it's very tricky to measure this via the `Pluto.run` below.
-@timeit TOUT "Configuration.from_flat_kwargs" @eval Pluto.Configuration.from_flat_kwargs()
+Pluto.SessionActions.shutdown(🍭, nb; async=false)
 
 # Compile HTTP get.
 HTTP.get("http://github.com")


### PR DESCRIPTION
From Julia 1.8 onwards, there is the `Base.Experimental.@max_methods` setting (https://github.com/JuliaLang/julia/pull/43370). See especially https://github.com/JuliaLang/julia/pull/43370#issuecomment-989186549 for an example of what this setting does.

In `Pluto.jl`, I've seen a bunch of methods showing inferred fields as `Union{Vector{Tuple}, Vector{Tuple{Any}}}` or other unhelpful types. It's better if the compiler would waste time on that and just infer `Any`.

## Benchmarks

Below are the benchmarks for compilation time and some random extra benchmarks to verify that running time isn't seriously affected. All benchmarks on Julia 1.8-beta3:

### Without `@max_methods` (`main`)

```
 Section                        ncalls     time    %tot     alloc    %tot
 ────────────────────────────────────────────────────────────────────────
 import Pluto                        1    580ms    1.9%   77.7MiB    2.9%
 compiletimes.jl                     1    29.8s   98.1%   2.50GiB   97.1%
   PlutoRunner.run_expression        1    1.48s    4.9%   86.8MiB    3.3%
   SessionActions.open               1    18.5s   60.7%   1.43GiB   55.6%
   Pluto.run                         1    4.85s   15.9%    558MiB   21.2%
 ──────────────────────────────────────────────────────────────────────── 
```

```julia
julia> @btime Pluto.PlutoRunner.format_output((a=[1,2], c=Dict("d"=>(5,6,true))));
  845.114 μs (1638 allocations: 104.02 KiB)

julia> @btime Pluto.PlutoRunner.try_macroexpand(Main, Pluto.uuid1(), Expr(:toplevel, :(import Base)));
  16.821 μs (195 allocations: 7.42 KiB)
```

### With `@max_methods` (this PR)

```
 Section                        ncalls     time    %tot     alloc    %tot
 ────────────────────────────────────────────────────────────────────────
 import Pluto                        1    561ms    1.9%   74.7MiB    3.0%
 compiletimes.jl                     1    29.0s   98.1%   2.38GiB   97.0%
   PlutoRunner.run_expression        1    1.42s    4.8%   79.4MiB    3.2%
   SessionActions.open               1    17.6s   59.6%   1.31GiB   53.4%
   Pluto.run                         1    4.67s   15.8%    562MiB   22.4%
 ────────────────────────────────────────────────────────────────────────  
```

```julia
julia> @btime Pluto.PlutoRunner.format_output((a=[1,2], c=Dict("d"=>(5,6,true))));
  846.670 μs (1638 allocations: 104.02 KiB)

julia> @btime Pluto.PlutoRunner.try_macroexpand(Main, Pluto.uuid1(), Expr(:toplevel, :(import Base)));
  15.118 μs (166 allocations: 6.83 KiB)
```