### PR TITLE
Replace all `Array{T,1}` by `Vector{T}`

### DIFF
--- a/sample/Tower of Hanoi.jl
+++ b/sample/Tower of Hanoi.jl
@@ -165,7 +165,7 @@ This is where we can check a solution. We start with a function that takes our r
 function run_solution(solver::Function, start = starting_stacks)
 	moves = solver(deepcopy(start)) #apply the solver
 	
-	all_states = Array{Any,1}(undef, length(moves) + 1)
+	all_states = Vector{Any}(undef, length(moves) + 1)
 	all_states[1] = start
 	
 	for (i, m) in enumerate(moves)

--- a/src/analysis/ExpressionExplorer.jl
+++ b/src/analysis/ExpressionExplorer.jl
@@ -9,7 +9,7 @@ import Base: union, union!, ==, push!
 # TWO STATE OBJECTS
 ###
 
-const FunctionName = Array{Symbol,1}
+const FunctionName = Vector{Symbol}
 
 struct FunctionNameSignaturePair
     name::FunctionName
@@ -113,7 +113,7 @@ function will_assign_global(assignee::Symbol, scopestate::ScopeState)::Bool
     (scopestate.inglobalscope || assignee ∈ scopestate.exposedglobals) && (assignee ∉ scopestate.hiddenglobals || assignee ∈ scopestate.definedfuncs)
 end
 
-function will_assign_global(assignee::Array{Symbol,1}, scopestate::ScopeState)::Bool
+function will_assign_global(assignee::Vector{Symbol}, scopestate::ScopeState)::Bool
     if length(assignee) == 0
         false
     elseif length(assignee) > 1

--- a/src/analysis/Parse.jl
+++ b/src/analysis/Parse.jl
@@ -81,7 +81,7 @@ fix_linenumbernodes!(::Any, actual_filename) = nothing
 `expression_boundaries("sqrt(1)\n\n123") == [ncodeunits("sqrt(1)\n\n") + 1, ncodeunits("sqrt(1)\n\n123") + 1]`
 
 """
-function expression_boundaries(code::String, start=1)::Array{<:Integer,1}
+function expression_boundaries(code::String, start=1)::Vector{<:Integer}
     expr, next = Meta.parse(code, start, raise=false)
     if next <= ncodeunits(code)
         [next, expression_boundaries(code, next)...]

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -1105,7 +1105,7 @@ pluto_showable(m::MIME, @nospecialize(x))::Bool = Base.invokelatest(showable, m,
 
 
 # We invent our own MIME _because we can_ but don't use it somewhere else because it might change :)
-pluto_showable(::MIME"application/vnd.pluto.tree+object", x::AbstractArray{<:Any,1}) = eltype(eachindex(x)) === Int
+pluto_showable(::MIME"application/vnd.pluto.tree+object", x::AbstractVector{<:Any}) = eltype(eachindex(x)) === Int
 pluto_showable(::MIME"application/vnd.pluto.tree+object", ::AbstractSet{<:Any}) = true
 pluto_showable(::MIME"application/vnd.pluto.tree+object", ::AbstractDict{<:Any,<:Any}) = true
 pluto_showable(::MIME"application/vnd.pluto.tree+object", ::Tuple) = true
@@ -1454,7 +1454,7 @@ const integrations = Integration[
                 # not enumerate(rows) because of some silliness
                 # not rows[i] because `getindex` is not guaranteed to exist
                 L = truncate_rows ? my_row_limit : length(rows)
-                row_data = Array{Any,1}(undef, L)
+                row_data = Vector{Any}(undef, L)
                 for (i, row) in zip(1:L,rows)
                     row_data[i] = (i, row_data_for(row))
                 end
@@ -1486,7 +1486,7 @@ const integrations = Integration[
             pluto_showable(::MIME"application/vnd.pluto.table+object", t::Type) = false
             pluto_showable(::MIME"application/vnd.pluto.table+object", t::AbstractVector{<:NamedTuple}) = false
             pluto_showable(::MIME"application/vnd.pluto.table+object", t::AbstractVector{<:Dict{Symbol,<:Any}}) = false
-            pluto_showable(::MIME"application/vnd.pluto.table+object", t::AbstractArray{Union{}, 1}) = false
+            pluto_showable(::MIME"application/vnd.pluto.table+object", t::AbstractVector{Union{}}) = false
 
         end,
     ),


### PR DESCRIPTION
Thanks to Comby:
```bash
comby -matcher .jl 'Array{:[1],1}' 'Vector{:[1]}'
comby -matcher .jl 'Array{:[1], 1}' 'Vector{:[1]}'
```