### PR TITLE
Performance of state diffing: improve runtime type checks

### DIFF
--- a/src/webserver/Dynamic.jl
+++ b/src/webserver/Dynamic.jl
@@ -131,7 +131,7 @@ function notebook_to_js(notebook::Notebook)
             id => Dict{String,Any}(
                 "cell_id" => cell.cell_id,
                 "depends_on_disabled_cells" => cell.depends_on_disabled_cells,
-                "output" => Dict(                
+                "output" => Dict{String,Any}(
                     "body" => cell.output.body,
                     "mime" => cell.output.mime,
                     "rootassignee" => cell.output.rootassignee,
@@ -150,7 +150,7 @@ function notebook_to_js(notebook::Notebook)
         "cell_order" => notebook.cell_order,
         "published_objects" => merge!(Dict{String,Any}(), (c.published_objects for c in values(notebook.cells_dict))...),
         "bonds" => Dict{String,Dict{String,Any}}(
-            String(key) => Dict(
+            String(key) => Dict{String,Any}(
                 "value" => bondvalue.value, 
             )
         for (key, bondvalue) in notebook.bonds),


### PR DESCRIPTION
The functions `notebook_to_js` and `Firebasey.diff` are performance bottlenecks right now, and their runtime scales linearly with notebook size. They are called after every notebook state change.

For the PlutoUI sample notebook, which is quite large, these functions take about **5ms** (on a fast CPU), adding a 5ms overhead to any state change. 

# Before
<img width="728" alt="Schermafbeelding 2022-04-29 om 12 31 18" src="https://user-images.githubusercontent.com/6933510/165928587-ed2ce69e-598c-4304-a9c9-7994068d82ef.png">


# After
<img width="729" alt="Schermafbeelding 2022-04-29 om 12 30 33" src="https://user-images.githubusercontent.com/6933510/165928606-3ff81346-c5f3-40cb-b6e1-f16e2939179c.png">

