### PR TITLE
Slightly reduce TTFX for `SessionActions.open`

### DIFF
--- a/src/analysis/ExpressionExplorer.jl
+++ b/src/analysis/ExpressionExplorer.jl
@@ -320,8 +320,8 @@ end
 # Possible leaf: value
 # Like: a = 1
 # 1 is a value (Int64)
-function explore!(value, scopestate::ScopeState)::SymbolsState
-    # includes: LineNumberNode, Int64, String, 
+function explore!(@nospecialize(value), scopestate::ScopeState)::SymbolsState
+    # includes: LineNumberNode, Int64, String, Markdown.LaTeX, DataType and more.
     return SymbolsState()
 end
 

--- a/src/analysis/topological_order.jl
+++ b/src/analysis/topological_order.jl
@@ -89,8 +89,9 @@ function topological_order(topology::NotebookTopology, roots::AbstractVector{Cel
 	# we use MergeSort because it is a stable sort: leaves cells in order if they are in the same category
 	prelim_order_1 = sort(roots, alg=MergeSort, by=c -> cell_precedence_heuristic(topology, c))
 	# reversing because our search returns reversed order
-	prelim_order_2 = Iterators.reverse(prelim_order_1)
-	bfs.(prelim_order_2)
+    for i in length(prelim_order_1):-1:1
+        bfs(prelim_order_1[i])
+    end
 	ordered = reverse(exits)
 	TopologicalOrder(topology, setdiff(ordered, keys(errable)), errable)
 end

--- a/src/notebook/Notebook.jl
+++ b/src/notebook/Notebook.jl
@@ -24,7 +24,7 @@ Base.@kwdef mutable struct Notebook
     "Cells are ordered in a `Notebook`, and this order can be changed by the user. Cells will always have a constant UUID."
     cells_dict::Dict{UUID,Cell}
     cell_order::Array{UUID,1}
-    
+
     path::String
     notebook_id::UUID=uuid1()
     topology::NotebookTopology
@@ -64,17 +64,18 @@ _initial_topology(cells_dict::Dict{UUID,Cell}, cells_order::Vector{UUID}) =
     NotebookTopology(;
         cell_order=ImmutableVector(_collect_cells(cells_dict, cells_order)),
     )
-    
-function Notebook(cells::Vector{Cell}, path::AbstractString, notebook_id::UUID)
+
+function Notebook(cells::Vector{Cell}, @nospecialize(path::AbstractString), notebook_id::UUID)
     cells_dict=Dict(map(cells) do cell
         (cell.cell_id, cell)
     end)
     cell_order=map(x -> x.cell_id, cells)
     Notebook(;
-        cells_dict, cell_order,
+        cells_dict,
+        cell_order,
         topology=_initial_topology(cells_dict, cell_order),
-        path=path,
-        notebook_id=notebook_id,
+        path,
+        notebook_id
     )
 end
 
@@ -208,8 +209,8 @@ end
 save_notebook(notebook::Notebook) = save_notebook(notebook, notebook.path)
 
 "Load a notebook without saving it or creating a backup; returns a `Notebook`. REMEMBER TO CHANGE THE NOTEBOOK PATH after loading it to prevent it from autosaving and overwriting the original file."
-function load_notebook_nobackup(io, path)::Notebook
-    firstline = String(readline(io))
+function load_notebook_nobackup(@nospecialize(io::IO), @nospecialize(path::AbstractString))::Notebook
+    firstline = String(readline(io))::String
 
     if firstline != _notebook_header
         error("File is not a Pluto.jl notebook")
@@ -336,6 +337,7 @@ function load_notebook_nobackup(io, path)::Notebook
         nbpkg_installed_versions_cache=nbpkg_cache(nbpkg_ctx),
     )
 end
+precompile(load_notebook_nobackup, (IOStream, String))
 
 function load_notebook_nobackup(path::String)::Notebook
     local loaded

--- a/src/notebook/Notebook.jl
+++ b/src/notebook/Notebook.jl
@@ -337,7 +337,6 @@ function load_notebook_nobackup(@nospecialize(io::IO), @nospecialize(path::Abstr
         nbpkg_installed_versions_cache=nbpkg_cache(nbpkg_ctx),
     )
 end
-precompile(load_notebook_nobackup, (IOStream, String))
 
 function load_notebook_nobackup(path::String)::Notebook
     local loaded

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -466,8 +466,8 @@ function run_expression(
         m::Module,
         expr::Any,
         cell_id::UUID,
-        function_wrapped_info::Union{Nothing,Tuple{Set{Symbol},Set{Symbol}}}=nothing,
-        forced_expr_id::Union{ObjectID,Nothing}=nothing;
+        @nospecialize(function_wrapped_info::Union{Nothing,Tuple{Set{Symbol},Set{Symbol}}}=nothing),
+        @nospecialize(forced_expr_id::Union{ObjectID,Nothing}=nothing);
         user_requested_run::Bool=true,
         capture_stdout::Bool=true,
     )
@@ -570,6 +570,7 @@ function run_expression(
     
     cell_results[cell_id], cell_runtimes[cell_id] = result, runtime
 end
+precompile(run_expression, (Module, Expr, UUID, Nothing, Nothing))
 
 # Channel to trigger implicits run
 const run_channel = Channel{UUID}(10)


### PR DESCRIPTION
I've been running 

```julia
ex = quote
    session = Pluto.ServerSession()
    session.options.server.disable_writing_notebook_files = true
    session.options.evaluation.workspace_use_distributed = false
    path = joinpath(pkgdir(Pluto), "sample", "Basic.jl")
    Pluto.SessionActions.open(session, path; run_async=false)
end
tinf = @snoopi_deep eval(ex)

sorted_children = if true
      sorted_children = sort(tinf.children; by=inclusive, rev=false)
      display(sorted_children)
      println()
      sorted_children
      # To figure out where those things are defined, use
      # ascend(Core.MethodInstance(sorted_children[end]))
  end
display(tinf)
@btime eval(ex)
```

in Julia 1.8-beta3 to find methods which take long to compile. Unfortunately, there are 40 or so methods here which all take 0.01-0.09 seconds. This PR gets rid of some of them.

## Benchmarks

Running multiple since the time varies and SnoopCompile.jl doesn't show allocations:

`main`: 16.3 seconds
this branch: 15.9 seconds
`main`: 16.2 seconds
this branch: 15.9 seconds
`main`: 16.3 seconds

Okay, so 0.3 seconds gain. It's something 