### PR TITLE
Fix high-frequency, complex bond combinations causing a stall

### DIFF
--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -263,6 +263,8 @@ export class Editor extends Component {
 
         const { launch_params, initial_notebook_state } = this.props
 
+        console.log("HELLO GUILHERME CAN YOU READ THIS")
+
         this.state = {
             notebook: /** @type {NotebookData} */ initial_notebook_state,
             cell_inputs_local: /** @type {{ [id: string]: CellInputData }} */ ({}),

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -923,7 +923,7 @@ patch: ${JSON.stringify(
                 if (is_idle) {
                     this.waiting_for_bond_to_trigger_execution =
                         this.waiting_for_bond_to_trigger_execution ||
-                        changes_involving_bonds.some((x) => x.path.length >= 1 && bond_will_trigger_evaluation(x.path[1]))
+                        changes_involving_bonds.some((x) => x.op === "replace" && x.path.length >= 1 && bond_will_trigger_evaluation(x.path[1]))
                 }
                 this.pending_local_updates++
                 this.on_patches_hook(changes)

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -263,8 +263,6 @@ export class Editor extends Component {
 
         const { launch_params, initial_notebook_state } = this.props
 
-        console.log("HELLO GUILHERME CAN YOU READ THIS")
-
         this.state = {
             notebook: /** @type {NotebookData} */ initial_notebook_state,
             cell_inputs_local: /** @type {{ [id: string]: CellInputData }} */ ({}),

--- a/frontend/imports/immer.d.ts
+++ b/frontend/imports/immer.d.ts
@@ -1,6 +1,6 @@
 export type Patch = {
     path: Array<string | number>
-    op: "add" | "replace"
+    op: "add" | "replace" | "remove"
     value: any
 }
 


### PR DESCRIPTION
@ghaetinger was working on a notebook with a custom JS input element where you drag a selection box around, and the selected elements are returned over `@bind`. A strange bug sometimes happened where suddenly, all bonds would stop working. 

After some chaotic debugging, this turned out to be an error in #1892 ! Let's break it down 🙌

You'll need to read #1892, #275 and [how our state management works](https://github.com/fonsp/Pluto.jl/blob/v0.19.6/src/webserver/Dynamic.jl#L24-L79) before reading this PR 🤓

1. #1892 introduced a new state: [`waiting_for_bond_to_trigger_execution`](https://github.com/fonsp/Pluto.jl/blob/5569b4511a89a34324d99e2573ea81cf18203af9/frontend/components/Editor.js#L851-L852), with docstring: _Whether we just set a bond value which will trigger a cell to run, but we are still waiting for the server to process the bond value (and run the cell)._

    (read #1892 to know what it does)

2. In our case, it turned out that when the notebook was stuck, `waiting_for_bond_to_trigger_execution` was `true` suggesting that no patches (i.e. state changes) arrived from the server since the bond value was sent. It turned out that the backend did send a response, but the response was that there are no changes to the notebook state. [There should always be at least one change when a cell runs: the `last_run_timestamp `.](https://github.com/fonsp/Pluto.jl/blob/v0.19.6/src/evaluation/Run.jl#L309)

3. This means that no cells ran on the backend, which must be because of the ["first value" mechanism](https://github.com/fonsp/Pluto.jl/blob/v0.19.6/src/evaluation/RunBonds.jl#L8-L33) (see also #275). Apparently, all bond values were (wrongly) treated as "first values", and all of them had the same value as the previous bond run. [When this happens, the reactive run is skipped, and an acknowledgement with zero patches sent back to the client.](https://github.com/fonsp/Pluto.jl/blob/v0.19.6/src/evaluation/RunBonds.jl#L35-L38)

4. Bond values are treated as "first values" [when they are introduced to the state using an "add" patch, instead of a "replace" patch](https://github.com/fonsp/Pluto.jl/blob/v0.19.6/src/webserver/Dynamic.jl#L269). For some reason, in this notebook, the bond values were being *added* to the state, and logging indeed showed that the last succesful bond request only contained `add` patches...

5. Back to the frontend, [the code that should set  `waiting_for_bond_to_trigger_execution  = false`](https://github.com/fonsp/Pluto.jl/blob/v0.19.6/frontend/components/Editor.js#L709-L715) never ran, because we never received any patches. This kept the value at `true`, preventing any future bond values from being sent. 


# The fix

The idea of `waiting_for_bond_to_trigger_execution ` is to only set it to `true` if it is *guaranteed* that a cell will run, which is checked by [looking at the cell topology](https://github.com/fonsp/Pluto.jl/blob/v0.19.6/frontend/components/Editor.js#L926). This issue revealed an edge case where the bond patches are `add` patches, which can trigger the "first value" escape hook, and not produce any patches. 

[The fix is to only consider `replace` patches](https://github.com/fonsp/Pluto.jl/pull/2147/commits/5a9418173287095d275e6e4d1d16c7e8fd8e895d) :)

