### PR TITLE
Advanced pkg manager

### DIFF
--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -170,13 +170,20 @@ const first_true_key = (obj) => {
  */
 
 /**
+ * @typedef PkgData
+ * @property {string} installed_version
+ * @property {string} pkg_str The equivalent PkgREPL string to be used to install the package
+ * @property {boolean} has_custom_pkg_str True if the package in question has a non-standard pkg_str, where standard is `add $(package_name)`
+ * @property {boolean} is_dev True if the package has en added with Pkg.develop rather than Pkg.add
+ */
+
+/**
  * @typedef NotebookPkgData
  * @type {{
  *  enabled: boolean,
  *  restart_recommended_msg: string?,
  *  restart_required_msg: string?,
- *  installed_versions: { [pkg_name: string]: string },
- *  installed_pkgstrs: { [pkg_name: string]: string },
+ *  installed_packages: { [pkg_name: string]: PkgData },
  *  terminal_outputs: { [pkg_name: string]: string },
  *  busy_packages: string[],
  *  instantiated: boolean,

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -625,7 +625,7 @@ export class Editor extends Component {
             /** This actions avoids pushing selected cells all the way down, which is too heavy to handle! */
             get_selected_cells: (cell_id, /** @type {boolean} */ allow_other_selected_cells) =>
                 allow_other_selected_cells ? this.state.selected_cells : [cell_id],
-            get_avaible_versions: async ({ package_name, notebook_id }) => {
+            get_available_versions: async ({ package_name, notebook_id }) => {
                 const { message } = await this.client.send("nbpkg_available_versions", { package_name: package_name }, { notebook_id: notebook_id })
                 return message.versions
             },

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -176,6 +176,7 @@ const first_true_key = (obj) => {
  *  restart_recommended_msg: string?,
  *  restart_required_msg: string?,
  *  installed_versions: { [pkg_name: string]: string },
+ *  installed_pkgstrs: { [pkg_name: string]: string },
  *  terminal_outputs: { [pkg_name: string]: string },
  *  busy_packages: string[],
  *  instantiated: boolean,

--- a/frontend/components/PkgStatusMark.js
+++ b/frontend/components/PkgStatusMark.js
@@ -110,7 +110,7 @@ export const PkgStatusMark = ({ package_name, pluto_actions, notebook_id, nbpkg 
     const [available_versions, set_available_versions] = useState(/** @type {string[]?} */ (null))
 
     useEffect(() => {
-        let available_version_promise = pluto_actions.get_avaible_versions({ package_name, notebook_id }) ?? Promise.resolve([])
+        let available_version_promise = pluto_actions.get_available_versions({ package_name, notebook_id }) ?? Promise.resolve([])
         available_version_promise.then((available_versions) => {
             set_available_versions(available_versions)
         })

--- a/frontend/components/Popup.js
+++ b/frontend/components/Popup.js
@@ -164,11 +164,7 @@ const PkgPopup = ({ notebook, recent_event, clear_recent_event }) => {
 
     async function try_update_pkgstr(message, _default) {
         const new_pkg_str = prompt(message, _default) ?? pkg_str
-        const result = await pluto_actions.send(
-            "pkg_str",
-            { package_name: recent_event.package_name, pkg_str: new_pkg_str },
-            { notebook_id: notebook.notebook_id }
-        )
+        const result = await pluto_actions.send("pkg_str", { package_name: package_name, pkg_str: new_pkg_str }, { notebook_id: notebook.notebook_id })
         if (result.message.errored) {
             try_update_pkgstr(result.message.message, new_pkg_str)
         }

--- a/frontend/components/Popup.js
+++ b/frontend/components/Popup.js
@@ -149,7 +149,7 @@ const PkgPopup = ({ notebook, recent_event, clear_recent_event }) => {
 
     const package_name = recent_event?.package_name
     const default_pkg_str = `add ${recent_event.package_name}`
-    const pkg_str = (notebook.nbpkg?.installed_pkgstrs ?? {}).hasOwnProperty(package_name) ? notebook.nbpkg?.installed_pkgstrs[package_name] : default_pkg_str
+    const pkg_str = notebook.metadata?.custom_pkgstrs?.[package_name] ?? default_pkg_str
 
     const busy = recent_event != null && ((notebook.nbpkg?.busy_packages ?? []).includes(package_name) || !(notebook.nbpkg?.instantiated ?? true))
 

--- a/frontend/components/Popup.js
+++ b/frontend/components/Popup.js
@@ -118,7 +118,7 @@ const PkgPopup = ({ notebook, recent_event, clear_recent_event }) => {
         if (recent_event == null) {
             set_pkg_status(null)
         } else if (recent_event?.type === "nbpkg") {
-            ;(pluto_actions.get_avaible_versions({ package_name: recent_event.package_name, notebook_id: notebook.notebook_id }) ?? Promise.resolve([])).then(
+            ;(pluto_actions.get_available_versions({ package_name: recent_event.package_name, notebook_id: notebook.notebook_id }) ?? Promise.resolve([])).then(
                 (versions) => {
                     if (still_valid) {
                         set_pkg_status(

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -1748,6 +1748,18 @@ pkg-status-mark.disable_pkg > button > span::after {
     filter: var(--image-filters);
 }
 
+pkg-status-mark.custom_pkg_str > button > span::after {
+    opacity: 0.6;
+    /* The filter comes from using https://codepen.io/sosuke/pen/Pjoqqp with a target color of #f5980c*/
+    filter: invert(68%) sepia(24%) saturate(3205%) hue-rotate(353deg) brightness(97%) contrast(99%);
+}
+
+pkg-status-mark.custom_pkg_str.dev_pkg > button > span::after {
+    opacity: 0.6;
+    /* The filter comes from using https://codepen.io/sosuke/pen/Pjoqqp with a target color of #d428eb*/
+    filter: invert(31%) sepia(61%) saturate(4615%) hue-rotate(278deg) brightness(95%) contrast(108%);
+}
+
 pluto-popup {
     display: block;
     position: absolute;

--- a/src/notebook/Notebook.jl
+++ b/src/notebook/Notebook.jl
@@ -52,6 +52,7 @@ Base.@kwdef mutable struct Notebook
     nbpkg_terminal_outputs::Dict{String,String}=Dict{String,String}()
     nbpkg_busy_packages::Vector{String}=String[]
     nbpkg_installed_versions_cache::Dict{String,String}=Dict{String,String}()
+    nbpkg_installed_pkgstrs_cache::Dict{String,String}=Dict{String,String}()
 
     process_status::String=ProcessStatus.starting
     wants_to_interrupt::Bool=false

--- a/src/notebook/Notebook.jl
+++ b/src/notebook/Notebook.jl
@@ -1,7 +1,7 @@
 import UUIDs: UUID, uuid1
 import .ExpressionExplorer: SymbolsState, FunctionNameSignaturePair, FunctionName
 import .Configuration
-import .PkgCompat: PkgCompat, PkgContext
+import .PkgCompat: PkgCompat, PkgContext, PkgData
 import Pkg
 import TOML
 
@@ -51,8 +51,7 @@ Base.@kwdef mutable struct Notebook
     nbpkg_restart_required_msg::Union{Nothing,String}=nothing
     nbpkg_terminal_outputs::Dict{String,String}=Dict{String,String}()
     nbpkg_busy_packages::Vector{String}=String[]
-    nbpkg_installed_versions_cache::Dict{String,String}=Dict{String,String}()
-    nbpkg_installed_pkgstrs_cache::Dict{String,String}=Dict{String,String}()
+    nbpkg_installed_pkgdata_cache::Dict{String,PkgData}=Dict{String,PkgData}()
 
     process_status::String=ProcessStatus.starting
     wants_to_interrupt::Bool=false

--- a/src/notebook/saving and loading.jl
+++ b/src/notebook/saving and loading.jl
@@ -301,15 +301,14 @@ function load_notebook_nobackup(@nospecialize(io::IO), @nospecialize(path::Abstr
         k ∈ appeared_order
     end
 
-    versions, pkgstrs = nbpkg_cache(nbpkg_ctx)
+    custom_pkgstrs = get(notebook_metadata, "custom_pkgstrs", Dict{String, Any}())
     Notebook(;
         cells_dict=appeared_cells_dict,
         cell_order=appeared_order,
         topology=_initial_topology(appeared_cells_dict, appeared_order),
         path=path,
         nbpkg_ctx=nbpkg_ctx,
-        nbpkg_installed_versions_cache=versions,
-        nbpkg_installed_pkgstrs_cache=pkgstrs,
+        nbpkg_installed_pkgdata_cache=nbpkg_cache(nbpkg_ctx, custom_pkgstrs),
         metadata=notebook_metadata,
     )
 end

--- a/src/notebook/saving and loading.jl
+++ b/src/notebook/saving and loading.jl
@@ -301,13 +301,15 @@ function load_notebook_nobackup(@nospecialize(io::IO), @nospecialize(path::Abstr
         k ∈ appeared_order
     end
 
+    versions, pkgstrs = nbpkg_cache(nbpkg_ctx)
     Notebook(;
         cells_dict=appeared_cells_dict,
         cell_order=appeared_order,
         topology=_initial_topology(appeared_cells_dict, appeared_order),
         path=path,
         nbpkg_ctx=nbpkg_ctx,
-        nbpkg_installed_versions_cache=nbpkg_cache(nbpkg_ctx),
+        nbpkg_installed_versions_cache=versions,
+        nbpkg_installed_pkgstrs_cache=pkgstrs,
         metadata=notebook_metadata,
     )
 end

--- a/src/packages/Packages.jl
+++ b/src/packages/Packages.jl
@@ -267,12 +267,12 @@ function sync_nbpkg(session, notebook, old_topology::NotebookTopology, new_topol
 				send_notebook_changes!(ClientRequest(session=session, notebook=notebook))
 			end
 			result = sync_nbpkg_core(notebook, old_topology, new_topology; on_terminal_output=iocallback, lag = session.options.server.simulated_pkg_lag)
-            # If nothing happened, we might still have to remove packages that were temporary added to the cache by the front-end but did not end up being installed, either because the cell was cancelled before being run or soemthing else
-            if any(p -> p.installed_version === nothing, values(notebook.nbpkg_installed_pkgdata_cache))
-                update_nbpkg_cache!(notebook) # This is here for the moment to eventually remove 
+			# If nothing happened, we might still have to remove packages that were temporary added to the cache by the front-end but did not end up being installed, either because the cell was cancelled before being run or soemthing else
+			if any(p -> p.installed_version === nothing, values(notebook.nbpkg_installed_pkgdata_cache))
+			    update_nbpkg_cache!(notebook) # This is here for the moment to eventually remove 
 				send_notebook_changes!(ClientRequest(session=session, notebook=notebook))
-            end
-            return result
+			end
+			return result
 		end
 
 		if pkg_result.did_something

--- a/src/packages/Packages.jl
+++ b/src/packages/Packages.jl
@@ -555,8 +555,8 @@ end
 function group_pkg_operations(notebook::Notebook, pkg_names)
     pkgstr_cache = notebook.nbpkg_installed_pkgstrs_cache
 	out = []
-	to_add = Pkg.PackageSpec[]
-	to_develop = Pkg.PackageSpec[]
+	to_add = Pkg.Types.PackageSpec[]
+	to_develop = Pkg.Types.PackageSpec[]
 	for name in pkg_names
         pkgspec, func = if haskey(pkgstr_cache, name)
             PkgCompat.parse_pkgstr(pkgstr_cache[name])

--- a/src/packages/Packages.jl
+++ b/src/packages/Packages.jl
@@ -1,7 +1,7 @@
 
 import .ExpressionExplorer: external_package_names
 import .PkgCompat
-import .PkgCompat: select, is_stdlib
+import .PkgCompat: select, is_stdlib, PkgData
 
 const tiers = [
 	Pkg.PRESERVE_ALL,
@@ -147,8 +147,9 @@ function sync_nbpkg_core(notebook::Notebook, old_topology::NotebookTopology, new
                 
                 # TODO: instead of Pkg.PRESERVE_ALL, we actually want:
                 # "Pkg.PRESERVE_DIRECT, but preserve exact verisons of Base.loaded_modules"
+                custom_pkgstrs = get(get_metadata(notebook), "custom_pkgstrs", Dict{String, Any}())
 
-                to_add = filter(x -> haskey(notebook.nbpkg_installed_pkgstrs_cache, x) || PkgCompat.package_exists(x), added)
+                to_add = filter(x -> haskey(custom_pkgstrs, x) || PkgCompat.package_exists(x), added)
                 
                 if !isempty(to_add)
                     @debug to_add
@@ -265,7 +266,13 @@ function sync_nbpkg(session, notebook, old_topology::NotebookTopology, new_topol
                 update_nbpkg_cache!(notebook)
 				send_notebook_changes!(ClientRequest(session=session, notebook=notebook))
 			end
-			 sync_nbpkg_core(notebook, old_topology, new_topology; on_terminal_output=iocallback, lag = session.options.server.simulated_pkg_lag)
+			result = sync_nbpkg_core(notebook, old_topology, new_topology; on_terminal_output=iocallback, lag = session.options.server.simulated_pkg_lag)
+            # If nothing happened, we might still have to remove packages that were temporary added to the cache by the front-end but did not end up being installed, either because the cell was cancelled before being run or soemthing else
+            if any(p -> p.installed_version === nothing, values(notebook.nbpkg_installed_pkgdata_cache))
+                update_nbpkg_cache!(notebook) # This is here for the moment to eventually remove 
+				send_notebook_changes!(ClientRequest(session=session, notebook=notebook))
+            end
+            return result
 		end
 
 		if pkg_result.did_something
@@ -451,26 +458,40 @@ function update_nbpkg(session, notebook::Notebook; level::Pkg.UpgradeLevel=Pkg.U
 	end
 end
 
-function nbpkg_cache(ctx::Union{Nothing,PkgContext})
-    caches = if ctx === nothing 
-        (Dict{String,String}(), Dict{String,String}()) 
+function nbpkg_cache(ctx::Union{Nothing,PkgContext}, custom_pkgstrs::Dict{String, Any})
+    cache = Dict{String, PkgData}()
+    update_nbpkg_cache!(cache, custom_pkgstrs, ctx)
+    return cache
+end
+
+function update_nbpkg_cache!(cache::Dict{String,PkgData}, custom_pkgstrs::Dict{String, Any}, ctx::Union{Nothing,PkgContext})
+    if ctx === nothing 
+        empty!(cache)
     else 
-        ks = keys(PkgCompat.project(ctx).dependencies)
-        versions = Dict{String,String}(
-            x => string(PkgCompat.get_manifest_version(ctx, x)) for x in ks
-        )
-        pkgstrs = Dict{String,String}(
-            x => string(PkgCompat.get_manifest_pkgstr(ctx, x)) for x in ks
-        )
-        (versions, pkgstrs)
+        pkg_names = keys(PkgCompat.project(ctx).dependencies)
+        # We remove the entries that are not installed anymore
+        filter_func = pair -> pair.first in pkg_names
+        filter!(filter_func, cache)
+        filter!(filter_func, custom_pkgstrs)
+        # We either modify or create the dictionary entry ex-novo
+        for name in pkg_names
+            installed_version = PkgCompat.get_manifest_version(ctx, name)
+            pkgstr = get(custom_pkgstrs, name, "add $name")::String # We annotate here as the notebook metadata dicts have Any values
+            entry = get!(cache, name, PkgData(pkgstr))
+            # We update the installed version
+            cache[name] = PkgData(entry; installed_version)
+        end 
     end
-    return caches
+    return cache
 end
 
 function update_nbpkg_cache!(notebook::Notebook)
-    versions, pkgstrs = nbpkg_cache(notebook.nbpkg_ctx)
-    notebook.nbpkg_installed_versions_cache = versions 
-    notebook.nbpkg_installed_pkgstrs_cache = pkgstrs
+    notebook_metadata = get_metadata(notebook)
+    # The Dict seems to be needed as the returned metadata is Dict{String, Any}
+    custom_pkgstrs = get(notebook_metadata, "custom_pkgstrs", Dict{String, Any}())
+    cache = notebook.nbpkg_installed_pkgdata_cache
+    update_nbpkg_cache!(cache, custom_pkgstrs, notebook.nbpkg_ctx)
+    isempty(custom_pkgstrs) && delete!(notebook_metadata, "custom_pkgstrs")
     notebook
 end
 
@@ -552,20 +573,22 @@ function stoplistening(listener::IOListener)
     end
 end
 
-function group_pkg_operations(notebook::Notebook, pkg_names)
-    pkgstr_cache = notebook.nbpkg_installed_pkgstrs_cache
+function pkgdata_to_js(notebook::Notebook) 
+    Dict(k => PkgCompat.to_js_dict(v) for (k,v) in notebook.nbpkg_installed_pkgdata_cache)
+end
+
+function group_pkg_operations(notebook::Notebook, pkg_names::Vector{String})
 	out = []
-	to_add = Pkg.Types.PackageSpec[]
-	to_develop = Pkg.Types.PackageSpec[]
-	for name in pkg_names
-        pkgspec, func = if haskey(pkgstr_cache, name)
-            PkgCompat.parse_pkgstr(pkgstr_cache[name])
-        else
-            # The package has no custom string, so we create the default one
-            Pkg.PackageSpec(;name), Pkg.add
+    to_add = Pkg.Types.PackageSpec[]
+    to_develop = Pkg.Types.PackageSpec[]
+    # We add eventual new packages that have not been processed yet
+    for name in pkg_names
+        p = get!(notebook.nbpkg_installed_pkgdata_cache, name, PkgData("add $name"))
+        if p.pkgfunc === Pkg.add
+            push!(to_add, p.spec)
+        elseif p.pkgfunc === Pkg.develop
+            push!(to_develop, p.spec)
         end
-        func === Pkg.add && push!(to_add, pkgspec)
-        func === Pkg.develop && push!(to_develop, pkgspec)
     end
     !isempty(to_add) && push!(out, (Pkg.add, to_add))
     !isempty(to_develop) && push!(out, (Pkg.develop, to_develop))

--- a/src/packages/Packages.jl
+++ b/src/packages/Packages.jl
@@ -477,8 +477,8 @@ function update_nbpkg_cache!(cache::Dict{String,PkgData}, custom_pkgstrs::Dict{S
         for name in pkg_names
             manifest_version = PkgCompat.get_manifest_version(ctx, name)
             installed_version = manifest_version === "stdlib" ? nothing : manifest_version
-            pkgstr = get(custom_pkgstrs, name, "add $name")::String # We annotate here as the notebook metadata dicts have Any values
-            entry = get!(cache, name, PkgData(pkgstr))
+            pkg_str = get(custom_pkgstrs, name, "add $name")::String # We annotate here as the notebook metadata dicts have Any values
+            entry = get!(cache, name, PkgData(pkg_str))
             # We update the installed version
             cache[name] = PkgData(entry; installed_version)
         end 

--- a/src/packages/PkgCompat.jl
+++ b/src/packages/PkgCompat.jl
@@ -480,9 +480,8 @@ function parse_pkgstr(pkg_str::String)
     # We check for single package
     args = command.arguments
     length(args) > 1 && error("The provided commands adds multiple packages, please only provide a command for $package_name")
-    # We extract and pre-process the package_spec
+    # We extract and the package_spec
     pkgspec = args[1]
-    Pkg.API.handle_package_input!(pkgspec)
     # We also extract the extracted function from the command
     func = command.spec.api
     return pkgspec, func

--- a/src/packages/PkgCompat.jl
+++ b/src/packages/PkgCompat.jl
@@ -452,6 +452,9 @@ end
 
 has_custom_pkg_str(p::PkgData) = p.spec.name === nothing || p.pkgstr !== "add $(p.spec.name)"
 is_dev(p::PkgData) = startswith(p.pkgstr, "dev")
+function is_installed_correctly(p::PkgData)
+	return p.installed_version !== nothing || (p.spec.name !== nothing && is_stdlib(p.spec.name))
+end
 
 function to_js_dict(p::PkgData)
 	Dict{String, Any}(

--- a/src/packages/PkgCompat.jl
+++ b/src/packages/PkgCompat.jl
@@ -432,10 +432,10 @@ Base.@kwdef struct PkgData{F <: Function}
 	installed_version::Union{Nothing, VersionNumber} = nothing
 	pkgfunc::F = Pkg.add
 	spec::Pkg.Types.PackageSpec
-	pkgstr::String
+	pkg_str::String
 end
 
-PkgData(v::AbstractString, pkgfunc::Function, spec::Pkg.Types.PackageSpec, pkgstr::String) = PkgData(VersionNumber(v), pkgfunc, spec, pkgstr)
+PkgData(v::AbstractString, pkgfunc::Function, spec::Pkg.Types.PackageSpec, pkg_str::String) = PkgData(VersionNumber(v), pkgfunc, spec, pkg_str)
 
 const _PKGDATA_FIELDS = fieldnames(PkgData) # This is used to avoid fieldnames runtime impact and the need of generated function, see https://discourse.julialang.org/t/slowness-of-fieldnames-and-propertynames/55364
 function PkgData(p::PkgData; kwargs...)
@@ -445,13 +445,13 @@ function PkgData(p::PkgData; kwargs...)
 	PkgData(args...)
 end
 
-function PkgData(pkgstr::AbstractString; kwargs...)
-	spec, pkgfunc = validate_pkgstr(nothing, pkgstr)
-	PkgData(; pkgfunc, spec, pkgstr, kwargs...)
+function PkgData(pkg_str::AbstractString; kwargs...)
+	spec, pkgfunc = validate_pkgstr(nothing, pkg_str)
+	PkgData(; pkgfunc, spec, pkg_str, kwargs...)
 end
 
-has_custom_pkg_str(p::PkgData) = p.spec.name === nothing || p.pkgstr !== "add $(p.spec.name)"
-is_dev(p::PkgData) = startswith(p.pkgstr, "dev")
+has_custom_pkg_str(p::PkgData) = p.spec.name === nothing || p.pkg_str !== "add $(p.spec.name)"
+is_dev(p::PkgData) = startswith(p.pkg_str, "dev")
 function is_installed_correctly(p::PkgData)
 	return p.installed_version !== nothing || (p.spec.name !== nothing && is_stdlib(p.spec.name))
 end
@@ -459,7 +459,7 @@ end
 function to_js_dict(p::PkgData)
 	Dict{String, Any}(
 		"installed_version" => p.installed_version,
-		"pkg_str" => p.pkgstr,
+		"pkg_str" => p.pkg_str,
 		"has_custom_pkg_str" => has_custom_pkg_str(p),
 		"is_dev" => is_dev(p),
 	)

--- a/src/packages/PkgCompat.jl
+++ b/src/packages/PkgCompat.jl
@@ -445,8 +445,8 @@ function PkgData(p::PkgData; kwargs...)
 	PkgData(args...)
 end
 
-function PkgData(pkg_str::AbstractString; kwargs...)
-	spec, pkgfunc = validate_pkgstr(nothing, pkg_str)
+function PkgData(pkg_str::AbstractString; package_name = nothing, kwargs...)
+	spec, pkgfunc = validate_pkgstr(package_name, pkg_str)
 	PkgData(; pkgfunc, spec, pkg_str, kwargs...)
 end
 

--- a/src/webserver/Dynamic.jl
+++ b/src/webserver/Dynamic.jl
@@ -520,13 +520,13 @@ responses[:pkg_str] = function response_pkg_str(🙋::ClientRequest)
     pkg_str = 🙋.body["pkg_str"]
     # We validate the pkg_str
     to_send = try
-        pkgdata = PkgData(pkg_str)
+        pkgdata = PkgData(pkg_str; package_name)
         # If no error happen, we update the notebook and send the changes
         if PkgCompat.is_custom_pkgstr(package_name, pkg_str)
             custom_pkgstrs = get!(get_metadata(notebook), "custom_pkgstrs", Dict{String, Any}())
             custom_pkgstrs[package_name] = pkg_str
         end
-        # We put the updated package_data into the cache
+        # We put the updated package_data into the cache and send changes back to the front-end
         notebook.nbpkg_installed_pkgdata_cache[package_name] = pkgdata
         send_notebook_changes!(🙋 |> without_initiator)
         Dict()

--- a/src/webserver/Dynamic.jl
+++ b/src/webserver/Dynamic.jl
@@ -157,6 +157,7 @@ function notebook_to_js(notebook::Notebook)
                 "restart_required_msg" => notebook.nbpkg_restart_required_msg,
                 # TODO: cache this
                 "installed_versions" => ctx === nothing ? Dict{String,String}() : notebook.nbpkg_installed_versions_cache,
+                "installed_pkgstrs" => ctx === nothing ? Dict{String,String}() : notebook.nbpkg_installed_pkgstrs_cache,
                 "terminal_outputs" => notebook.nbpkg_terminal_outputs,
                 "busy_packages" => notebook.nbpkg_busy_packages,
                 "instantiated" => notebook.nbpkg_ctx_instantiated,
@@ -511,4 +512,21 @@ responses[:pkg_update] = function response_pkg_update(🙋::ClientRequest)
     require_notebook(🙋)
     update_nbpkg(🙋.session, 🙋.notebook)
     putclientupdates!(🙋.session, 🙋.initiator, UpdateMessage(:🦆, Dict(), nothing, nothing, 🙋.initiator))
+end
+
+responses[:pkg_str] = function response_pkg_str(🙋::ClientRequest)
+    require_notebook(🙋)
+    package_name = 🙋.body["package_name"]
+    pkg_str = 🙋.body["pkg_str"]
+    # We validate the pkgstr
+    to_send = try
+        PkgCompat.validate_pkgstr(package_name, pkg_str)
+        # If no error happen, we update the notebook and send the changes
+        🙋.notebook.nbpkg_installed_pkgstrs_cache[package_name] = pkg_str
+        send_notebook_changes!(🙋 |> without_initiator)
+        Dict()
+    catch e
+        Dict("errored" => true, "message" => e.msg)
+    end
+    putclientupdates!(🙋.session, 🙋.initiator, UpdateMessage(:💻, to_send, nothing, nothing, 🙋.initiator))
 end

--- a/src/webserver/Dynamic.jl
+++ b/src/webserver/Dynamic.jl
@@ -518,7 +518,7 @@ responses[:pkg_str] = function response_pkg_str(🙋::ClientRequest)
     notebook = 🙋.notebook
     package_name = 🙋.body["package_name"]
     pkg_str = 🙋.body["pkg_str"]
-    # We validate the pkgstr
+    # We validate the pkg_str
     to_send = try
         pkgdata = PkgData(pkg_str)
         # If no error happen, we update the notebook and send the changes


### PR DESCRIPTION
This PR implements a modification to the integrated Package Manager that allows one to specify custom commands for adding packages (in a form of strings as you would type them in the julia PkgREPL), allowing people to have more control on the packages they add to a notebook, like:
- Adding un-registered packages
- Adding specific versions of packages
- Adding packages as developed ones, so that one can exploit Revise to track code changes from within the notebook

 I have wanted these features since a long time (together with multiple people based on discourse/zulip and github discussions) but was always scared away by the amount of understanding of Pluto internals both on the front-end and back-end I needed to implement this.
 As I had somehow more time in these past weeks I slowly tried to understand and implement a change to allow the points above while maintaining as much as possible the convenience of the Pluto PackageManager that we all love.

# Disclaimer regarding #2118 
I initially thought about starting from dealing with issue #2118 as a way to start dwelling into the PkgManager internals but at the time it looked like https://github.com/GunnarFarneback/RegistryInstances.jl was not registered yet.
Given that, it was a bit pointless to start an implementation as the API might have changed and Pluto could only depend on registered packages. When I decided to go for this implementation, I checked [this](https://github.com/GunnarFarneback/RegistryInstances.jl/issues/1) open issue where it seemed that registration didn't happen yet. I only discovered 2 days ago that the RegistryInstances had been registered since 2 weeks, but I was already quite advanced on this PR so I decided to skip #2118 for a later step.

# Some implementation details

I initially though about having a pop-up that would allow one to select an eventual version/repo/path with different fields, but I ended up resorting to a single pop-up that accepts a string that is then parsed to extract package details like the PkgREPL does.
I believe this solution would be more user friendly to users as people are more used to add packages from the PkgREPL.

This new PR internally uses the parsing commands from `Pkg.REPLMode` so that most of the work (with some additional Compat caveats due to changes in Pkg between 1.6 and 1.8) is done from Pkg itself.

In order to ease this, I created a new struct (`PkgData`) inside PkgCompat.jl that keeps useful information about a given installed package, like the `pkg_str` that is needed to parse the Pkg command, the finally installed version in the manifest as well as the function that is used to add the package to the environment (can be only `Pkg.add` or `Pkg.develop`) and the `Pkg.PackageSpec` that is actually used to specify the package details.

On the front-end, a new button has been added to the PkgPopup to allow specifying the custom string to be used using an HTML prompt (that defaults to `add $package_name`). The string is then sent to julia for validation/error_checking and the result is sent back to the notebook to assess whether the given string is acceptable or not. The validation step only looks at the string without trying to install the package immediately, so one could still provide a random github repository that does not contain a valid Julia package and the validation would still succeed at this step.
If the validation fails due to some ill-conditioned string, the prompt is re-issued forcing the user to change the string until a valid one is provided.

# Some usage examples

## Custom package commands

To add packages like you used to before, nothing changes. Instead, if you want to provide custom Pkg commands, you can do so using the newly added button:

https://user-images.githubusercontent.com/12846528/184658981-0ee355a2-b169-4344-a64a-143ff6af3fc4.mp4

You noticed that illegal commands re-prompts the user to fix the problem and try to provide some hints on it.
You also see that as soon as a valid custom string was provided, the PkgStatus marker became orange (randomly selected color), and the finally installed version is 0.4.4, satisfying the constraint provided with the `0.4` version specifier in the command.
The marker remains orange for all packages with a custom command string in order to recognize those more easily.

## Developing a package

One can also specify a command to develop a specific path:

https://user-images.githubusercontent.com/12846528/184660732-3932d8df-20fc-4005-a86f-931de1a0207c.mp4

The color for dev'd path is purple to further differentiate with just added packages.

# Conclusions

This PR still needs some modifications, but it is usable from my small testing in the current state so I would really love feedback and tests/comments from other people.

## TODO
- [ ] add Tests
- [ ] find corner-case things to fix
- [ ] Polish the front-end stuff (Here help/feedback from @fonsp, @pankgeorg, @Pangoraw would be helpful)
- [ ] Understand whether `precompile` statements should be added and where (@rikhuijzer)



 