### PR TITLE
Refactor `load_notebook_nobackup`

### DIFF
--- a/src/notebook/Notebook.jl
+++ b/src/notebook/Notebook.jl
@@ -26,7 +26,7 @@ const ProcessStatus = (
 Base.@kwdef mutable struct Notebook
     "Cells are ordered in a `Notebook`, and this order can be changed by the user. Cells will always have a constant UUID."
     cells_dict::Dict{UUID,Cell}
-    cell_order::Array{UUID,1}
+    cell_order::Vector{UUID}
 
     path::String
     notebook_id::UUID=uuid1()

--- a/src/notebook/saving and loading.jl
+++ b/src/notebook/saving and loading.jl
@@ -241,7 +241,7 @@ function _notebook_cell_order!(@nospecialize(io::IO), collected_cells)
     return cell_order
 end
 
-function _notebook_nbpkg_ctx(cell_order::Vector{UUID})
+function _notebook_nbpkg_ctx(cell_order::Vector{UUID}, collected_cells::Dict{Base.UUID, Cell})
     read_package =
         _ptoml_cell_id ∈ cell_order &&
         _mtoml_cell_id ∈ cell_order &&
@@ -296,7 +296,7 @@ function load_notebook_nobackup(@nospecialize(io::IO), @nospecialize(path::Abstr
 
     collected_cells = _notebook_collected_cells!(io)
     cell_order = _notebook_cell_order!(io, collected_cells)
-    nbpkg_ctx = _notebook_nbpkg_ctx(cell_order)
+    nbpkg_ctx = _notebook_nbpkg_ctx(cell_order, collected_cells)
     appeared_order = _notebook_appeared_order!(cell_order, collected_cells)
     appeared_cells_dict = filter(collected_cells) do (k, v)
         k ∈ appeared_order

--- a/src/notebook/saving and loading.jl
+++ b/src/notebook/saving and loading.jl
@@ -249,8 +249,8 @@ function _notebook_nbpkg_ctx(cell_order::Vector{UUID})
         haskey(collected_cells, _mtoml_cell_id)
 
     nbpkg_ctx = if read_package
-        ptoml_code = collected_cells[_ptoml_cell_id].code
-        mtoml_code = collected_cells[_mtoml_cell_id].code
+        ptoml_code = string(collected_cells[_ptoml_cell_id].code)::String
+        mtoml_code = string(collected_cells[_mtoml_cell_id].code)::String
 
         ptoml_contents = lstrip(split(ptoml_code, "\"\"\"")[2])
         mtoml_contents = lstrip(split(mtoml_code, "\"\"\"")[2])


### PR DESCRIPTION
This is an [extract method refactoring](https://refactoring.guru/extract-method) on `load_notebook_nobackup`. This makes the `load_notebook_nobackup` easier to read. For TTFX, it makes a tiny difference of 0.15 or so seconds in Julia 1.8 RC1