### PR TITLE
Return a `Rich` object instead of `Dict` for `show_richest`

### DIFF
--- a/src/evaluation/Run.jl
+++ b/src/evaluation/Run.jl
@@ -297,7 +297,7 @@ end
 _body_mime(x::Tuple) = (x[1], x[2])
 _body_mime(x::Rich) = (x.body, x.rich)
 
-function set_output!(cell::Cell, run, expr_cache::ExprAnalysisCache; persist_js_state::Bool=false)
+function set_output!(cell::Cell, run::FormattedCellResult, expr_cache::ExprAnalysisCache; persist_js_state::Bool=false)
     body, mime = _body_mime(run.output_formatted)
 	cell.output = CellOutput(;
         body,

--- a/src/evaluation/Run.jl
+++ b/src/evaluation/Run.jl
@@ -4,7 +4,7 @@ import .ExpressionExplorer: FunctionNameSignaturePair, is_joined_funcname, Using
 import .WorkspaceManager: macroexpand_in_workspace
 import .MoreAnalysis: find_bound_variables
 
-using .PlutoRunner: Rich
+using .PlutoRunner: FormattedCellResult, Rich
 
 Base.push!(x::Set{Cell}) = x
 

--- a/src/evaluation/WorkspaceManager.jl
+++ b/src/evaluation/WorkspaceManager.jl
@@ -379,16 +379,17 @@ end
 
 `expr` has to satisfy `ExpressionExplorer.is_toplevel_expr`."
 function eval_format_fetch_in_workspace(
-    session_notebook::Union{SN,Workspace},
-    expr::Expr,
-    cell_id::UUID;
-    ends_with_semicolon::Bool=false,
-    function_wrapped_info::Union{Nothing,Tuple}=nothing,
-    forced_expr_id::Union{PlutoRunner.ObjectID,Nothing}=nothing,
-    known_published_objects::Vector{String}=String[],
-    user_requested_run::Bool=true,
-    capture_stdout::Bool=true,
-)::PlutoRunner.FormattedCellResult
+        session_notebook::Union{SN,Workspace},
+        expr::Expr,
+        cell_id::UUID;
+        ends_with_semicolon::Bool=false,
+        function_wrapped_info::Union{Nothing,Tuple}=nothing,
+        forced_expr_id::Union{PlutoRunner.ObjectID,Nothing}=nothing,
+        known_published_objects::Vector{String}=String[],
+        user_requested_run::Bool=true,
+        capture_stdout::Bool=true,
+    )
+    # Not asserting PlutoRunner.FormattedCellResult as return type since there exist two.
 
     workspace = get_workspace(session_notebook)
     
@@ -445,7 +446,8 @@ function format_fetch_in_workspace(
     ends_with_semicolon, 
     known_published_objects::Vector{String}=String[],
     showmore_id::Union{PlutoRunner.ObjectDimPair,Nothing}=nothing,
-)::PlutoRunner.FormattedCellResult
+)
+    # Not asserting PlutoRunner.FormattedCellResult as return type since there exist two.
     workspace = get_workspace(session_notebook)
     
     # instead of fetching the output value (which might not make sense in our context, since the user can define structs, types, functions, etc), we format the cell output on the worker, and fetch the formatted output.

--- a/src/notebook/Cell.jl
+++ b/src/notebook/Cell.jl
@@ -9,7 +9,7 @@ const DEFAULT_CELL_METADATA = Dict{String, Any}(
 )
 
 Base.@kwdef struct CellOutput
-    body::Union{Nothing,String,Vector{UInt8},Dict,Rich}=nothing
+    body::Union{Nothing,String,Vector{UInt8},Dict,<:Rich}=nothing
     mime::MIME=MIME("text/plain")
     rootassignee::Union{Symbol,Nothing}=nothing
 

--- a/src/notebook/Cell.jl
+++ b/src/notebook/Cell.jl
@@ -1,5 +1,6 @@
 import UUIDs: UUID, uuid1
 import .ExpressionExplorer: SymbolsState, UsingsImports
