### PR TITLE
Use URI(uri, ...) instead of merge(uri, ...)

### DIFF
--- a/src/webserver/WebServer.jl
+++ b/src/webserver/WebServer.jl
@@ -358,7 +358,7 @@ function pretty_address(session::ServerSession, hostIP, port)
     else
         root
     end
-    merge(HTTP.URIs.URI(new_root), query=url_params) |> string
+    string(HTTP.URI(HTTP.URI(new_root); query=url_params))
 end
 
 "All messages sent over the WebSocket get decoded+deserialized and end up here."


### PR DESCRIPTION
Closes #2112.

This newer syntax is available since at least Nov 28, 2020 as far as I can tell (https://github.com/JuliaWeb/HTTP.jl/pull/627). Around that time, HTTP was at version 0.8, so this change should work for the HTTP range of 0.9.1-0.9.17 which is specified in `Project.toml`.