### PR TITLE
Include set of disabled cells in `NotebookTopology`

### DIFF
--- a/src/analysis/Topology.jl
+++ b/src/analysis/Topology.jl
@@ -32,6 +32,7 @@ Base.@kwdef struct NotebookTopology
     cell_order::ImmutableVector{Cell}=ImmutableVector{Cell}()
 
     unresolved_cells::ImmutableSet{Cell} = ImmutableSet{Cell}()
+    disabled_cells::ImmutableSet{Cell} = ImmutableSet{Cell}()
 end
 
 # BIG TODO HERE: CELL ORDER
@@ -48,6 +49,7 @@ function set_unresolved(topology::NotebookTopology, unresolved_cells::Vector{Cel
         nodes=topology.nodes, 
         codes=merge(topology.codes, codes), 
         unresolved_cells=union(topology.unresolved_cells, unresolved_cells),
-        cell_order = topology.cell_order,
+        cell_order=topology.cell_order,
+        disabled_cells=topology.disabled_cells,
     )
 end

--- a/src/analysis/TopologyUpdate.jl
+++ b/src/analysis/TopologyUpdate.jl
@@ -68,7 +68,7 @@ function updated_topology(old_topology::NotebookTopology, notebook::Notebook, ce
 		ImmutableSet(new_unresolved_set; skip_copy=true)
 	end
 
-	disabled = if new_disabled_set == old_topology.disabled_cells
+	disabled_cells = if new_disabled_set == old_topology.disabled_cells
 		old_topology.disabled_cells
 	else
 		ImmutableSet(new_disabled_set; skip_copy=true)

--- a/src/analysis/TopologyUpdate.jl
+++ b/src/analysis/TopologyUpdate.jl
@@ -46,26 +46,45 @@ function updated_topology(old_topology::NotebookTopology, notebook::Notebook, ce
 				!isempty(new_nodes[c].macrocalls)
 			end,
 		),
-		# ...minus cells that were removed
+		# ...minus cells that were removed.
 		removed_cells,
 	)
-		
+
+	new_disabled_set = setdiff!(
+		union!(
+			Set{Cell}(),
+			# all cells that were disabled before...
+			old_topology.disabled_cells,
+			# ...plus all cells that changed...
+			cells,
+		),
+		# ...minus cells that changed and are not disabled.
+		Iterators.filter(!is_disabled, cells),
+	)
+
 	unresolved_cells = if new_unresolved_set == old_topology.unresolved_cells
 		old_topology.unresolved_cells
 	else
 		ImmutableSet(new_unresolved_set; skip_copy=true)
 	end
 
+	disabled = if new_disabled_set == old_topology.disabled_cells
+		old_topology.disabled_cells
+	else
+		ImmutableSet(new_disabled_set; skip_copy=true)
+	end
+
 	cell_order = if old_cells == notebook.cells
 		old_topology.cell_order
 	else
-		ImmutableVector(notebook.cells)
+		ImmutableVector(notebook.cells) # makes a copy
 	end
 	
 	NotebookTopology(;
 		nodes=new_nodes,
 		codes=new_codes,
 		unresolved_cells, 
+        disabled_cells,
 		cell_order,
 	)
 end

--- a/src/evaluation/MacroAnalysis.jl
+++ b/src/evaluation/MacroAnalysis.jl
@@ -26,6 +26,7 @@ function with_new_soft_definitions(topology::NotebookTopology, cell::Cell, soft_
 		nodes=merge(topology.nodes, Dict(cell => new_node)), 
 		unresolved_cells=topology.unresolved_cells,
 		cell_order=topology.cell_order,
+        disabled_cells=topology.disabled_cells,
 	)
 end
 
@@ -170,11 +171,12 @@ function resolve_topology(
 		ImmutableSet(still_unresolved_nodes; skip_copy=true)
 	end
 
-	NotebookTopology(
+	NotebookTopology(;
 		nodes=all_nodes, 
 		codes=all_codes, 
 		unresolved_cells=new_unresolved_cells,
 		cell_order=unresolved_topology.cell_order,
+        disabled_cells=unresolved_topology.disabled_cells,
 	)
 end
 
@@ -199,5 +201,6 @@ function static_resolve_topology(topology::NotebookTopology)
 		codes=topology.codes, 
 		unresolved_cells=topology.unresolved_cells,
 		cell_order=topology.cell_order,
+        disabled_cells=topology.disabled_cells,
 	)
 end

--- a/src/evaluation/Run.jl
+++ b/src/evaluation/Run.jl
@@ -76,6 +76,7 @@ function run_reactive_core!(
         ),
         unresolved_cells = new_topology.unresolved_cells,
         cell_order = new_topology.cell_order,
+        disabled_cells=new_topology.disabled_cells,
     )
 
     # save the old topological order - we'll delete variables assigned from its
@@ -375,6 +376,7 @@ function update_save_run!(
 			codes=setdiffkeys(old.codes, to_remove),
 			unresolved_cells=setdiff(old.unresolved_cells, to_remove),
 			cell_order=old.cell_order,
+			disabled_cells=old.disabled_cells,
 		)
 		
 		# and don't run them

--- a/src/evaluation/Run.jl
+++ b/src/evaluation/Run.jl
@@ -375,7 +375,7 @@ function update_save_run!(
 			codes=setdiffkeys(old.codes, to_remove),
 			unresolved_cells=setdiff(old.unresolved_cells, to_remove),
 			cell_order=old.cell_order,
-			disabled_cells=old.disabled_cells,
+			disabled_cells=setdiff(old.disabled_cells, to_remove),
 		)
 		
 		# and don't run them

--- a/src/evaluation/Run.jl
+++ b/src/evaluation/Run.jl
@@ -93,8 +93,7 @@ function run_reactive_core!(
     to_run_raw = setdiff(union(new_runnable, old_runnable), keys(new_order.errable))::Vector{Cell} # TODO: think if old error cell order matters
 
     # find (indirectly) deactivated cells and update their status
-    disabled_cells = filter(is_disabled, notebook.cells)
-    indirectly_deactivated = collect(topological_order(new_topology, disabled_cells))
+    indirectly_deactivated = collect(topological_order(new_topology, collect(new_topology.disabled_cells)))
     for cell in indirectly_deactivated
         cell.running = false
         cell.queued = false


### PR DESCRIPTION
For future use, including #2268 . This PR already uses it in Run.jl (see changed file), which used to be a race condition maybe?

This makes sense because: which cells are disabled affects which cells will run, which should be fully captured by the `NotebookTopology`. 