### PR TITLE
`resolve_topology`: maintain identity when nothing changed

### DIFF
--- a/src/analysis/data structures.jl
+++ b/src/analysis/data structures.jl
@@ -77,10 +77,10 @@ begin
         get!(aid.default, aid.container, key)
     end
     function Base.merge(a1::ImmutableDefaultDict{K,V}, a2::ImmutableDefaultDict{K,V}) where {K,V}
-        ImmutableDefaultDict{K,V}(a1.default, merge(a1.container, a2.container))
+        isempty(a2) ? a1 : ImmutableDefaultDict{K,V}(a1.default, merge(a1.container, a2.container))
     end
     function Base.merge(a1::ImmutableDefaultDict{K,V}, a2::AbstractDict) where {K,V}
-        ImmutableDefaultDict{K,V}(a1.default, merge(a1.container, a2))
+        isempty(a2) ? a1 : ImmutableDefaultDict{K,V}(a1.default, merge(a1.container, a2))
     end
     # disabled because it's immutable!
     # Base.setindex!(aid::ImmutableDefaultDict{K,V}, args...) where {K,V} = Base.setindex!(aid.container, args...)

--- a/src/evaluation/Run.jl
+++ b/src/evaluation/Run.jl
@@ -445,11 +445,18 @@ function resolve_topology(
 
 	all_nodes = merge(unresolved_topology.nodes, new_nodes)
 	all_codes = merge(unresolved_topology.codes, new_codes)
+	
+	new_unresolved_cells = if length(still_unresolved_nodes) == length(unresolved_topology.unresolved_cells)
+		# then they must equal, and we can skip creating a new one to preserve identity:
+		unresolved_topology.unresolved_cells
+	else
+		ImmutableSet(still_unresolved_nodes; skip_copy=true)
+	end
 
 	NotebookTopology(
 		nodes=all_nodes, 
 		codes=all_codes, 
-		unresolved_cells=ImmutableSet(still_unresolved_nodes; skip_copy=true),
+		unresolved_cells=new_unresolved_cells,
 		cell_order=unresolved_topology.cell_order,
 	)
 end


### PR DESCRIPTION
(Part of #2076)

This PR ensures that `resolve_topology` returns exactly the same `NotebookTopology` as its input, when no cells were be resolved. Returning the same topology means that our caching system can do its magic: https://github.com/fonsp/Pluto.jl/blob/caf7326b58a1aef5b8f3ecc4b1cf6bfd4f0dfce7/src/analysis/topological_order.jl#L98-L105