### PR TITLE
`updated_topology`: maintain identity when there are no changes

### DIFF
--- a/src/analysis/TopologyUpdate.jl
+++ b/src/analysis/TopologyUpdate.jl
@@ -6,7 +6,7 @@ function updated_topology(old_topology::NotebookTopology, notebook::Notebook, ce
 	
 	updated_codes = Dict{Cell,ExprAnalysisCache}()
 	updated_nodes = Dict{Cell,ReactiveNode}()
-	unresolved_cells = copy(old_topology.unresolved_cells.c)
+	
 	for cell in cells
 		old_code = old_topology.codes[cell]
 		if old_code.code !== cell.code
@@ -20,17 +20,9 @@ function updated_topology(old_topology::NotebookTopology, notebook::Notebook, ce
 			# reset computer code
 			updated_codes[cell] = ExprAnalysisCache(old_code; forced_expr_id=nothing, function_wrapped=false)
 		end
-
-		new_reactive_node = get(updated_nodes, cell, old_topology.nodes[cell])
-		if !isempty(new_reactive_node.macrocalls)
-			# The unresolved cells are the cells for wich we cannot create
-			# a ReactiveNode yet, because they contains macrocalls.
-			push!(unresolved_cells, cell) 
-		else
-			pop!(unresolved_cells, cell, nothing)
-		end
 	end
-
+	
+	
 	old_cells = all_cells(old_topology)
 	removed_cells = setdiff(old_cells, notebook.cells)
 	if isempty(removed_cells)
@@ -38,9 +30,28 @@ function updated_topology(old_topology::NotebookTopology, notebook::Notebook, ce
 		new_codes = merge(old_topology.codes, updated_codes)
 		new_nodes = merge(old_topology.nodes, updated_nodes)
 	else
-		setdiff!(unresolved_cells, removed_cells)
 		new_codes = merge(setdiffkeys(old_topology.codes, removed_cells), updated_codes)
 		new_nodes = merge(setdiffkeys(old_topology.nodes, removed_cells), updated_nodes)
+	end
+	
+	unresolved_cells = if isempty(updated_nodes) && isempty(removed_cells)
+		old_topology.unresolved_cells
+	else
+		# The new set of unresolved cells is...
+		new_unresolved_set = setdiff!(
+			union!(
+				Set{Cell}(),
+				# all cells that were unresolved before...
+				old_topology.unresolved_cells,
+				# ...plus all cells that changed...
+				keys(updated_nodes),
+			),
+			# ...minus cells that were removed...
+			removed_cells, 
+			# ...minus cells that changed, which do not use any macros.
+			(c for (c,n) in updated_nodes if isempty(n.macrocalls))
+		)
+		ImmutableSet{Cell}(new_unresolved_set; skip_copy=true)
 	end
 
 	cell_order = if old_cells == notebook.cells
@@ -48,11 +59,11 @@ function updated_topology(old_topology::NotebookTopology, notebook::Notebook, ce
 	else
 		ImmutableVector(notebook.cells)
 	end
-
+	
 	NotebookTopology(;
 		nodes=new_nodes,
 		codes=new_codes,
-		unresolved_cells=ImmutableSet(unresolved_cells; skip_copy=true), 
+		unresolved_cells, 
 		cell_order,
 	)
 end

--- a/test/Analysis.jl
+++ b/test/Analysis.jl
@@ -1,78 +1,122 @@
 using Test
-import Pluto: Notebook, ServerSession, ClientSession, Cell, updated_topology, static_resolve_topology, is_just_text
+import Pluto: Notebook, Cell, updated_topology, static_resolve_topology, is_just_text, NotebookTopology
 
 @testset "Analysis" begin
-    notebook = Notebook([
-        Cell(""),
-        Cell("md\"a\""),
-        Cell("html\"a\""),
-        Cell("md\"a \$b\$\""),
-        Cell("md\"a ``b``\""),
-        Cell("""
-        let
-            x = md"a"
-            md"r \$x"
+    @testset "is_just_text" begin
+        notebook = Notebook([
+            Cell(""),
+            Cell("md\"a\""),
+            Cell("html\"a\""),
+            Cell("md\"a \$b\$\""),
+            Cell("md\"a ``b``\""),
+            Cell("""
+            let
+                x = md"a"
+                md"r \$x"
+            end
+            """),
+            Cell("html\"a 7 \$b\""),
+
+            Cell("md\"a 8 \$b\""),
+            Cell("@a md\"asdf 9\""),
+            Cell("x()"),
+            Cell("x() = y()"),
+            Cell("12 + 12"),
+            Cell("import Dates"),
+            Cell("import Dates"),
+            Cell("while false end"),
+            Cell("for i in [16]; end"),
+            Cell("[i for i in [17]]"),
+            Cell("module x18 end"),
+            Cell("""
+            module x19
+                exit()
+            end
+            """),
+            Cell("""quote end"""),
+            Cell("""quote x = 21 end"""),
+            Cell("""quote \$(x = 22) end"""),
+            Cell("""asdf"23" """),
+            Cell("""@asdf("24") """),
+            Cell("""@x"""),
+            Cell("""@y z 26"""),
+            Cell("""f(g"27")"""),
+        ])
+
+        old = notebook.topology
+        new = notebook.topology = updated_topology(old, notebook, notebook.cells) |> static_resolve_topology
+
+        @testset "Only-text detection" begin
+            @test is_just_text(new, notebook.cells[1])
+            @test is_just_text(new, notebook.cells[2])
+            @test is_just_text(new, notebook.cells[3])
+            @test is_just_text(new, notebook.cells[4])
+            @test is_just_text(new, notebook.cells[5])
+            @test is_just_text(new, notebook.cells[6])
+            @test is_just_text(new, notebook.cells[7])
+
+            @test !is_just_text(new, notebook.cells[8])
+            @test !is_just_text(new, notebook.cells[9])
+            @test !is_just_text(new, notebook.cells[10])
+            @test !is_just_text(new, notebook.cells[11])
+            @test !is_just_text(new, notebook.cells[12])
+            @test !is_just_text(new, notebook.cells[13])
+            @test !is_just_text(new, notebook.cells[14])
+            @test !is_just_text(new, notebook.cells[15])
+            @test !is_just_text(new, notebook.cells[16])
+            @test !is_just_text(new, notebook.cells[17])
+            @test !is_just_text(new, notebook.cells[18])
+            @test !is_just_text(new, notebook.cells[19])
+            @test !is_just_text(new, notebook.cells[20])
+            @test !is_just_text(new, notebook.cells[21])
+            @test !is_just_text(new, notebook.cells[22])
+            @test !is_just_text(new, notebook.cells[23])
+            @test !is_just_text(new, notebook.cells[24])
+            @test !is_just_text(new, notebook.cells[25])
+            @test !is_just_text(new, notebook.cells[26])
+            @test !is_just_text(new, notebook.cells[27])
         end
-        """),
-        Cell("html\"a 7 \$b\""),
+    end
 
-        Cell("md\"a 8 \$b\""),
-        Cell("@a md\"asdf 9\""),
-        Cell("x()"),
-        Cell("x() = y()"),
-        Cell("12 + 12"),
-        Cell("import Dates"),
-        Cell("import Dates"),
-        Cell("while false end"),
-        Cell("for i in [16]; end"),
-        Cell("[i for i in [17]]"),
-        Cell("module x18 end"),
-        Cell("""
-        module x19
-            exit()
-        end
-        """),
-        Cell("""quote end"""),
-        Cell("""quote x = 21 end"""),
-        Cell("""quote \$(x = 22) end"""),
-        Cell("""asdf"23" """),
-        Cell("""@asdf("24") """),
-        Cell("""@x"""),
-        Cell("""@y z 26"""),
-        Cell("""f(g"27")"""),
-    ])
-
-    old = notebook.topology
-    new = notebook.topology = updated_topology(old, notebook, notebook.cells) |> static_resolve_topology
-
-    @testset "Only-text detection" begin
-        @test is_just_text(new, notebook.cells[1])
-        @test is_just_text(new, notebook.cells[2])
-        @test is_just_text(new, notebook.cells[3])
-        @test is_just_text(new, notebook.cells[4])
-        @test is_just_text(new, notebook.cells[5])
-        @test is_just_text(new, notebook.cells[6])
-        @test is_just_text(new, notebook.cells[7])
-
-        @test !is_just_text(new, notebook.cells[8])
-        @test !is_just_text(new, notebook.cells[9])
-        @test !is_just_text(new, notebook.cells[10])
-        @test !is_just_text(new, notebook.cells[11])
-        @test !is_just_text(new, notebook.cells[12])
-        @test !is_just_text(new, notebook.cells[13])
-        @test !is_just_text(new, notebook.cells[14])
-        @test !is_just_text(new, notebook.cells[15])
-        @test !is_just_text(new, notebook.cells[16])
-        @test !is_just_text(new, notebook.cells[17])
-        @test !is_just_text(new, notebook.cells[18])
-        @test !is_just_text(new, notebook.cells[19])
-        @test !is_just_text(new, notebook.cells[20])
-        @test !is_just_text(new, notebook.cells[21])
-        @test !is_just_text(new, notebook.cells[22])
-        @test !is_just_text(new, notebook.cells[23])
-        @test !is_just_text(new, notebook.cells[24])
-        @test !is_just_text(new, notebook.cells[25])
-        @test !is_just_text(new, notebook.cells[26])
-        @test !is_just_text(new, notebook.cells[27])
+    @testset "updated_topology identity" begin
+        notebook = Notebook([
+            Cell("x = 1")
+            Cell("function f(x)
+                x + 1
+            end")
+            Cell("a = x - 123")
+            Cell("")
+            Cell("")
+            Cell("")
+        ])
+        
+        empty_top = notebook.topology
+        top = updated_topology(empty_top, notebook, notebook.cells)
+        # updated_topology should preserve the identity of the topology if nothing changed. This means that we can cache the result of other functions in our code!
+        @test top === updated_topology(top, notebook, notebook.cells)
+        @test top === updated_topology(top, notebook, Cell[])
+        @test top === static_resolve_topology(top)
+        
+        # for n in fieldnames(NotebookTopology)
+        #     @test getfield(top, n) === getfield(top2a, n)
+        # end
+        
+        setcode!(notebook.cells[1], "x = 999")
+        top_2 = updated_topology(top, notebook, notebook.cells[1:1])
+        @test top_2 !== top
+        
+        
+        setcode!(notebook.cells[4], "@asdf 1 + 2")
+        top_3 = updated_topology(top_2, notebook, notebook.cells[4:4])
+        @test top_3 !== top_2
+        @test top_3 !== top
+        
+        @test top_3.unresolved_cells |> only === notebook.cells[4]
+        
+        @info "aaa"
+        @test top_3 === updated_topology(top_3, notebook, notebook.cells)
+        @info "bbb"
+        @test top_3 === updated_topology(top_3, notebook, Cell[])
+        # @test top_3 === static_resolve_topology(top_3)
     end
 end

--- a/test/cell_disabling.jl
+++ b/test/cell_disabling.jl
@@ -31,7 +31,7 @@ using Pluto: update_run!, ServerSession, ClientSession, Cell, Notebook
 
     # disable first cell
     notebook.cells[1].metadata["disabled"] = true
-    update_run!(🍭, notebook, notebook.cells)
+    update_run!(🍭, notebook, notebook.cells[1])
     should_be_disabled = [1, 3, 5]
     @test get_disabled_cells(notebook) == should_be_disabled
     @test notebook.cells[1].metadata["disabled"] == true


### PR DESCRIPTION
I noticed that `unresolved_cells` was always copied, creating a `===`-new object, which broke identity (see the new tests). I added tests to avoid this in the future.