### PR TITLE
fix cell paste at specific cell

### DIFF
--- a/frontend/common/Serialization.js
+++ b/frontend/common/Serialization.js
@@ -1,5 +1,3 @@
-import { in_textarea_or_input } from "./KeyboardShortcuts.js"
-
 /**
  * Serialize an array of cells into a string form (similar to the .jl file).
  *
@@ -53,9 +51,9 @@ export function deserialize_repl(repl_session) {
         .filter((s) => s !== "")
 }
 
-export const detect_deserializer = (topaste, check_in_textarea_or_input = true) =>
+export const detect_deserializer = (topaste) =>
     topaste.trim().startsWith(JULIA_REPL_PROMPT)
         ? deserialize_repl
-        : check_in_textarea_or_input && !in_textarea_or_input() && topaste.match(/# ╔═╡ ........-....-....-....-............/g)?.length
+        : topaste.match(/# ╔═╡ ........-....-....-....-............/g)?.length
         ? deserialize_cells
         : null

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -6,7 +6,6 @@ import { utf8index_to_ut16index } from "../common/UnicodeTools.js"
 import { PlutoActionsContext } from "../common/PlutoContext.js"
 import { get_selected_doc_from_state } from "./CellInput/LiveDocsFromCursor.js"
 import { go_to_definition_plugin, GlobalDefinitionsFacet } from "./CellInput/go_to_definition_plugin.js"
-import { detect_deserializer } from "../common/Serialization.js"
 
 import {
     EditorState,

--- a/frontend/components/CellInput/pluto_paste_plugin.js
+++ b/frontend/components/CellInput/pluto_paste_plugin.js
@@ -14,7 +14,7 @@ export let pluto_paste_plugin = ({ pluto_actions, cell_id }) => {
             event.stopPropagation()
 
             const topaste = event.clipboardData.getData("text/plain")
-            const deserializer = detect_deserializer(topaste, false)
+            const deserializer = detect_deserializer(topaste)
             if (deserializer == null) {
                 return false
             }


### PR DESCRIPTION
Fixes https://github.com/fonsp/Pluto.jl/issues/2188

The removed flags inside the serializer are carry-overs from the CM5 era, but should not be needed anymore with the separate CellInput paste handler after migration to CM6.

This should fix the mentioned issue while still avoiding the issue addressed by https://github.com/fonsp/Pluto.jl/issues/2131

I also removed an unused import inside CellInput.js (again coming from the CM5 era)