### PR TITLE
unresolved_cells: handle Skipped correctly

### DIFF
--- a/src/evaluation/Run.jl
+++ b/src/evaluation/Run.jl
@@ -435,10 +435,10 @@ function resolve_topology(
 
 			# set function_wrapped to the function wrapped analysis of the expanded expression.
 			new_codes[cell] = ExprAnalysisCache(unresolved_topology.codes[cell]; forced_expr_id, function_wrapped)
+		elseif result isa Skipped
+			# Skipped because it has already been resolved during ExpressionExplorer.
 		else
-			if result isa Failure
-				@debug "Expansion failed" err=result.error
-			end
+			@debug "Could not resolve" result cell.code
 			push!(still_unresolved_nodes, cell)
 		end
 	end

--- a/src/evaluation/Run.jl
+++ b/src/evaluation/Run.jl
@@ -415,6 +415,7 @@ function resolve_topology(
 			# Do not try to expand if a newer version of the macro is also scheduled to run in the
 			# current run. The recursive reactive runs will take care of it.
 			push!(still_unresolved_nodes, cell)
+			continue
 		end
 
 		result = try

--- a/test/MacroAnalysis.jl
+++ b/test/MacroAnalysis.jl
@@ -729,6 +729,20 @@ import Pluto: PlutoRunner, Notebook, WorkspaceManager, Cell, ServerSession, Clie
         @test ":world" == cell(4).output.body
     end
 
+    @testset "Is just text macros" begin
+        notebook = Notebook(Cell.([
+            """
+            md"# Hello world!"
+            """,
+            """
+            "no julia value here"
+            """,
+        ]))
+        update_run!(🍭, notebook, notebook.cells)
+
+        @test isempty(notebook.topology.unresolved_cells)
+    end
+
     @testset "Macros using import" begin
         notebook = Notebook(Cell.([
             """


### PR DESCRIPTION
Before this PR, cells that only use `md"` or `@bind` would always stay in the `unresolved_cells` list, which is not what we want, right? This PR checks for the `Skipped` case and marks them as "resolved".

Also see https://github.com/fonsp/Pluto.jl/issues/2076#issuecomment-1113349780

@Pangoraw did I interpret the meaning of `Skipped` correctly?