### PR TITLE
Improve ARM support for `roughly_the_number_of_physical_cpu_cores`

### DIFF
--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -159,12 +159,20 @@ const HISTORY_FILE_DEFAULT = "no"
 
 function roughly_the_number_of_physical_cpu_cores()
     # https://gist.github.com/fonsp/738fe244719cae820245aa479e7b4a8d
-    if Sys.CPU_THREADS == 1
+    threads = Sys.CPU_THREADS
+    num_threads_is_maybe_doubled_for_marketing = Sys.ARCH === :x86_64
+    
+    if threads == 1
         1
-    elseif Sys.CPU_THREADS == 2 || Sys.CPU_THREADS == 3
+    elseif threads == 2 || threads == 3
         2
+    elseif num_threads_is_maybe_doubled_for_marketing
+        # This includes:
+        # - intel hyperthreading
+        # - Apple ARM efficiency cores included in the count (when running the x86 executable)
+        threads ÷ 2
     else
-        Sys.CPU_THREADS ÷ 2
+        threads
     end
 end
 


### PR DESCRIPTION
We did `Sys.CPU_THREADS ÷ 2` for the default number of threads because of intel hyperthreading, which doubles the CPU count more for marketing than for performance. 

This change will just use `Sys.CPU_THREADS` when you are _not_ using x86.


Thread counts on Apple M1:

```
➜  PlutoSliderServer.jl git:(update_http_1.0) julia18ARM
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.8.0 (2022-08-17)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

julia> Sys.ARCH
:aarch64

julia> Sys.CPU_THREADS
4

julia> Sys.cpu_info() |> length
8

➜  PlutoSliderServer.jl git:(update_http_1.0) julia18x86
               _
   _       _ _(_)_     |  Documentation: https://docs.julialang.org
  (_)     | (_) (_)    |
   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 1.8.0 (2022-08-17)
 _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
|__/                   |

julia> Sys.ARCH
:x86_64

julia> Sys.CPU_THREADS
8

julia> Sys.cpu_info() |> length
8

```