### PR TITLE
Continue CI on error

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -48,4 +48,3 @@ jobs:
             
             # 🚗
             - uses: julia-actions/julia-runtest@v1
-              continue-on-error: ${{ matrix.julia-version == 'nightly' }}

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -36,7 +36,7 @@ jobs:
                 # We test quite a lot of versions because we do some OS and version specific things unfortunately
                 julia-version: ["1.6", "1.7", "~1.8.0-0"] #, "nightly"]
                 os: [ubuntu-latest, macOS-latest, windows-latest]
-                
+
         steps:
             # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
             - uses: actions/checkout@v2

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -28,14 +28,15 @@ jobs:
     test:
         runs-on: ${{ matrix.os }}
         timeout-minutes: 40
-        # With `continue-on-error: false`, the first failed test cancels all others
-        continue-on-error: true
+        
         strategy:
+            # Without setting this, a failing test cancels all others
+            fail-fast: false
             matrix:
                 # We test quite a lot of versions because we do some OS and version specific things unfortunately
                 julia-version: ["1.6", "1.7", "~1.8.0-0"] #, "nightly"]
                 os: [ubuntu-latest, macOS-latest, windows-latest]
-
+                
         steps:
             # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
             - uses: actions/checkout@v2

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -28,8 +28,8 @@ jobs:
     test:
         runs-on: ${{ matrix.os }}
         timeout-minutes: 40
-        # Uncomment if you want to see all results for all OSses. Otherwise, the first failed test cancels all others
-        # continue-on-error: true
+        # With `continue-on-error: false`, the first failed test cancels all others
+        continue-on-error: true
         strategy:
             matrix:
                 # We test quite a lot of versions because we do some OS and version specific things unfortunately


### PR DESCRIPTION
Currently, all CI test jobs get cancelled as soon as one job fails. This is very useful to save GitHub Actions minutes. However, Pluto's tests are a bit flakely which often causes all jobs to be cancelled for no good reason. Even worse, in many cases, this happens after 20 minutes. So, when the jobs are almost done anyway! Instead of getting a lot of valuable information, we now get just a bunch of "cancelled" reports.

EDIT: Got it. Other CI configs set `fail-fast: false` explicitly. For example, https://github.com/JuliaData/DataFrames.jl/blob/main/.github/workflows/ci.yml.