### PR TITLE
TopologyUpdate: don't preserve identity when cells are removed 

### DIFF
--- a/src/analysis/TopologyUpdate.jl
+++ b/src/analysis/TopologyUpdate.jl
@@ -43,7 +43,11 @@ function updated_topology(old_topology::NotebookTopology, notebook::Notebook, ce
 		new_nodes = merge(setdiffkeys(old_topology.nodes, removed_cells), updated_nodes)
 	end
 
-	cell_order = old_cells == notebook.cells ? old_cells : ImmutableVector(notebook.cells)
+	cell_order = if old_cells == notebook.cells
+		old_topology.cell_order
+	else
+		ImmutableVector(notebook.cells)
+	end
 
 	NotebookTopology(;
 		nodes=new_nodes,

--- a/src/analysis/TopologyUpdate.jl
+++ b/src/analysis/TopologyUpdate.jl
@@ -30,24 +30,24 @@ function updated_topology(old_topology::NotebookTopology, notebook::Notebook, ce
 			pop!(unresolved_cells, cell, nothing)
 		end
 	end
-	new_codes = merge(old_topology.codes, updated_codes)
-	new_nodes = merge(old_topology.nodes, updated_nodes)
 
-	for removed_cell in setdiff(keys(old_topology.nodes), notebook.cells)
-		delete_unsafe!(new_nodes, removed_cell)
-		delete_unsafe!(new_codes, removed_cell)
-		delete!(unresolved_cells, removed_cell)
+	removed_cells = setdiff(all_cells(old_topology), notebook.cells)
+	if isempty(removed_cells)
+		# We can keep identity
+		new_codes = merge(old_topology.codes, updated_codes)
+		new_nodes = merge(old_topology.nodes, updated_nodes)
+		cell_order = old_topology.cell_order
+	else
+		setdiff!(unresolved_cells, removed_cells)
+		new_codes = merge(setdiffkeys(old_topology.codes, removed_cells), updated_codes)
+		new_nodes = merge(setdiffkeys(old_topology.nodes, removed_cells), updated_nodes)
+		cell_order = ImmutableVector(notebook.cells)
 	end
-	
-	# TODO: this could be cached in a better way if it matters
-	cell_order = notebook.cells == old_topology.cell_order ?
-		old_topology.cell_order : # if the order is the same, we can reuse the old one
-		ImmutableVector(notebook.cells) # (this will do a shallow copy)
-	
+
 	NotebookTopology(;
-		nodes=new_nodes, 
-		codes=new_codes, 
+		nodes=new_nodes,
+		codes=new_codes,
 		unresolved_cells=ImmutableSet(unresolved_cells; skip_copy=true), 
-		cell_order
+		cell_order,
 	)
 end

--- a/src/analysis/TopologyUpdate.jl
+++ b/src/analysis/TopologyUpdate.jl
@@ -31,18 +31,19 @@ function updated_topology(old_topology::NotebookTopology, notebook::Notebook, ce
 		end
 	end
 
-	removed_cells = setdiff(all_cells(old_topology), notebook.cells)
+	old_cells = all_cells(old_topology)
+	removed_cells = setdiff(old_cells, notebook.cells)
 	if isempty(removed_cells)
 		# We can keep identity
 		new_codes = merge(old_topology.codes, updated_codes)
 		new_nodes = merge(old_topology.nodes, updated_nodes)
-		cell_order = old_topology.cell_order
 	else
 		setdiff!(unresolved_cells, removed_cells)
 		new_codes = merge(setdiffkeys(old_topology.codes, removed_cells), updated_codes)
 		new_nodes = merge(setdiffkeys(old_topology.nodes, removed_cells), updated_nodes)
-		cell_order = ImmutableVector(notebook.cells)
 	end
+
+	cell_order = old_cells == notebook.cells ? old_cells : ImmutableVector(notebook.cells)
 
 	NotebookTopology(;
 		nodes=new_nodes,

--- a/src/evaluation/Run.jl
+++ b/src/evaluation/Run.jl
@@ -34,7 +34,7 @@ function run_reactive!(
     roots::Vector{Cell};
     deletion_hook::Function = WorkspaceManager.move_vars,
     user_requested_run::Bool = true,
-	bond_value_pairs=_empty_bond_value_pairs,
+    bond_value_pairs=_empty_bond_value_pairs,
 )::TopologicalOrder
     withtoken(notebook.executetoken) do
         run_reactive_core!(
@@ -45,7 +45,7 @@ function run_reactive!(
             roots;
             deletion_hook,
             user_requested_run,
-			bond_value_pairs
+            bond_value_pairs
         )
     end
 end
@@ -65,7 +65,7 @@ function run_reactive_core!(
     deletion_hook::Function = WorkspaceManager.move_vars,
     user_requested_run::Bool = true,
     already_run::Vector{Cell} = Cell[],
-	bond_value_pairs = _empty_bond_value_pairs,
+    bond_value_pairs = _empty_bond_value_pairs,
 )::TopologicalOrder
     @assert !isready(notebook.executetoken) "run_reactive_core!() was called with a free notebook.executetoken."
     @assert will_run_code(notebook)
@@ -80,8 +80,8 @@ function run_reactive_core!(
         update_dependency_cache!(notebook)
     end
 
-    removed_cells = setdiff(keys(old_topology.nodes), keys(new_topology.nodes))
-    roots = Cell[roots..., removed_cells...]
+    removed_cells = setdiff(all_cells(old_topology), all_cells(new_topology))
+    roots = vcat(roots, removed_cells)
 
     # by setting the reactive node and expression caches of deleted cells to "empty", we are essentially pretending that those cells still exist, but now have empty code. this makes our algorithm simpler.
     new_topology = NotebookTopology(
@@ -97,7 +97,8 @@ function run_reactive_core!(
         cell_order = new_topology.cell_order,
     )
 
-    # save the old topological order - we'll delete variables assigned from it and re-evalutate its cells unless the cells have already run previously in the reactive run
+    # save the old topological order - we'll delete variables assigned from its
+    # and re-evalutate its cells unless the cells have already run previously in the reactive run
     old_order = topological_order(old_topology, roots)
 
     old_runnable = setdiff(old_order.runnable, already_run)
@@ -110,8 +111,8 @@ function run_reactive_core!(
     to_run_raw = setdiff(union(new_runnable, old_runnable), keys(new_order.errable))::Vector{Cell} # TODO: think if old error cell order matters
 
     # find (indirectly) deactivated cells and update their status
-	deactivated = filter(c -> c.metadata["disabled"], notebook.cells)
-    indirectly_deactivated = collect(topological_order(new_topology, deactivated))
+    disabled_cells = filter(is_disabled, notebook.cells)
+    indirectly_deactivated = collect(topological_order(new_topology, disabled_cells))
     for cell in indirectly_deactivated
         cell.running = false
         cell.queued = false

--- a/src/notebook/Cell.jl
+++ b/src/notebook/Cell.jl
@@ -1,10 +1,13 @@
 import UUIDs: UUID, uuid1
 import .ExpressionExplorer: SymbolsState, UsingsImports
 
+const METADATA_DISABLED_KEY = "disabled"
+const METADATA_SHOW_LOGS_KEY = "show_logs"
+
 # Make sure to keep this in sync with DEFAULT_CELL_METADATA in ../frontend/components/Editor.js
 const DEFAULT_CELL_METADATA = Dict{String, Any}(
-    "disabled" => false,
-    "show_logs" => true,
+    METADATA_DISABLED_KEY => false,
+    METADATA_SHOW_LOGS_KEY => true,
 )
 
 Base.@kwdef struct CellOutput
@@ -74,5 +77,5 @@ end
 
 
 "Returns whether or not the cell is **explicitely** disabled."
-is_disabled(c::Cell) = get(c.metadata, "disabled", false)
-can_show_logs(c::Cell) = get(c.metadata, "show_logs", true)
+is_disabled(c::Cell) = get(c.metadata, METADATA_DISABLED_KEY, DEFAULT_CELL_METADATA[METADATA_DISABLED_KEY])
+can_show_logs(c::Cell) = get(c.metadata, METADATA_SHOW_LOGS_KEY, DEFAULT_CELL_METADATA[METADATA_SHOW_LOGS_KEY])

--- a/src/notebook/saving and loading.jl
+++ b/src/notebook/saving and loading.jl
@@ -68,7 +68,7 @@ function save_notebook(io::IO, notebook::Notebook)
             end
         end
         
-        cell_running_disabled = get(c.metadata, "disabled", false)::Bool
+        cell_running_disabled = is_disabled(c)::Bool
         if cell_running_disabled || c.depends_on_disabled_cells
             print(io, _disabled_prefix)
             print(io, replace(c.code, _cell_id_delimiter => "# "))

--- a/test/React.jl
+++ b/test/React.jl
@@ -159,6 +159,24 @@ import Distributed
         end
     end
 
+    @testset "Simple delete cell" begin
+        notebook = Notebook(Cell.([
+            "x = 42",
+            "x",
+        ]))
+        update_run!(🍭, notebook, notebook.cells)
+
+        @test all(noerror, notebook.cells)
+        cell_to_delete = notebook.cells[begin]
+
+        delete!(notebook.cells_dict, cell_to_delete.cell_id)
+        filter!(!=(cell_to_delete.cell_id), notebook.cell_order)
+        @test length(notebook.cells) == 1
+
+        update_run!(🍭, notebook, Cell[])
+        @test occursinerror("UndefVarError: x", notebook.cells[begin])
+    end
+
     @testset ".. as an identifier" begin
         notebook = Notebook(Cell.([
            ".. = 1",

--- a/test/React.jl
+++ b/test/React.jl
@@ -159,6 +159,30 @@ import Distributed
         end
     end
 
+    @testset "Simple insert cell" begin
+        notebook = Notebook(Cell[])
+        update_run!(🍭, notebook, notebook.cells)
+
+        insert_cell!(notebook, Cell("a = 1"))
+        update_run!(🍭, notebook, notebook.cells[begin])
+
+        insert_cell!(notebook, Cell("b = 2"))
+        update_run!(🍭, notebook, notebook.cells[begin+1])
+
+        insert_cell!(notebook, Cell("c = 3"))
+        update_run!(🍭, notebook, notebook.cells[begin+2])
+
+        insert_cell!(notebook, Cell("a + b + c"))
+        update_run!(🍭, notebook, notebook.cells[begin+3])
+
+        @test notebook.cells[begin+3].output.body == "6"
+
+        setcode!(notebook.cells[begin+1], "b = 10")
+        update_run!(🍭, notebook, notebook.cells[begin+1])
+
+        @test notebook.cells[begin+3].output.body == "14"
+    end
+
     @testset "Simple delete cell" begin
         notebook = Notebook(Cell.([
             "x = 42",
@@ -167,10 +191,8 @@ import Distributed
         update_run!(🍭, notebook, notebook.cells)
 
         @test all(noerror, notebook.cells)
-        cell_to_delete = notebook.cells[begin]
 
-        delete!(notebook.cells_dict, cell_to_delete.cell_id)
-        filter!(!=(cell_to_delete.cell_id), notebook.cell_order)
+        delete_cell!(notebook, notebook.cells[begin])
         @test length(notebook.cells) == 1
 
         update_run!(🍭, notebook, Cell[])

--- a/test/helpers.jl
+++ b/test/helpers.jl
@@ -127,6 +127,16 @@ function easy_symstate(expected_references, expected_definitions, expected_funcc
     SymbolsState(Set(expected_references), Set(expected_definitions), new_expected_funccalls, new_expected_funcdefs, new_expected_macrocalls)
 end
 
+function insert_cell!(notebook, cell)
+    notebook.cells_dict[cell.cell_id] = cell
+    push!(notebook.cell_order, cell.cell_id)
+end
+
+function delete_cell!(notebook, cell)
+    deleteat!(notebook.cell_order, findfirst(==(cell.cell_id), notebook.cell_order))
+    delete!(notebook.cells_dict, cell.cell_id)
+end
+
 function setcode!(cell, newcode)
     cell.code = newcode
 end


### PR DESCRIPTION
This lead to a subtle bug where the identity branch in
`Base.merge(::ImmutableDefaultDict, ::ImmutableDefaultDict)` would cause the
the `delete_unsafe!` to be applied to both new and old topologies :worried:.

> **Note**
> identity was already not preserved with the cell_order being different!

Fixes #2167 