### PR TITLE
Plots.jl GR respect fmt setting for auto choosing between SVG PNG

### DIFF
--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -1546,7 +1546,17 @@ const integrations = Integration[
                 0
             end
             const max_plot_size = 8000
-            pluto_showable(::MIME"image/svg+xml", p::Plots.Plot{Plots.GRBackend}) = approx_size(p) <= max_plot_size
+            function pluto_showable(::MIME"image/svg+xml", p::Plots.Plot{Plots.GRBackend})
+                format = try
+                    p.attr[:html_output_format]
+                catch
+                    :auto
+                end
+                
+                format === :svg || (
+                    format === :auto && approx_size(p) <= max_plot_size
+                )
+            end
             pluto_showable(::MIME"text/html", p::Plots.Plot{Plots.GRBackend}) = false
         end,
     ),


### PR DESCRIPTION
Tweak on #1090, we now respect the `:fmt` keyword argument in Plots.jl: `plot(data; fmt=:svg)` will always show as SVG, `plot(data; fmt=:png)` will always show as PNG

Demo:

https://fonsp-stuff.netlify.app/plots%20gr%20auto%20points%20respect%20fmt%20setting