### PR TITLE
frontend bundler: Replace search param with hash in filename

### DIFF
--- a/src/webserver/Static.jl
+++ b/src/webserver/Static.jl
@@ -369,7 +369,7 @@ function http_router_for(session::ServerSession)
     
     function serve_asset(request::HTTP.Request)
         uri = HTTP.URI(request.target)
-        filepath = project_relative_path(frontend_directory(), relpath(uri.path, "/"))
+        filepath = project_relative_path(frontend_directory(), relpath(HTTP.unescapeuri(uri.path), "/"))
         asset_response(filepath; cacheable=should_cache(filepath))
     end
     HTTP.register!(router, "GET", "/**", serve_asset)


### PR DESCRIPTION
This replace the weird URL encoded filename in https://github.com/fonsp/Pluto.jl/tree/fec115f5d55d427b34c1b6dd5ea43fbf6cbc449f/frontend-dist
with a small hash which should not contain weird characters. This way we can still URI decode component in the path.

This should fix https://github.com/JuliaPluto/PlutoSliderServer.jl/issues/88
