### PR TITLE
Attach hljs to the window object to allow custom highlighting within code blocks

### DIFF
--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -3,8 +3,6 @@ import * as preact from "../imports/Preact.js"
 import immer, { applyPatches, produceWithPatches } from "../imports/immer.js"
 import _ from "../imports/lodash.js"
 
-import hljs from "../imports/highlightjs.js"
-
 import { empty_notebook_state, set_disable_ui_css } from "../editor.js"
 import { create_pluto_connection } from "../common/PlutoConnection.js"
 import { init_feedback } from "../common/Feedback.js"
@@ -1213,10 +1211,6 @@ patch: ${JSON.stringify(
                 // and don't prevent the unload
             }
         })
-
-        // Attach the highlighter object to the window to allow custom highlighting from the frontend. See https://github.com/fonsp/Pluto.jl/pull/2244
-        //@ts-ignore
-        window.hljs = hljs
     }
 
     componentDidMount() {

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -3,6 +3,8 @@ import * as preact from "../imports/Preact.js"
 import immer, { applyPatches, produceWithPatches } from "../imports/immer.js"
 import _ from "../imports/lodash.js"
 
+import hljs from "../imports/highlightjs.js"
+
 import { empty_notebook_state, set_disable_ui_css } from "../editor.js"
 import { create_pluto_connection } from "../common/PlutoConnection.js"
 import { init_feedback } from "../common/Feedback.js"
@@ -1213,7 +1215,9 @@ patch: ${JSON.stringify(
         })
     }
 
-    componentDidMount() {
+    componentDidMount() {        
+        //@ts-ignore
+        window.hljs = hljs
         if (this.state.static_preview) {
             this.setState({
                 initializing: false,

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -1213,11 +1213,13 @@ patch: ${JSON.stringify(
                 // and don't prevent the unload
             }
         })
-    }
 
-    componentDidMount() {        
+        // Attach the highlighter object to the window to allow custom highlighting from the frontend. See https://github.com/fonsp/Pluto.jl/pull/2244
         //@ts-ignore
         window.hljs = hljs
+    }
+
+    componentDidMount() {
         if (this.state.static_preview) {
             this.setState({
                 initializing: false,

--- a/frontend/imports/highlightjs.js
+++ b/frontend/imports/highlightjs.js
@@ -8,4 +8,8 @@ import hljs_juliarepl from "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@
 hljs.registerLanguage("julia", hljs_julia)
 hljs.registerLanguage("julia-repl", hljs_juliarepl)
 
+// Attach the highlighter object to the window to allow custom highlighting from the frontend. See https://github.com/fonsp/Pluto.jl/pull/2244
+//@ts-ignore
+window.hljs = hljs
+
 export default hljs


### PR DESCRIPTION
Pluto already uses highlight.js to provide synthax highlighting within code_blocks. This very small changes just attaches the `hljs` object to the window in order to be able to register new languages to it.

The library comes with 36 languages [by default](https://highlightjs.org/download/), but many more can be easily added if we have access to the object

Here is a small example to enable Matlab highlighting:
![image](https://user-images.githubusercontent.com/12846528/184498337-4300f0ae-7c4a-4e40-96bd-480af4b5d6b8.png)

I am not sure whether I attached it in the right part of the code in `Editor.js`, so that might be changed.