### PR TITLE
Include secret search param in WS connect

### DIFF
--- a/frontend/common/Binder.js
+++ b/frontend/common/Binder.js
@@ -161,7 +161,7 @@ export const start_binder = async ({ setStatePromise, connect, launch_params }) 
 
         console.log("Connecting WebSocket")
 
-        const connect_promise = connect(with_token(ws_address_from_base(binder_session_url) + "channels"))
+        const connect_promise = connect(with_token(new URL("channels", ws_address_from_base(binder_session_url))))
         await timeout_promise(connect_promise, 20_000).catch((e) => {
             console.error("Failed to establish connection within 20 seconds. Navigating to the edit URL directly.", e)
             const edit_url = with_query_params(new URL("edit", binder_session_url), { id: new_notebook_id })

--- a/frontend/common/PlutoConnection.js
+++ b/frontend/common/PlutoConnection.js
@@ -1,6 +1,7 @@
 import { Promises } from "../common/SetupCellEnvironment.js"
 import { pack, unpack } from "./MsgPack.js"
 import "./Polyfill.js"
+import { with_query_params } from "./URLTools.js"
 
 // https://github.com/denysdovhan/wtfjs/issues/61
 const different_Infinity_because_js_is_yuck = 2147483646
@@ -230,7 +231,11 @@ const batched_updates = (send) => {
 export const ws_address_from_base = (base_url) => {
     const ws_url = new URL("./", base_url)
     ws_url.protocol = ws_url.protocol.replace("http", "ws")
-    return String(ws_url)
+
+    // if the original URL had a secret in the URL, we can also add it here:
+    const ws_url_with_secret = with_query_params(ws_url, { secret: new URL(base_url).searchParams.get("secret") })
+
+    return ws_url_with_secret
 }
 
 const default_ws_address = () => ws_address_from_base(window.location.href)

--- a/frontend/common/URLTools.js
+++ b/frontend/common/URLTools.js
@@ -1,15 +1,15 @@
-export const with_query_params = (/** @type {String | URL} */ url_str, /** @type {Record<String,any>} */ params) => {
+export const with_query_params = (/** @type {String | URL} */ url_str, /** @type {Record<string,string?>} */ params) => {
     const fake_base = "http://delete-me.com/"
     const url = new URL(url_str, fake_base)
-    Object.entries(params)
-        .filter(([_, v]) => v != null)
-        .forEach(([key, val]) => url.searchParams.append(key, val))
+    Object.entries(params).forEach(([key, val]) => {
+        if (val != null) url.searchParams.append(key, val)
+    })
     return url.toString().replace(fake_base, "")
 }
 
 console.assert(with_query_params("https://example.com/", { a: "b c" }) === "https://example.com/?a=b+c")
 console.assert(with_query_params(new URL("https://example.com/"), { a: "b c" }) === "https://example.com/?a=b+c")
-console.assert(with_query_params(new URL("https://example.com/"), { a: "b c", asdf: null, xx: 123 }) === "https://example.com/?a=b+c&xx=123")
+console.assert(with_query_params(new URL("https://example.com/"), { a: "b c", asdf: null, xx: "123" }) === "https://example.com/?a=b+c&xx=123")
 console.assert(with_query_params("index.html", { a: "b c" }) === "index.html?a=b+c")
 console.assert(with_query_params("index.html?x=123", { a: "b c" }) === "index.html?x=123&a=b+c")
 console.assert(with_query_params("index.html?x=123#asdf", { a: "b c" }) === "index.html?x=123&a=b+c#asdf")


### PR DESCRIPTION
Normally not necessary because the token is given through the cookie, but this came up in a Pluto-inside-iframe-inside-iframe-inside-iframe situation today.