### PR TITLE
Speed up `tree_data_array_elements`

### DIFF
--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -1123,15 +1123,14 @@ pluto_showable(::MIME"application/vnd.pluto.tree+object", ::Any) = false
 const Context = IOContext{IOBuffer}
 
 function tree_data_array_elements(@nospecialize(x::AbstractVector{<:Any}), indices::AbstractVector{I}, context::Context) where {I<:Integer}
-    out = Tuple{I,Tuple}[]
-    for i in indices
+    Tuple{I,Any}[
         if isassigned(x, i)
-            push!(out, (i, format_output_default(x[i], context)))
+            i, format_output_default(x[i], context)
         else
-            push!(out, (i, format_output_default(Text(Base.undef_ref_str), context)))
+            i, format_output_default(Text(Base.undef_ref_str), context)
         end
-    end
-    return out
+        for i in indices
+    ] |> collect
 end
 precompile(tree_data_array_elements, (Vector{Any}, Vector{Int}, Context))
 


### PR DESCRIPTION
Reduces TTFX and improves readability for some `show_richest` helpers. The main gain is the `precompile` on `tree_data_array_elements`. This method showed up in SnoopCompile to require the most time during TTFX. The rewrite for `IOContext` types to `Context` types is mostly aimed at readability. It makes it easier for developers to figure out what type they can expect for that argument.

## Benchmark

```julia
julia --project -e 'using Pluto; @time @eval Pluto.PlutoRunner.format_output((a=[1,2],c=Dict("d"=>(5,6,true))))'
```
on Julia 1.8-beta1.

**Before (`main`):**

```
1.177027 seconds (3.42 M allocations: 178.309 MiB, 16.03% gc time, 99.38% compilation time)
```

**This PR:**

```
0.960743 seconds (1.75 M allocations: 91.670 MiB, 17.53% gc time, 99.28% compilation time)
```

On a sidenote, I wish it was as easy to bring running time down as that it is to bring allocations down for TTFX. This will probably be the last PR aimed at `PlutoRunner.format_output` since the easy gain seem to be gone now. Let's hope for more Julia compiler improvements in the future