### PR TITLE
Prevent registry update if it is fresh

### DIFF
--- a/src/packages/PkgCompat.jl
+++ b/src/packages/PkgCompat.jl
@@ -194,6 +194,30 @@ function update_registries(; force::Bool=false)
 	end
 end
 
+# ✅ Public API
+"""
+Check when the registries were last updated. If it is recent (max 7 days), `Pkg.UPDATED_REGISTRY_THIS_SESSION` is set to `true`, which will prevent Pkg from doing an automatic registry update.
+
+Returns the new value of `Pkg.UPDATED_REGISTRY_THIS_SESSION`.
+"""
+function check_registry_age(max_age_ms = 1000.0 * 60 * 60 * 24 * 7)::Bool
+	paths = _get_registry_paths()
+	isempty(paths) && return _updated_registries_compat[]
+	
+	ages = map(paths) do p
+		try
+			mtime(p)
+		catch
+			zero(time())
+		end
+	end
+	
+	if all(ages .> time() - max_age_ms)
+		_updated_registries_compat[] = true
+	end
+	_updated_registries_compat[]
+end
+
 
 ###
 # Instantiate

--- a/src/webserver/WebServer.jl
+++ b/src/webserver/WebServer.jl
@@ -292,8 +292,9 @@ function run(session::ServerSession, pluto_router)
 
     # Start this in the background, so that the first notebook launch (which will trigger registry update) will be faster
     @asynclog withtoken(pkg_token) do
+        will_update = !PkgCompat.check_registry_age()
         PkgCompat.update_registries(; force=false)
-        println("    Updating registry done ✓")
+        will_update && println("    Updating registry done ✓")
     end
 
     shutdown_server[] = () -> @sync begin


### PR DESCRIPTION
Registry update can be very slow. Julia will only update the registry once per session (this is implemented with `Pkg.UPDATED_REGISTRY_THIS_SESSION`), but I think that this is still too eager.

This PR does `mtime` on the registry TOML file to find out how old it is, and if it was updated in the past 7 days, it will skip the registry update.