### PR TITLE
:sparkle: Isolated Cell Layout builder :sparkle: 

### DIFF
--- a/frontend/components/Cell.js
+++ b/frontend/components/Cell.js
@@ -253,9 +253,13 @@ export const Cell = ({
                 <button onClick=${on_code_fold} class="foldcode" title="Show/hide code">
                     <span></span>
                 </button>
+                ${
+                output == null || output.body != "" ? html`
                 <button onClick=${on_cell_isolate} class="isolatecell" title="Isolate cell">
                     <span></span>
                 </button>
+                ` : html``
+                }
             </pluto-shoulder>
             <pluto-trafficlight></pluto-trafficlight>
             <button

--- a/frontend/components/Cell.js
+++ b/frontend/components/Cell.js
@@ -100,7 +100,7 @@ const on_jump = (hasBarrier, pluto_actions, cell_id) => () => {
  * }} props
  * */
 export const Cell = ({
-    cell_input: { cell_id, code, code_folded, metadata },
+    cell_input: { cell_id, code, code_folded, isolated, metadata },
     cell_result: { queued, running, runtime, errored, output, logs, published_object_keys, depends_on_disabled_cells, depends_on_skipped_cells },
     cell_dependencies,
     cell_input_local,
@@ -168,6 +168,7 @@ export const Cell = ({
 
     const class_code_differs = code !== (cell_input_local?.code ?? code)
     const class_code_folded = code_folded && cm_forced_focus == null
+    const class_isolated = isolated;
 
     // during the initial page load, force_hide_input === true, so that cell outputs render fast, and codemirrors are loaded after
     let show_input = !force_hide_input && (errored || class_code_differs || !class_code_folded)
@@ -208,6 +209,9 @@ export const Cell = ({
     const on_code_fold = useCallback(() => {
         pluto_actions.fold_remote_cells(pluto_actions.get_selected_cells(cell_id, selected), !code_folded)
     }, [pluto_actions, cell_id, selected, code_folded])
+    const on_cell_isolate = useCallback(() => {
+        pluto_actions.isolate_remote_cells(pluto_actions.get_selected_cells(cell_id, selected), !isolated)
+    }, [pluto_actions, cell_id, selected, code_folded, isolated])
     const on_run = useCallback(() => {
         pluto_actions.set_and_run_multiple(pluto_actions.get_selected_cells(cell_id, selected))
         set_waiting_to_run_smart(true)
@@ -233,6 +237,7 @@ export const Cell = ({
                 selected,
                 code_differs: class_code_differs,
                 code_folded: class_code_folded,
+                isolated: class_isolated,
                 skip_as_script,
                 running_disabled,
                 depends_on_disabled_cells,
@@ -246,6 +251,9 @@ export const Cell = ({
             ${variables.map((name) => html`<span id=${encodeURI(name)} />`)}
             <pluto-shoulder draggable="true" title="Drag to move cell">
                 <button onClick=${on_code_fold} class="foldcode" title="Show/hide code">
+                    <span></span>
+                </button>
+                <button onClick=${on_cell_isolate} class="isolatecell" title="Isolate cell">
                     <span></span>
                 </button>
             </pluto-shoulder>

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -70,6 +70,8 @@ const ProcessStatus = {
     waiting_to_restart: "waiting_to_restart",
 }
 
+const compute_isolated_cells = (notebook) => notebook.cell_order.filter((cell_id) => notebook.cell_inputs[cell_id].isolated)
+
 /**
  * Map of status => Bool. In order of decreasing prioirty.
  */
@@ -120,6 +122,7 @@ const first_true_key = (obj) => {
  *  cell_id: string,
  *  code: string,
  *  code_folded: boolean,
+ *  isolated: boolean,
  *  metadata: CellMetaData,
  * }}
  */
@@ -362,6 +365,7 @@ export class Editor extends Component {
                     cell_id: uuidv4(),
                     code: code,
                     code_folded: false,
+                    isolated: false,
                 }))
 
                 let index
@@ -447,6 +451,7 @@ export class Editor extends Component {
                         cell_id: uuidv4(),
                         code: code,
                         code_folded: false,
+                        isolated: false,
                         metadata: {
                             ...DEFAULT_CELL_METADATA,
                         },
@@ -507,6 +512,7 @@ export class Editor extends Component {
                         cell_id: id,
                         code,
                         code_folded: false,
+                        isolated: false,
                         metadata: { ...DEFAULT_CELL_METADATA },
                     }
                     notebook.cell_order = [...notebook.cell_order.slice(0, index), id, ...notebook.cell_order.slice(index, Infinity)]
@@ -552,6 +558,13 @@ export class Editor extends Component {
                 await update_notebook((notebook) => {
                     for (let cell_id of cell_ids) {
                         notebook.cell_inputs[cell_id].code_folded = newFolded
+                    }
+                })
+            },
+            isolate_remote_cells: async (cell_ids, newIsolated) => {
+                await update_notebook((notebook) => {
+                    for (let cell_id of cell_ids) {
+                        notebook.cell_inputs[cell_id].isolated = newIsolated
                     }
                 })
             },
@@ -1335,6 +1348,7 @@ patch: ${JSON.stringify(
                         <${ExportBanner}
                             notebookfile_url=${this.export_url("notebookfile")}
                             notebookexport_url=${this.export_url("notebookexport")}
+                            isolated_cells=${compute_isolated_cells(this.state.notebook)}
                             open=${export_menu_open}
                             onClose=${() => this.setState({ export_menu_open: false })}
                             start_recording=${() => this.setState({ recording_waiting_to_start: true })}

--- a/frontend/components/ExportBanner.js
+++ b/frontend/components/ExportBanner.js
@@ -26,10 +26,19 @@ const Square = ({ fill }) => html`
     </svg>
 `
 
+// TODO
+const SquigglyAnimation = ({ fill }) => html``
+
 //@ts-ignore
 window.enable_secret_pluto_recording = true
 
-export const ExportBanner = ({ onClose, notebookfile_url, notebookexport_url, start_recording }) => {
+const append_isolated_cells_to_url = (isolated_cells) => {
+  let url = new URL(window.location.href);
+  isolated_cells.forEach(cell_id => url.searchParams.append('isolated_cell_id', cell_id))
+  window.location.href = url
+}
+
+export const ExportBanner = ({ onClose, notebookfile_url, isolated_cells, notebookexport_url, start_recording }) => {
     return html`
         <aside id="export">
             <div id="container">
@@ -46,6 +55,10 @@ export const ExportBanner = ({ onClose, notebookfile_url, notebookexport_url, st
                 <a href="#" class="export_card" onClick=${() => window.print()}>
                     <header><${Square} fill="#619b3d" /> Static PDF</header>
                     <section>A static <b>.pdf</b> file for print or email.</section>
+                </a>
+                <a href="#" class="export_card" onClick=${() => append_isolated_cells_to_url(isolated_cells)}>
+                    <header><${Square} fill="gold" /> Isolated Cells</header>
+                    <section>Open Isolated Cells Layout</section>
                 </a>
                 ${
                     //@ts-ignore

--- a/frontend/components/Notebook.js
+++ b/frontend/components/Notebook.js
@@ -42,7 +42,7 @@ let CellMemo = ({
 }) => {
     const { body, last_run_timestamp, mime, persist_js_state, rootassignee } = cell_result?.output || {}
     const { queued, running, runtime, errored, depends_on_disabled_cells, logs, depends_on_skipped_cells } = cell_result || {}
-    const { cell_id, code, code_folded, metadata } = cell_input || {}
+    const { cell_id, code, code_folded, isolated, metadata } = cell_input || {}
     return useMemo(() => {
         return html`
             <${Cell}
@@ -79,6 +79,7 @@ let CellMemo = ({
         logs,
         code,
         code_folded,
+        isolated,
         cell_input_local,
         notebook_id,
         cell_dependencies,

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -92,7 +92,7 @@ body:not(.disable_ui) {
 /* CAN WE HAVE CONTAINER QUERIES PLESSSSS */
 @media screen and (min-width: calc(700px + 25px + 6px)) and (max-width: calc(700px + 25px + 6px + 500px)) {
     body:not(.disable_ui) pluto-editor.fullscreen main {
-        margin-left: 0px;
+        margin-left: 25px;
         align-self: flex-start;
     }
 }
@@ -1261,15 +1261,22 @@ pluto-shoulder {
     border-radius: var(--border-radius) 0px 0px var(--border-radius);
     cursor: move;
     display: flex;
-    flex-direction: row;
-    justify-content: flex-end;
-    align-items: flex-start;
     /* Add an invisible border around the shoulder, to make it easier to click on. (The area between two cells is divided in two, each half belongs to the closest pluto-cell.) */
     top: calc(0px - var(--invisible-border));
     bottom: calc(0px - var(--invisible-border));
     border: var(--invisible-border) solid rgba(0, 0, 0, 0);
     border-right: none;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: flex-end;
 }
+
+/* TODO: Make this variable to output being of a given size */
+pluto-cell.code_folded > pluto-shoulder {
+    flex-direction: row-reverse;
+    column-gap: 0px;
+}
+
 pluto-editor.fullscreen pluto-shoulder {
     --shoulder-width: 2000px;
 }
@@ -1283,7 +1290,7 @@ pluto-shoulder > button {
     flex: 0 0 auto;
     position: sticky;
     top: 0;
-    padding: 4px 5px 4px 10px;
+    padding: 4px 5px 4px 0px;
 }
 
 pluto-cell:focus-within > pluto-shoulder > button {
@@ -1291,17 +1298,31 @@ pluto-cell:focus-within > pluto-shoulder > button {
     padding-right: 9px;
 }
 
+pluto-cell.code_folded:focus-within > pluto-shoulder > button.isolatecell {
+    padding-right: 4px;
+}
+
 /* pluto-cell.code_folded.inline-output > pluto-shoulder > button {
     margin-top: 3px;
 } */
 
-pluto-shoulder > button > span::after {
+pluto-shoulder > button.foldcode > span::after {
     background-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/eye-outline.svg");
     filter: var(--image-filters);
 }
 
-pluto-cell.code_folded > pluto-shoulder > button > span::after {
+pluto-cell.code_folded > pluto-shoulder > button.foldcode > span::after {
     background-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/eye-off-outline.svg");
+    filter: var(--image-filters);
+}
+
+pluto-shoulder > button.isolatecell > span::after {
+    background-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/ellipse-outline.svg");
+    filter: var(--image-filters);
+}
+
+pluto-cell.isolated > pluto-shoulder > button.isolatecell > span::after {
+    background-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/checkmark-circle-outline.svg");
     filter: var(--image-filters);
 }
 

--- a/src/notebook/Cell.jl
+++ b/src/notebook/Cell.jl
@@ -40,6 +40,7 @@ Base.@kwdef mutable struct Cell
 
     code::String=""
     code_folded::Bool=false
+    isolated::Bool=false
     
     output::CellOutput=CellOutput()
     queued::Bool=false
@@ -67,10 +68,11 @@ Cell(code) = Cell(uuid1(), code)
 cell_id(cell::Cell) = cell.cell_id
 
 function Base.convert(::Type{Cell}, cell::Dict)
-	Cell(
+    Cell(
         cell_id=UUID(cell["cell_id"]),
         code=cell["code"],
         code_folded=cell["code_folded"],
+        isolated=cell["isolated"],
         metadata=cell["metadata"],
     )
 end

--- a/src/webserver/Dynamic.jl
+++ b/src/webserver/Dynamic.jl
@@ -110,6 +110,7 @@ function notebook_to_js(notebook::Notebook)
                 "cell_id" => cell.cell_id,
                 "code" => cell.code,
                 "code_folded" => cell.code_folded,
+                "isolated" => cell.isolated,
                 "metadata" => cell.metadata,
             )
         for (id, cell) in notebook.cells_dict),

--- a/src/webserver/Firebasey.jl
+++ b/src/webserver/Firebasey.jl
@@ -638,6 +638,9 @@ function direct_diff(old::Cell, new::Cell)
 	if old.folded ≠ new.folded
 		push!(changes, ReplacePatch([:folded], new.folded))
 	end
+	if old.isolated ≠ new.isolated
+		push!(changes, ReplacePatch([:isolated], new.isolated))
+	end
 	changes
 end
   ╠═╡ =#


### PR DESCRIPTION
This PR adds a small checkbox button on the side of every cell that contains an output. When selected, the cell will be flagged as `isolated`. All of the cells marked as such will be layed out in an Isolated Cell Layout when a button in the export menu is clicked.

![isolated](https://user-images.githubusercontent.com/23220288/186273917-19eae54d-6b28-404a-a551-8503eaa542ad.gif)

Selections are saved much like code folding, but for means of practicality, I added an identifier to the right side of the UUID, which I fell like is a big no-no.