+using .PlutoRunner: Rich
 
 # Make sure to keep this in sync with DEFAULT_CELL_METADATA in ../frontend/components/Editor.js
 const DEFAULT_CELL_METADATA = Dict{String, Any}(
@@ -8,7 +9,7 @@ const DEFAULT_CELL_METADATA = Dict{String, Any}(
 )
 
 Base.@kwdef struct CellOutput
-    body::Union{Nothing,String,Vector{UInt8},Dict}=nothing
+    body::Union{Nothing,String,Vector{UInt8},Dict,Rich}=nothing
     mime::MIME=MIME("text/plain")
     rootassignee::Union{Symbol,Nothing}=nothing
 
@@ -55,13 +56,13 @@ Base.@kwdef mutable struct Cell
     metadata::Dict{String,Any}=copy(DEFAULT_CELL_METADATA)
 end
 
-Cell(cell_id, code) = Cell(cell_id=cell_id, code=code)
+Cell(cell_id, code) = Cell(; cell_id, code)
 Cell(code) = Cell(uuid1(), code)
 
 cell_id(cell::Cell) = cell.cell_id
 
 function Base.convert(::Type{Cell}, cell::Dict)
-	Cell(
+    Cell(
         cell_id=UUID(cell["cell_id"]),
         code=cell["code"],
         code_folded=cell["code_folded"],

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -24,7 +24,17 @@ import Logging
 
 export @bind
 
-MimedOutput = Tuple{Union{String,Vector{UInt8},Dict{Symbol,Any}},MIME}
+Base.@kwdef struct Rich
+    objectid::String
+    type::Symbol
+    elements::Any=nothing
+    prefix::String=""
+    prefix_short::String=""
+    key_value::Union{Nothing,Tuple}=nothing
+    schema::Union{Nothing,Dict{Symbol,Any}}=nothing
+end
+
+MimedOutput = Tuple{Union{String,Vector{UInt8},Dict{Symbol,Any},Rich},MIME}
 const ObjectID = typeof(objectid("hello computer"))
 const ObjectDimPair = Tuple{ObjectID,Int64}
 
@@ -1057,7 +1067,7 @@ Like two-argument `Base.show`, except:
 2. the used MIME type is returned as second element
 3. if the first returned element is `nothing`, then we wrote our data to `io`. If it is something else (a Dict), then that object will be the cell's output, instead of the buffered io stream. This allows us to output rich objects to the frontend that are not necessarily strings or byte streams
 """
-function show_richest(io::IO, @nospecialize(x))::Tuple{<:Any,MIME}
+function show_richest(io::IO, @nospecialize(x))::Tuple{Union{Rich,Nothing},MIME}
     # ugly code to fix an ugly performance problem
     local mime = nothing
     for m in allmimes
@@ -1158,16 +1168,6 @@ function get_my_display_limit(@nospecialize(x), dim::Integer, depth::Integer, co
             b * get(d, (objectid(x), dim), 0)
         end
     end
-end
-
-Base.@kwdef struct Rich
-    objectid::String
-    type::Symbol
-    elements::Any=nothing
-    prefix::String=""
-    prefix_short::String=""
-    key_value::Union{Nothing,Tuple}=nothing
-    schema::Union{Nothing,Dict{Symbol,Any}}=nothing
 end
 
 objectid2str(@nospecialize(x)) = string(objectid(x); base=16)::String

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -1,7 +1,7 @@
 # Will be evaluated _inside_ the workspace process.
 
 # Pluto does most things on process 1 (the server), and it uses little workspace processes to evaluate notebook code in.
-# These baby processes don't import Pluto, they only import this module. Functions from this module are called by WorkspaceManager.jl, using Distributed
+# These baby processes don't import Pluto, they only import this module. Functions from this module are called by WorkspaceManager.jl via Distributed
 
 # So when reading this file, pretend that you are living in process 2, and you are communicating with Pluto's server, who lives in process 1.
 # The package environment that this file is loaded with is the NotebookProcessProject.toml file in this directory.

--- a/src/webserver/MsgPack.jl
+++ b/src/webserver/MsgPack.jl
@@ -7,7 +7,7 @@ import MsgPack
 import .Configuration
 import Pkg
 
-using .PlutoRunner: Rich
+using .PlutoRunner: RichObject, RichTable
 
 # MsgPack.jl doesn't define a serialization method for MIME and UUID objects, so we write these ourselves:
 MsgPack.msgpack_type(::Type{<:MIME}) = MsgPack.StringType()
@@ -32,7 +32,8 @@ MsgPack.msgpack_type(::Type{Configuration.EvaluationOptions}) = MsgPack.StructTy
 MsgPack.msgpack_type(::Type{Configuration.CompilerOptions}) = MsgPack.StructType()
 MsgPack.msgpack_type(::Type{Configuration.ServerOptions}) = MsgPack.StructType()
 MsgPack.msgpack_type(::Type{Configuration.SecurityOptions}) = MsgPack.StructType()
-MsgPack.msgpack_type(::Type{Rich}) = MsgPack.StructType()
+MsgPack.msgpack_type(::Type{RichObject}) = MsgPack.StructType()
+MsgPack.msgpack_type(::Type{RichTable}) = MsgPack.StructType()
 
 # Don't try to send callback functions which can't be serialized (see ServerOptions.event_listener)
 MsgPack.msgpack_type(::Type{Function}) = MsgPack.NilType()

--- a/src/webserver/MsgPack.jl
+++ b/src/webserver/MsgPack.jl
@@ -7,7 +7,7 @@ import MsgPack
 import .Configuration
 import Pkg
 
-using .PlutoRunner: Rich
+using .PlutoRunner: Rich, MimedOutput
 
 # MsgPack.jl doesn't define a serialization method for MIME and UUID objects, so we write these ourselves:
 MsgPack.msgpack_type(::Type{<:MIME}) = MsgPack.StringType()
@@ -33,6 +33,7 @@ MsgPack.msgpack_type(::Type{Configuration.CompilerOptions}) = MsgPack.StructType
 MsgPack.msgpack_type(::Type{Configuration.ServerOptions}) = MsgPack.StructType()
 MsgPack.msgpack_type(::Type{Configuration.SecurityOptions}) = MsgPack.StructType()
 MsgPack.msgpack_type(::Type{<:Rich}) = MsgPack.StructType()
+MsgPack.msgpack_type(::Type{<:MimedOutput}) = MsgPack.StructType()
 
 # Don't try to send callback functions which can't be serialized (see ServerOptions.event_listener)
 MsgPack.msgpack_type(::Type{Function}) = MsgPack.NilType()

--- a/src/webserver/MsgPack.jl
+++ b/src/webserver/MsgPack.jl
@@ -7,7 +7,7 @@ import MsgPack
 import .Configuration
 import Pkg
 
-using .PlutoRunner: RichObject, RichTable
+using .PlutoRunner: Rich
 
 # MsgPack.jl doesn't define a serialization method for MIME and UUID objects, so we write these ourselves:
 MsgPack.msgpack_type(::Type{<:MIME}) = MsgPack.StringType()
@@ -32,8 +32,7 @@ MsgPack.msgpack_type(::Type{Configuration.EvaluationOptions}) = MsgPack.StructTy
 MsgPack.msgpack_type(::Type{Configuration.CompilerOptions}) = MsgPack.StructType()
 MsgPack.msgpack_type(::Type{Configuration.ServerOptions}) = MsgPack.StructType()
 MsgPack.msgpack_type(::Type{Configuration.SecurityOptions}) = MsgPack.StructType()
-MsgPack.msgpack_type(::Type{RichObject}) = MsgPack.StructType()
-MsgPack.msgpack_type(::Type{RichTable}) = MsgPack.StructType()
+MsgPack.msgpack_type(::Type{<:Rich}) = MsgPack.StructType()
 
 # Don't try to send callback functions which can't be serialized (see ServerOptions.event_listener)
 MsgPack.msgpack_type(::Type{Function}) = MsgPack.NilType()

--- a/src/webserver/MsgPack.jl
+++ b/src/webserver/MsgPack.jl
@@ -7,6 +7,8 @@ import MsgPack
 import .Configuration
 import Pkg
 
+using .PlutoRunner: Rich
+
 # MsgPack.jl doesn't define a serialization method for MIME and UUID objects, so we write these ourselves:
 MsgPack.msgpack_type(::Type{<:MIME}) = MsgPack.StringType()
 MsgPack.msgpack_type(::Type{UUID}) = MsgPack.StringType()
@@ -30,6 +32,7 @@ MsgPack.msgpack_type(::Type{Configuration.EvaluationOptions}) = MsgPack.StructTy
 MsgPack.msgpack_type(::Type{Configuration.CompilerOptions}) = MsgPack.StructType()
 MsgPack.msgpack_type(::Type{Configuration.ServerOptions}) = MsgPack.StructType()
 MsgPack.msgpack_type(::Type{Configuration.SecurityOptions}) = MsgPack.StructType()
+MsgPack.msgpack_type(::Type{Rich}) = MsgPack.StructType()
 
 # Don't try to send callback functions which can't be serialized (see ServerOptions.event_listener)
 MsgPack.msgpack_type(::Type{Function}) = MsgPack.NilType()

--- a/test/React.jl
+++ b/test/React.jl
@@ -3,6 +3,8 @@ import Pluto: Configuration, Notebook, ServerSession, ClientSession, update_run!
 import Pluto.Configuration: Options, EvaluationOptions
 import Distributed
 
+using Pluto.PlutoRunner: Rich
+
 @testset "Reactivity" begin
     🍭 = ServerSession()
     🍭.options.evaluation.workspace_use_distributed = false
@@ -1203,7 +1205,7 @@ import Distributed
         # https://github.com/fonsp/Pluto.jl/issues/59
         original_repr = Pluto.PlutoRunner.format_output(Ref((25, :fish)))[1]
         @test_nowarn update_run!(🍭, notebook, notebook.cells[25])
-        @test notebook.cells[25].output.body isa Dict
+        @test notebook.cells[25].output.body isa Rich
         @test_nowarn update_run!(🍭, notebook, notebook.cells[26])
         @test_broken notebook.cells[25].output.body == "🐟" # cell'🍭 don't automatically call `show` again when a new overload is defined - that'🍭 a minor issue
         @test_nowarn update_run!(🍭, notebook, notebook.cells[25])
@@ -1212,7 +1214,7 @@ import Distributed
         setcode!(notebook.cells[26], "")
         @test_nowarn update_run!(🍭, notebook, notebook.cells[26])
         @test_nowarn update_run!(🍭, notebook, notebook.cells[25])
-        @test notebook.cells[25].output.body isa Dict
+        @test notebook.cells[25].output.body isa Rich
 
         @test_nowarn update_run!(🍭, notebook, notebook.cells[28:29])
         @test notebook.cells[28].output.body == "false"

--- a/test/RichOutput.jl
+++ b/test/RichOutput.jl
@@ -1,7 +1,7 @@
 using Test
 import Pluto
 import Pluto: update_run!, WorkspaceManager, ClientSession, ServerSession, Notebook, Cell
-
+using Pluto.PlutoRunner: RichObject, RichTable
 
 @testset "Rich output" begin
 
@@ -58,37 +58,37 @@ import Pluto: update_run!, WorkspaceManager, ClientSession, ServerSession, Noteb
             @test notebook.cells[8].output.mime isa MIME"application/vnd.pluto.tree+object"
             @test notebook.cells[9].output.mime isa MIME"application/vnd.pluto.tree+object"
             @test notebook.cells[10].output.mime isa MIME"application/vnd.pluto.tree+object"
-            @test notebook.cells[1].output.body isa Dict
-            @test notebook.cells[2].output.body isa Dict
-            @test notebook.cells[3].output.body isa Dict
-            @test notebook.cells[4].output.body isa Dict
-            @test notebook.cells[5].output.body isa Dict
-            @test notebook.cells[6].output.body isa Dict
-            @test notebook.cells[7].output.body isa Dict
-            @test notebook.cells[8].output.body isa Dict
-            @test notebook.cells[9].output.body isa Dict
-            @test notebook.cells[10].output.body isa Dict
+            @test notebook.cells[1].output.body isa RichObject
+            @test notebook.cells[2].output.body isa RichObject
+            @test notebook.cells[3].output.body isa RichObject
+            @test notebook.cells[4].output.body isa RichObject
+            @test notebook.cells[5].output.body isa RichObject
+            @test notebook.cells[6].output.body isa RichObject
+            @test notebook.cells[7].output.body isa RichObject
+            @test notebook.cells[8].output.body isa RichObject
+            @test notebook.cells[9].output.body isa RichObject
+            @test notebook.cells[10].output.body isa RichObject
 
             @test notebook.cells[12].output.mime isa MIME"application/vnd.pluto.tree+object"
-            @test notebook.cells[12].output.body isa Dict
+            @test notebook.cells[12].output.body isa RichObject
             @test notebook.cells[14].output.mime isa MIME"application/vnd.pluto.tree+object"
-            @test notebook.cells[14].output.body isa Dict
+            @test notebook.cells[14].output.body isa RichObject
 
             @test notebook.cells[15].output.mime isa MIME"text/plain"
             
             @test notebook.cells[16].output.mime isa MIME"application/vnd.pluto.tree+object"
-            @test notebook.cells[16].output.body isa Dict
+            @test notebook.cells[16].output.body isa RichObject
             @test occursin("circular", notebook.cells[16].output.body |> string)
 
-            @test notebook.cells[17].output.body isa Dict
-            @test length(notebook.cells[17].output.body[:elements]) == 2
-            @test notebook.cells[17].output.body[:prefix] == "Set{Any}"
+            @test notebook.cells[17].output.body isa RichObject
+            @test length(notebook.cells[17].output.body.elements) == 2
+            @test notebook.cells[17].output.body.prefix == "Set{Any}"
             @test notebook.cells[17].output.mime isa MIME"application/vnd.pluto.tree+object"
             @test occursin("Set", notebook.cells[17].output.body |> string)
 
-            @test notebook.cells[18].output.body isa Dict
-            @test length(notebook.cells[18].output.body[:elements]) < 180
-            @test notebook.cells[18].output.body[:prefix] == "Set{Float64}"
+            @test notebook.cells[18].output.body isa RichObject
+            @test length(notebook.cells[18].output.body.elements) < 180
+            @test notebook.cells[18].output.body.prefix == "Set{Float64}"
             @test notebook.cells[18].output.mime isa MIME"application/vnd.pluto.tree+object"
 
             sizes = [length(string(notebook.cells[i].output.body)) for i in 19:22]
@@ -242,20 +242,20 @@ import Pluto: update_run!, WorkspaceManager, ClientSession, ServerSession, Noteb
         @test notebook.cells[15].output.mime isa MIME"application/vnd.pluto.tree+object"
         @test notebook.cells[16].output.mime isa MIME"application/vnd.pluto.tree+object"
         @test notebook.cells[17].output.mime isa MIME"application/vnd.pluto.tree+object"
-        @test notebook.cells[2].output.body isa Dict
-        @test notebook.cells[3].output.body isa Dict
-        @test notebook.cells[4].output.body isa Dict
-        @test notebook.cells[5].output.body isa Dict
-        @test notebook.cells[6].output.body isa Dict
-        @test notebook.cells[7].output.body isa Dict
-        @test notebook.cells[8].output.body isa Dict
-        @test notebook.cells[9].output.body isa Dict
-        @test notebook.cells[11].output.body isa Dict
-        @test notebook.cells[12].output.body isa Dict
-        @test notebook.cells[14].output.body isa Dict
-        @test notebook.cells[15].output.body isa Dict
-        @test notebook.cells[16].output.body isa Dict
-        @test notebook.cells[17].output.body isa Dict
+        @test notebook.cells[2].output.body isa RichTable
+        @test notebook.cells[3].output.body isa RichTable
+        @test notebook.cells[4].output.body isa RichTable
+        @test notebook.cells[5].output.body isa RichTable
+        @test notebook.cells[6].output.body isa RichTable
+        @test notebook.cells[7].output.body isa RichTable
+        @test notebook.cells[8].output.body isa RichTable
+        @test notebook.cells[9].output.body isa RichTable
+        @test notebook.cells[11].output.body isa RichTable
+        @test notebook.cells[12].output.body isa RichTable
+        @test notebook.cells[14].output.body isa RichObject
+        @test notebook.cells[15].output.body isa RichObject
+        @test notebook.cells[16].output.body isa RichObject
+        @test notebook.cells[17].output.body isa RichObject
         @test occursin("String?", string(notebook.cells[13].output.body)) # Issue 1490.
 
         @test notebook.cells[10].output.mime isa MIME"text/plain"

--- a/test/WorkspaceManager.jl
+++ b/test/WorkspaceManager.jl
@@ -83,7 +83,8 @@ import Distributed
             s = Pluto.ServerSession()
             """),
             Cell("""
-            nb = Pluto.SessionActions.open(s, Pluto.project_relative_path("sample", "Tower of Hanoi.jl"); run_async=false, as_sample=true)"""),
+            nb = Pluto.SessionActions.open(s, Pluto.project_relative_path("sample", "Tower of Hanoi.jl"); run_async=false, as_sample=true)
+            """),
             Cell("length(nb.cells)"),
             Cell(""),
         ])


### PR DESCRIPTION
I was trying to reduce the TTFX for `SessionActions.open` and ended up in `PlutoRunner` again.

With this PR, `show_richest` will now always return a `Rich` object instead of a `Dict`. This improves readability and also makes the compiler a bit happier. It reduces allocations from ~90 MB to ~80 MB on the TTFX benchmark of #2117 on `@btime` it reduces time by 17 μs (wow wow). Anyway, the main argument for this PR is code readability.