### PR TITLE
fix async process issue

### DIFF
--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -2209,8 +2209,8 @@ function with_io_to_logs(f::Function; enabled::Bool=true, loglevel::Logging.LogL
         # If we do not close the pipe then the cell
         #   run(`julia -e 'sleep(5)'`; wait=false)
         # takes 5 seconds to complete even though it should run asyncronously. This is
-        # because wait(output, pipe) runs until EOF.
-        close(pipe.out)
+        # because write(output, pipe) runs until EOF.
+        close(pipe)
         wait(buffer_redirect_task)
     end
 

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -2206,6 +2206,11 @@ function with_io_to_logs(f::Function; enabled::Bool=true, loglevel::Logging.LogL
         redirect_stderr(default_stderr)
         close(pe_stdout)
         close(pe_stderr)
+        # If we do not close the pipe then the cell
+        #   run(`julia -e 'sleep(5)'`; wait=false)
+        # takes 5 seconds to complete even though it should run asyncronously. This is
+        # because wait(output, pipe) runs until EOF.
+        close(pipe.out)
         wait(buffer_redirect_task)
     end
 

--- a/test/React.jl
+++ b/test/React.jl
@@ -1722,4 +1722,17 @@ import Distributed
         update_run!(🍭, notebook, notebook.cells)
         @test all(noerror, notebook.cells)
     end
+
+    @testset "Asynchronous commands - Issue #2121 & PR #2216" begin
+        notebook = Notebook(Cell[
+            Cell("@async run(`sleep 5`)"),
+        ])
+        update_run!(🍭, notebook, notebook.cells)
+        @test notebook.cells[begin] |> noerror
+        second = 1e9
+        @test notebook.cells[begin].runtime < .1second
+        @test occursin("runnable", notebook.cells[begin].output.body)
+        @test occursin("Task", notebook.cells[begin].output.body)
+        WorkspaceManager.unmake_workspace((🍭, notebook); verbose=false)
+    end
 end


### PR DESCRIPTION
Fixes #2121.

Here's a cell you can test with:
```julia
begin
    cmd = `julia -e 'println(0); sleep(3); println(1);'`
    pipe = pipeline(cmd; stdout, stderr)
    proc = run(pipe; wait=false)
    sleep(0)
end
```

With the old behaviour, this cell takes 3 seconds to run, even though the running process should occur asynchronously.

With this PR, the cell finishes immediately. If you change to `sleep(2)` then you get the terminal viewer popping up with the first message printed ("0") and with `sleep(4)` you get both messages ("0" and "1"), all as you'd expect.

As @fonsp supposed, it was indeed hanging at `wait(buffer_redirect_task)`. I think what's going on is this:
- the stdout from `proc` is redirected to Julia's `stdout`
- `pipe` is created, redirecting Julia's `stdout`
- hence `pipe` does not hit EOF until `proc` terminates
- and `write(output, pipe)` loops until `pipe` hits EOF

Anyway, `close(pipe.out)` forces EOF and solves the problem. Seems to work on Windows and Linux.