### PR TITLE
Set default formatter

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,9 +16,11 @@
     
     "editor.formatOnSave": false,
     "[javascript]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
         "editor.formatOnSave": true
     },
     "[css]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
         "editor.formatOnSave": true
     }
 }


### PR DESCRIPTION
To ensure that prettier has higher precedence over other installed formatters.

Reference: 
https://github.com/prettier/prettier-vscode/blob/main/README.md#default-formatter