### PR TITLE
🍔 Logs: Vertical layout

### DIFF
--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -585,6 +585,7 @@ export const CellInput = ({
                     highlighted_line_compartment,
                     global_definitions_compartment,
                     editable_compartment,
+                    highlightLinePlugin(),
 
                     // This is waaaay in front of the keys it is supposed to override,
                     // Which is necessary because it needs to run before *any* keymap,

--- a/frontend/components/CellInput/highlight_line.js
+++ b/frontend/components/CellInput/highlight_line.js
@@ -9,7 +9,7 @@ const highlighted_line = Decoration.line({
  */
 function create_line_decorations(view) {
     let line_number = view.state.facet(HighlightLineFacet)
-    if (line_number == null || line_number == undefined || line_number > view.state.doc.lines) {
+    if (line_number == null || line_number == undefined || line_number < 0 || line_number > view.state.doc.lines) {
         return Decoration.set([])
     }
 

--- a/frontend/components/CellInput/highlight_line.js
+++ b/frontend/components/CellInput/highlight_line.js
@@ -36,6 +36,7 @@ export const highlightLinePlugin = () =>
              * @param {EditorView} view
              */
             constructor(view) {
+                this.decorations = Decoration.set([])
                 this.updateDecos(view)
             }
 

--- a/frontend/components/Logs.js
+++ b/frontend/components/Logs.js
@@ -81,13 +81,6 @@ const Progress = ({ progress }) => {
 const mimepair_output = (pair) => html`<${SimpleOutputBody} cell_id=${"adsf"} mime=${pair[1]} body=${pair[0]} persist_js_state=${false} />`
 
 const Dot = ({ set_cm_highlighted_line, msg, kwargs, y, level, mykey }) => {
-    const node_ref = useRef(/** @type{HTMLElement?} */ (null))
-    // const label_ref = useRef(null)
-    // useEffect(() => {
-    //     label_ref.current.innerHTML = body
-    // }, [body])
-    const [inspecting, set_inspecting] = useState(false)
-
     const is_progress = is_progress_log({ level, kwargs })
     const is_stdout = level === "LogLevel(-555)"
     let progress = null
@@ -107,33 +100,14 @@ const Dot = ({ set_cm_highlighted_line, msg, kwargs, y, level, mykey }) => {
         level = "Stdout"
     }
 
-    useLayoutEffect(() => {
-        if (inspecting) {
-            const f = (e) => {
-                if (!e.target.closest || e.target.closest("pluto-log-dot-positioner") !== node_ref.current) {
-                    set_inspecting(false)
-                    set_cm_highlighted_line(null)
-                }
-            }
-            window.addEventListener("blur", f)
-
-            return () => {
-                window.removeEventListener("blur", f)
-            }
-        }
-    }, [inspecting])
-
     return html`<pluto-log-dot-positioner
         data-line=${y + 1}
-        ref=${node_ref}
-        class=${cl({ inspecting, [level]: true })}
-        onClick=${() => {
-            set_inspecting(true)
-            console.log("highlighting line", y)
-            is_progress || set_cm_highlighted_line(y + 1)
-        }}
+        class=${cl({ [level]: true })}
         onMouseenter=${() => is_progress || set_cm_highlighted_line(y + 1)}
-        onMouseleave=${() => set_cm_highlighted_line(null)}
+        onMouseleave=${() => {
+            console.log("leaving!")
+            set_cm_highlighted_line(null)
+        }}
     >
         <pluto-log-icon></pluto-log-icon>
         ${is_stdout

--- a/frontend/components/Logs.js
+++ b/frontend/components/Logs.js
@@ -5,7 +5,6 @@ import { SimpleOutputBody } from "./TreeView.js"
 import { help_circle_icon, open_pluto_popup } from "./Popup.js"
 import AnsiUp from "../imports/AnsiUp.js"
 
-// const GRID_WIDTH = 10
 const LOGS_VISIBLE_START = 60
 const LOGS_VISIBLE_END = 20
 const PROGRESS_LOG_LEVEL = "LogLevel(-1)"
@@ -15,9 +14,6 @@ const is_progress_log = (log) => {
 }
 
 export const Logs = ({ logs, line_heights, set_cm_highlighted_line }) => {
-    const container = useRef(/** @type {HTMLElement?} */ (null))
-    // const [from, setFrom] = useState(0)
-    // const [to, setTo] = useState(Math.round(1000 / GRID_WIDTH))
     const progress_logs = logs.filter(is_progress_log)
     const latest_progress_logs = progress_logs.reduce((progress_logs, log) => ({ ...progress_logs, [log.id]: log }), {})
     const [_, grouped_progress_and_logs] = logs.reduce(
@@ -43,13 +39,12 @@ export const Logs = ({ logs, line_heights, set_cm_highlighted_line }) => {
         level=${log.level}
         msg=${log.msg}
         kwargs=${log.kwargs}
-        mykey=${`log${i}`}
         key=${i}
         y=${is_hidden_input ? 0 : log.line - 1}
     /> `
 
     return html`
-        <pluto-logs-container ref=${container}>
+        <pluto-logs-container>
             <pluto-logs>
                 ${grouped_progress_and_logs.length <= LOGS_VISIBLE_END + LOGS_VISIBLE_START
                     ? grouped_progress_and_logs.map(dot)
@@ -80,7 +75,7 @@ const Progress = ({ progress }) => {
 
 const mimepair_output = (pair) => html`<${SimpleOutputBody} cell_id=${"adsf"} mime=${pair[1]} body=${pair[0]} persist_js_state=${false} />`
 
-const Dot = ({ set_cm_highlighted_line, msg, kwargs, y, level, mykey }) => {
+const Dot = ({ set_cm_highlighted_line, msg, kwargs, y, level }) => {
     const is_progress = is_progress_log({ level, kwargs })
     const is_stdout = level === "LogLevel(-555)"
     let progress = null
@@ -101,7 +96,6 @@ const Dot = ({ set_cm_highlighted_line, msg, kwargs, y, level, mykey }) => {
     }
 
     return html`<pluto-log-dot-positioner
-        data-line=${y + 1}
         class=${cl({ [level]: true })}
         onMouseenter=${() => is_progress || set_cm_highlighted_line(y + 1)}
         onMouseleave=${() => {

--- a/frontend/components/Logs.js
+++ b/frontend/components/Logs.js
@@ -119,12 +119,6 @@ const Dot = ({ set_cm_highlighted_line, show, msg, kwargs, x, y, level }) => {
     }
 
     useLayoutEffect(() => {
-        if (!node_ref.current) return
-        node_ref.current.style.gridColumn = `${x + 1}`
-        node_ref.current.style.gridRow = `${y + 1}`
-    }, [node_ref.current, x, y])
-
-    useLayoutEffect(() => {
         if (inspecting && show) {
             const f = (e) => {
                 if (!e.target.closest || e.target.closest("pluto-log-dot-positioner") !== node_ref.current) {
@@ -145,7 +139,7 @@ const Dot = ({ set_cm_highlighted_line, show, msg, kwargs, x, y, level }) => {
     return show
         ? html`<pluto-log-dot-positioner
               ref=${node_ref}
-              class=${cl({ inspecting })}
+              class=${cl({ inspecting, [level]: true })}
               onClick=${() => {
                   set_inspecting(true)
                   is_progress || set_cm_highlighted_line(y + 1)
@@ -153,6 +147,7 @@ const Dot = ({ set_cm_highlighted_line, show, msg, kwargs, x, y, level }) => {
               onMouseenter=${() => is_progress || set_cm_highlighted_line(y + 1)}
               onMouseleave=${() => set_cm_highlighted_line(null)}
           >
+              <pluto-log-icon></pluto-log-icon>
               ${is_stdout
                   ? html`<${MoreInfo}
                         body=${html`This text was written to the ${" "}<a href="https://en.wikipedia.org/wiki/Standard_streams" target="_blank"

--- a/frontend/components/Logs.js
+++ b/frontend/components/Logs.js
@@ -34,11 +34,6 @@ export const Logs = ({ logs, line_heights, set_cm_highlighted_line }) => {
     )
     const logsWidth = grouped_progress_and_logs.length * GRID_WIDTH
 
-    const logsStyle = useMemo(
-        () => `grid-template-rows: ${line_heights.map((y) => y + "px").join(" ")} repeat(auto-fill, 15px); width: ${logsWidth}px;`,
-        [logsWidth, line_heights]
-    )
-
     useEffect(() => {
         const elem = container.current
         if (!elem) return
@@ -63,7 +58,7 @@ export const Logs = ({ logs, line_heights, set_cm_highlighted_line }) => {
 
     return html`
         <pluto-logs-container ref=${container}>
-            <pluto-logs style="${logsStyle}">
+            <pluto-logs>
                 ${grouped_progress_and_logs.map((log, i) => {
                     return html`<${Dot}
                         set_cm_highlighted_line=${set_cm_highlighted_line}
@@ -158,34 +153,30 @@ const Dot = ({ set_cm_highlighted_line, show, msg, kwargs, x, y, level }) => {
               onMouseenter=${() => is_progress || set_cm_highlighted_line(y + 1)}
               onMouseleave=${() => set_cm_highlighted_line(null)}
           >
-              <pluto-log-dot-sizer>
-                  ${is_stdout
+              ${is_stdout
+                  ? html`<${MoreInfo}
+                        body=${html`This text was written to the ${" "}<a href="https://en.wikipedia.org/wiki/Standard_streams" target="_blank"
+                                >terminal stream</a
+                            >${" "}while running the cell. It is not the${" "}<em>output value</em>${" "}of this cell.`}
+                    />`
+                  : null}
+              <pluto-log-dot class=${level}
+                  >${is_progress
+                      ? html`<${Progress} progress=${progress} />`
+                      : is_stdout
                       ? html`<${MoreInfo}
-                            body=${html`This text was written to the ${" "}<a href="https://en.wikipedia.org/wiki/Standard_streams" target="_blank"
-                                    >terminal stream</a
-                                >${" "}while running the cell. It is not the${" "}<em>output value</em>${" "}of this cell.`}
-                        />`
-                      : null}
-                  <pluto-log-dot class=${level}
-                      >${is_progress
-                          ? html`<${Progress} progress=${progress} />`
-                          : is_stdout
-                          ? html`<${MoreInfo}
-                                    body=${html`${"This text was written to the "}
-                                        <a href="https://en.wikipedia.org/wiki/Standard_streams" target="_blank">terminal stream</a
-                                        >${" while running the cell. "}<span style="opacity: .5"
-                                            >${"(It is not the "}<em>return value</em>${" of the cell.)"}</span
-                                        >`}
-                                />
-                                <${LogViewAnsiUp} value=${msg[0]} />`
-                          : html`${mimepair_output(msg)}${kwargs.map(
-                                ([k, v]) =>
-                                    html`
-                                        <pluto-log-dot-kwarg><pluto-key>${k}</pluto-key> <pluto-value>${mimepair_output(v)}</pluto-value></pluto-log-dot-kwarg>
-                                    `
-                            )}`}</pluto-log-dot
-                  >
-              </pluto-log-dot-sizer>
+                                body=${html`${"This text was written to the "}
+                                    <a href="https://en.wikipedia.org/wiki/Standard_streams" target="_blank">terminal stream</a
+                                    >${" while running the cell. "}<span style="opacity: .5"
+                                        >${"(It is not the "}<em>return value</em>${" of the cell.)"}</span
+                                    >`}
+                            />
+                            <${LogViewAnsiUp} value=${msg[0]} />`
+                      : html`${mimepair_output(msg)}${kwargs.map(
+                            ([k, v]) =>
+                                html` <pluto-log-dot-kwarg><pluto-key>${k}</pluto-key> <pluto-value>${mimepair_output(v)}</pluto-value></pluto-log-dot-kwarg> `
+                        )}`}</pluto-log-dot
+              >
           </pluto-log-dot-positioner>`
         : html`<pluto-log-dot-positioner ref=${node_ref}></pluto-log-dot-positioner>`
 }

--- a/frontend/dark_color.css
+++ b/frontend/dark_color.css
@@ -66,7 +66,7 @@
         rgb(38 90 32);
         --jl-message-accent-color:
         rgb(131 191 138);
-        --jl-info-color: transparent;
+        --jl-info-color: #484848;
         --jl-info-accent-color: inherit;
         --jl-warn-color:
         rgb(80 76 38);
@@ -107,6 +107,7 @@
         --pluto-logs-bg-color:
         hsl(0deg 0% 17%);
         --pluto-logs-progress-fill: #5f7f5b;
+        --pluto-logs-progress-bg: #3d3d3d;
         --pluto-logs-progress-border:
         hsl(210deg 35% 72%);
 

--- a/frontend/dark_color.css
+++ b/frontend/dark_color.css
@@ -42,14 +42,14 @@
         --admonition-title-color: black;
         --jl-message-color: rgb(38 90 32);
         --jl-message-accent-color: rgb(131 191 138);
-        --jl-info-color: #484848;
-        --jl-info-accent-color: inherit;
-        --jl-warn-color: rgb(80 76 38);
-        --jl-warn-accent-color: rgb(239 231 135);
+        --jl-info-color: rgb(42 73 115);
+        --jl-info-accent-color: rgb(92 140 205);
+        --jl-warn-color: rgb(96 90 34);
+        --jl-warn-accent-color: rgb(221 212 100);
         --jl-danger-color: rgb(100 47 39);
-        --jl-danger-accent-color: rgb(255 147 132);
-        --jl-debug-color: hsl(288deg 19% 25%);
-        --jl-debug-accent-color: hsl(283deg 56% 79%);
+        --jl-danger-accent-color: rgb(255, 117, 98);
+        --jl-debug-color: hsl(288deg 33% 27%);
+        --jl-debug-accent-color: hsl(283deg 59% 69%);
         --table-border-color: rgba(255, 255, 255, 0.2);
         --table-bg-hover-color: rgba(193, 192, 235, 0.15);
         --pluto-tree-color: rgb(209 207 207 / 61%);
@@ -67,9 +67,19 @@
 
         /* Logs */
         --pluto-logs-bg-color: hsl(0deg 0% 17%);
+        --pluto-logs-key-color: rgba(255, 255, 255, 0.6);
         --pluto-logs-progress-fill: #5f7f5b;
         --pluto-logs-progress-bg: #3d3d3d;
         --pluto-logs-progress-border: hsl(210deg 35% 72%);
+
+        --pluto-logs-info-color: #484848;
+        --pluto-logs-info-accent-color: inherit;
+        --pluto-logs-warn-color: rgb(80 76 38);
+        --pluto-logs-warn-accent-color: rgb(239 231 135);
+        --pluto-logs-danger-color: rgb(100 47 39);
+        --pluto-logs-danger-accent-color: rgb(255 147 132);
+        --pluto-logs-debug-color: hsl(288deg 19% 25%);
+        --pluto-logs-debug-accent-color: hsl(283deg 56% 79%);
 
         /*Top navbar styling*/
         --nav-h1-text-color: white;

--- a/frontend/dark_color.css
+++ b/frontend/dark_color.css
@@ -1,138 +1,90 @@
 @media (prefers-color-scheme: dark) {
     :root {
-        --image-filters:
-        invert(1) hue-rotate(180deg) contrast(0.8);
+        --image-filters: invert(1) hue-rotate(180deg) contrast(0.8);
         --out-of-focus-opacity: 0.5;
-        --main-bg-color:
-        hsl(0deg 0% 12%);
-        --rule-color:
-        rgba(255, 255, 255, 0.15);
+        --main-bg-color: hsl(0deg 0% 12%);
+        --rule-color: rgba(255, 255, 255, 0.15);
         --kbd-border-color: #222222;
-        --header-bg-color:
-        hsl(30deg 3% 16%);
+        --header-bg-color: hsl(30deg 3% 16%);
         --header-border-color: transparent;
-        --ui-button-color:
-        rgb(255, 255, 255);
+        --ui-button-color: rgb(255, 255, 255);
         --cursor-color: white;
 
         /* Cells */
         --normal-cell: 100, 100, 100;
         --error-color: 255, 125, 125;
-        --normal-cell-color:
-        rgba(var(--normal-cell), 0.2);
-        --dark-normal-cell-color:
-        rgba(var(--normal-cell), 0.4);
-        --selected-cell-color:
-        rgb(40 147 189 / 65%);
+        --normal-cell-color: rgba(var(--normal-cell), 0.2);
+        --dark-normal-cell-color: rgba(var(--normal-cell), 0.4);
+        --selected-cell-color: rgb(40 147 189 / 65%);
         --code-differs-cell-color: #9b906c;
-        --error-cell-color:
-        rgba(var(--error-color), 0.6);
-        --bright-error-cell-color:
-        rgba(var(--error-color), 0.9);
-        --light-error-cell-color:
-        rgba(var(--error-color), 0);
+        --error-cell-color: rgba(var(--error-color), 0.6);
+        --bright-error-cell-color: rgba(var(--error-color), 0.9);
+        --light-error-cell-color: rgba(var(--error-color), 0);
 
         /*Export styling*/
-        --export-bg-color:
-        hsl(225deg 17% 18%);
-        --export-color:
-        rgb(255 255 255 / 84%);
-        --export-card-bg-color:
-        rgb(73 73 73);
-        --export-card-title-color:
-        rgba(255, 255, 255, 0.85);
-        --export-card-text-color:
-        rgb(255 255 255 / 70%);
+        --export-bg-color: hsl(225deg 17% 18%);
+        --export-color: rgb(255 255 255 / 84%);
+        --export-card-bg-color: rgb(73 73 73);
+        --export-card-title-color: rgba(255, 255, 255, 0.85);
+        --export-card-text-color: rgb(255 255 255 / 70%);
         --export-card-shadow-color: #0000001c;
 
         /*Pluto output styling */
-        --pluto-schema-types-color:
-        rgba(255, 255, 255, 0.6);
-        --pluto-schema-types-border-color:
-        rgba(255, 255, 255, 0.2);
-        --pluto-dim-output-color:
-        hsl(0, 0, 70%);
-        --pluto-output-color:
-        hsl(0deg 0% 77%);
-        --pluto-output-h-color:
-        hsl(0, 0%, 90%);
-        --pluto-output-bg-color:
-        var(--main-bg-color);
+        --pluto-schema-types-color: rgba(255, 255, 255, 0.6);
+        --pluto-schema-types-border-color: rgba(255, 255, 255, 0.2);
+        --pluto-dim-output-color: hsl(0, 0, 70%);
+        --pluto-output-color: hsl(0deg 0% 77%);
+        --pluto-output-h-color: hsl(0, 0%, 90%);
+        --pluto-output-bg-color: var(--main-bg-color);
         --a-underline: #ffffff69;
         --blockquote-color: inherit;
         --blockquote-bg: #2e2e2e;
         --admonition-title-color: black;
-        --jl-message-color:
-        rgb(38 90 32);
-        --jl-message-accent-color:
-        rgb(131 191 138);
+        --jl-message-color: rgb(38 90 32);
+        --jl-message-accent-color: rgb(131 191 138);
         --jl-info-color: #484848;
         --jl-info-accent-color: inherit;
-        --jl-warn-color:
-        rgb(80 76 38);
-        --jl-warn-accent-color:
-        rgb(239 231 135);
-        --jl-danger-color:
-        rgb(100 47 39);
-        --jl-danger-accent-color:
-        rgb(255 147 132);
-        --jl-debug-color:
-        hsl(288deg 19% 25%);
-        --jl-debug-accent-color:
-        hsl(283deg 56% 79%);
-        --table-border-color:
-        rgba(255, 255, 255, 0.2);
-        --table-bg-hover-color:
-        rgba(193, 192, 235, 0.15);
-        --pluto-tree-color:
-        rgb(209 207 207 / 61%);
+        --jl-warn-color: rgb(80 76 38);
+        --jl-warn-accent-color: rgb(239 231 135);
+        --jl-danger-color: rgb(100 47 39);
+        --jl-danger-accent-color: rgb(255 147 132);
+        --jl-debug-color: hsl(288deg 19% 25%);
+        --jl-debug-accent-color: hsl(283deg 56% 79%);
+        --table-border-color: rgba(255, 255, 255, 0.2);
+        --table-bg-hover-color: rgba(193, 192, 235, 0.15);
+        --pluto-tree-color: rgb(209 207 207 / 61%);
 
         /*pluto cell styling*/
-        --disabled-cell-bg-color:
-        rgba(139, 139, 139, 0.25);
-        --selected-cell-bg-color:
-        rgb(42 115 205 / 78%);
-        --hover-scrollbar-color-1:
-        rgba(0, 0, 0, 0.15);
-        --hover-scrollbar-color-2:
-        rgba(0, 0, 0, 0.05);
+        --disabled-cell-bg-color: rgba(139, 139, 139, 0.25);
+        --selected-cell-bg-color: rgb(42 115 205 / 78%);
+        --hover-scrollbar-color-1: rgba(0, 0, 0, 0.15);
+        --hover-scrollbar-color-2: rgba(0, 0, 0, 0.05);
         --skip-as-script-background-color: #888;
         --depends-on-skip-as-script-background-color: #666;
 
         /* Pluto shoulders */
-        --shoulder-hover-bg-color:
-        rgba(255, 255, 255, 0.05);
+        --shoulder-hover-bg-color: rgba(255, 255, 255, 0.05);
 
         /* Logs */
-        --pluto-logs-bg-color:
-        hsl(0deg 0% 17%);
+        --pluto-logs-bg-color: hsl(0deg 0% 17%);
         --pluto-logs-progress-fill: #5f7f5b;
         --pluto-logs-progress-bg: #3d3d3d;
-        --pluto-logs-progress-border:
-        hsl(210deg 35% 72%);
+        --pluto-logs-progress-border: hsl(210deg 35% 72%);
 
         /*Top navbar styling*/
         --nav-h1-text-color: white;
         --nav-filepicker-color: #b6b6b6;
         --nav-filepicker-border-color: #c7c7c7;
-        --nav-process-status-bg-color:
-        rgb(82, 82, 82);
-        --nav-process-status-color:
-        var(--pluto-output-h-color);
+        --nav-process-status-bg-color: rgb(82, 82, 82);
+        --nav-process-status-color: var(--pluto-output-h-color);
 
         /*header*/
-        --restart-recc-header-color:
-        rgb(44 106 157 / 56%);
-        --restart-req-header-color:
-        rgb(145 66 60 / 56%);
-        --dead-process-header-color:
-        rgba(250, 75, 21, 0.473);
-        --loading-header-color:
-        hsl(0deg 0% 20% / 50%);
-        --disconnected-header-color:
-        rgba(255, 169, 114, 0.56);
-        --binder-loading-header-color:
-        hsl(51deg 64% 90% / 50%);
+        --restart-recc-header-color: rgb(44 106 157 / 56%);
+        --restart-req-header-color: rgb(145 66 60 / 56%);
+        --dead-process-header-color: rgba(250, 75, 21, 0.473);
+        --loading-header-color: hsl(0deg 0% 20% / 50%);
+        --disconnected-header-color: rgba(255, 169, 114, 0.56);
+        --binder-loading-header-color: hsl(51deg 64% 90% / 50%);
 
         /*loading bar*/
         --loading-grad-color-1: #a9d4f1;
@@ -144,110 +96,82 @@
         --overlay-button-color: white;
 
         /*input_context_menu*/
-        --input-context-menu-border-color:
-        rgba(255, 255, 255, 0.1);
-        --input-context-menu-bg-color:
-        rgb(39, 40, 47);
+        --input-context-menu-border-color: rgba(255, 255, 255, 0.1);
+        --input-context-menu-bg-color: rgb(39, 40, 47);
         --input-context-menu-soon-color: #b1b1b144;
-        --input-context-menu-hover-bg-color:
-        rgba(255, 255, 255, 0.1);
+        --input-context-menu-hover-bg-color: rgba(255, 255, 255, 0.1);
         --input-context-menu-li-color: #c7c7c7;
 
         /*Pkg status*/
         --pkg-popup-bg: #3d2f44;
         --pkg-popup-border-color: #574f56;
-        --pkg-popup-buttons-bg-color:
-        var(--input-context-menu-bg-color);
+        --pkg-popup-buttons-bg-color: var(--input-context-menu-bg-color);
         --black: white;
         --white: black;
         --pkg-terminal-bg-color: #252627;
         --pkg-terminal-border-color: #c3c3c388;
 
         /* run area*/
-        --pluto-runarea-bg-color:
-        rgb(43, 43, 43);
-        --pluto-runarea-span-color:
-        hsl(353, 5%, 64%);
+        --pluto-runarea-bg-color: rgb(43, 43, 43);
+        --pluto-runarea-span-color: hsl(353, 5%, 64%);
 
         /*drop ruler*/
-        --dropruler-bg-color:
-        rgba(255, 255, 255, 0.1);
+        --dropruler-bg-color: rgba(255, 255, 255, 0.1);
 
         /* jlerror */
         --jlerror-header-color: #d9baba;
-        --jlerror-mark-bg-color:
-        rgb(0 0 0 / 18%);
-        --jlerror-a-bg-color:
-        rgba(82, 58, 58, 0.5);
+        --jlerror-mark-bg-color: rgb(0 0 0 / 18%);
+        --jlerror-a-bg-color: rgba(82, 58, 58, 0.5);
         --jlerror-a-border-left-color: #704141;
         --jlerror-mark-color: #b1a9a9;
 
         /* helpbox */
-        --helpbox-bg-color:
-        rgb(30 34 31);
+        --helpbox-bg-color: rgb(30 34 31);
         --helpbox-box-shadow-color: #00000017;
         --helpbox-header-bg-color: #2c3e36;
-        --helpbox-header-color:
-        rgb(255 248 235);
-        --helpbox-notfound-header-color:
-        rgb(139, 139, 139);
-        --helpbox-text-color:
-        rgb(230, 230, 230);
-        --code-section-bg-color:
-        rgb(44, 44, 44);
+        --helpbox-header-color: rgb(255 248 235);
+        --helpbox-notfound-header-color: rgb(139, 139, 139);
+        --helpbox-text-color: rgb(230, 230, 230);
+        --code-section-bg-color: rgb(44, 44, 44);
         --code-section-border-color: #555a64;
 
         /*footer*/
         --footer-color: #cacaca;
-        --footer-bg-color:
-        rgb(38, 39, 44);
-        --footer-atag-color:
-        rgb(114, 161, 223);
+        --footer-bg-color: rgb(38, 39, 44);
+        --footer-atag-color: rgb(114, 161, 223);
         --footer-input-border-color: #6c6c6c;
         --footer-filepicker-button-color: black;
         --footer-filepicker-focus-color: #c1c1c1;
-        --footnote-border-color:
-        rgba(114, 225, 231, 0.15);
+        --footnote-border-color: rgba(114, 225, 231, 0.15);
 
         /* undo delete cell*/
-        --undo-delete-box-shadow-color:
-        rgba(213, 213, 214, 0.2);
+        --undo-delete-box-shadow-color: rgba(213, 213, 214, 0.2);
 
         /*codemirror hints*/
-        --cm-editor-tooltip-border-color:
-        rgba(0, 0, 0, 0.2);
+        --cm-editor-tooltip-border-color: rgba(0, 0, 0, 0.2);
         --cm-editor-li-aria-selected-bg-color: #3271e7;
         --cm-editor-li-aria-selected-color: white;
-        --cm-editor-li-notexported-color:
-        rgba(255, 255, 255, 0.5);
-        --code-background:
-        hsl(222deg 16% 19%);
-        --cm-code-differs-gutters-color:
-        rgb(235 213 28 / 11%);
+        --cm-editor-li-notexported-color: rgba(255, 255, 255, 0.5);
+        --code-background: hsl(222deg 16% 19%);
+        --cm-code-differs-gutters-color: rgb(235 213 28 / 11%);
         --cm-line-numbers-color: #8d86875e;
-        --cm-selection-background:
-        hsl(215deg 64% 59% / 48%);
-        --cm-selection-background-blurred:
-        hsl(215deg 0% 59% / 48%);
+        --cm-selection-background: hsl(215deg 64% 59% / 48%);
+        --cm-selection-background-blurred: hsl(215deg 0% 59% / 48%);
 
         /* code highlighting */
         --cm-editor-text-color: #ffe9fc;
         --cm-comment-color: #e96ba8;
-        --cm-atom-color:
-        hsl(8deg 72% 62%);
-        --cm-number-color:
-        hsl(271deg 45% 64%);
+        --cm-atom-color: hsl(8deg 72% 62%);
+        --cm-number-color: hsl(271deg 45% 64%);
         --cm-property-color: #f99b15;
         --cm-keyword-color: #ff7a6f;
-        --cm-string-color:
-        hsl(20deg 69% 59%);
+        --cm-string-color: hsl(20deg 69% 59%);
         --cm-var-color: #afb7d3;
         --cm-var2-color: #06b6ef;
         --cm-macro-color: #82b38b;
         --cm-builtin-color: #5e7ad3;
         --cm-function-color: #f99b15;
-        --cm-type-color:
-        hsl(51deg 32% 44%);
+        --cm-type-color: hsl(51deg 32% 44%);
         --cm-bracket-color: #a2a273;
         --cm-tag-color: #ef6155;
         --cm-link-color: #815ba4;
@@ -255,27 +179,20 @@
         --cm-error-color: #f7f7f7;
         --cm-matchingBracket-color: white;
         --cm-matchingBracket-bg-color: #c58c237a;
-        --cm-placeholder-text-color:
-        rgb(255 255 255 / 20%);
+        --cm-placeholder-text-color: rgb(255 255 255 / 20%);
 
         /*autocomplete menu*/
-        --autocomplete-menu-bg-color:
-        var(--input-context-menu-bg-color);
+        --autocomplete-menu-bg-color: var(--input-context-menu-bg-color);
 
         /* Landing colors */
-        --index-text-color:
-        rgb(199, 199, 199);
-        --index-clickable-text-color:
-        rgb(235, 235, 235);
+        --index-text-color: rgb(199, 199, 199);
+        --index-clickable-text-color: rgb(235, 235, 235);
         --index-card-bg: #313131;
-        --welcome-mywork-bg:
-        var(--header-bg-color);
-        --welcome-newnotebook-bg:
-        rgb(68 72 102);
+        --welcome-mywork-bg: var(--header-bg-color);
+        --welcome-newnotebook-bg: rgb(68 72 102);
         --welcome-recentnotebook-bg: #3b3b3b;
         --welcome-recentnotebook-border: #6e6e6e;
-        --welcome-open-bg:
-        hsl(233deg 20% 33%);
+        --welcome-open-bg: hsl(233deg 20% 33%);
         --welcome-card-author-backdrop: #0000006b;
 
         /* docs binding */

--- a/frontend/dark_color.css
+++ b/frontend/dark_color.css
@@ -1,89 +1,137 @@
 @media (prefers-color-scheme: dark) {
     :root {
-        --image-filters: invert(1) hue-rotate(180deg) contrast(0.8);
+        --image-filters:
+        invert(1) hue-rotate(180deg) contrast(0.8);
         --out-of-focus-opacity: 0.5;
-        --main-bg-color: hsl(0deg 0% 12%);
-        --rule-color: rgba(255, 255, 255, 0.15);
+        --main-bg-color:
+        hsl(0deg 0% 12%);
+        --rule-color:
+        rgba(255, 255, 255, 0.15);
         --kbd-border-color: #222222;
-        --header-bg-color: hsl(30deg 3% 16%);
+        --header-bg-color:
+        hsl(30deg 3% 16%);
         --header-border-color: transparent;
-        --ui-button-color: rgb(255, 255, 255);
+        --ui-button-color:
+        rgb(255, 255, 255);
         --cursor-color: white;
 
         /* Cells */
         --normal-cell: 100, 100, 100;
         --error-color: 255, 125, 125;
-        --normal-cell-color: rgba(var(--normal-cell), 0.2);
-        --dark-normal-cell-color: rgba(var(--normal-cell), 0.4);
-        --selected-cell-color: rgb(40 147 189 / 65%);
+        --normal-cell-color:
+        rgba(var(--normal-cell), 0.2);
+        --dark-normal-cell-color:
+        rgba(var(--normal-cell), 0.4);
+        --selected-cell-color:
+        rgb(40 147 189 / 65%);
         --code-differs-cell-color: #9b906c;
-        --error-cell-color: rgba(var(--error-color), 0.6);
-        --bright-error-cell-color: rgba(var(--error-color), 0.9);
-        --light-error-cell-color: rgba(var(--error-color), 0);
+        --error-cell-color:
+        rgba(var(--error-color), 0.6);
+        --bright-error-cell-color:
+        rgba(var(--error-color), 0.9);
+        --light-error-cell-color:
+        rgba(var(--error-color), 0);
 
         /*Export styling*/
-        --export-bg-color: hsl(225deg 17% 18%);
-        --export-color: rgb(255 255 255 / 84%);
-        --export-card-bg-color: rgb(73 73 73);
-        --export-card-title-color: rgba(255, 255, 255, 0.85);
-        --export-card-text-color: rgb(255 255 255 / 70%);
+        --export-bg-color:
+        hsl(225deg 17% 18%);
+        --export-color:
+        rgb(255 255 255 / 84%);
+        --export-card-bg-color:
+        rgb(73 73 73);
+        --export-card-title-color:
+        rgba(255, 255, 255, 0.85);
+        --export-card-text-color:
+        rgb(255 255 255 / 70%);
         --export-card-shadow-color: #0000001c;
 
         /*Pluto output styling */
-        --pluto-schema-types-color: rgba(255, 255, 255, 0.6);
-        --pluto-schema-types-border-color: rgba(255, 255, 255, 0.2);
-        --pluto-dim-output-color: hsl(0, 0, 70%);
-        --pluto-output-color: hsl(0deg 0% 77%);
-        --pluto-output-h-color: hsl(0, 0%, 90%);
-        --pluto-output-bg-color: var(--main-bg-color);
+        --pluto-schema-types-color:
+        rgba(255, 255, 255, 0.6);
+        --pluto-schema-types-border-color:
+        rgba(255, 255, 255, 0.2);
+        --pluto-dim-output-color:
+        hsl(0, 0, 70%);
+        --pluto-output-color:
+        hsl(0deg 0% 77%);
+        --pluto-output-h-color:
+        hsl(0, 0%, 90%);
+        --pluto-output-bg-color:
+        var(--main-bg-color);
         --a-underline: #ffffff69;
         --blockquote-color: inherit;
         --blockquote-bg: #2e2e2e;
         --admonition-title-color: black;
-        --jl-message-color: rgb(38 90 32);
-        --jl-message-accent-color: rgb(131 191 138);
-        --jl-info-color: rgb(42 73 115);
-        --jl-info-accent-color: rgb(92 140 205);
-        --jl-warn-color: rgb(96 90 34);
-        --jl-warn-accent-color: rgb(221 212 100);
-        --jl-danger-color: rgb(100 47 39);
-        --jl-danger-accent-color: rgb(255, 117, 98);
-        --jl-debug-color: hsl(288deg 33% 27%);
-        --jl-debug-accent-color: hsl(283deg 59% 69%);
-        --table-border-color: rgba(255, 255, 255, 0.2);
-        --table-bg-hover-color: rgba(193, 192, 235, 0.15);
-        --pluto-tree-color: rgb(209 207 207 / 61%);
+        --jl-message-color:
+        rgb(38 90 32);
+        --jl-message-accent-color:
+        rgb(131 191 138);
+        --jl-info-color: transparent;
+        --jl-info-accent-color: inherit;
+        --jl-warn-color:
+        rgb(80 76 38);
+        --jl-warn-accent-color:
+        rgb(239 231 135);
+        --jl-danger-color:
+        rgb(100 47 39);
+        --jl-danger-accent-color:
+        rgb(255 147 132);
+        --jl-debug-color:
+        hsl(288deg 19% 25%);
+        --jl-debug-accent-color:
+        hsl(283deg 56% 79%);
+        --table-border-color:
+        rgba(255, 255, 255, 0.2);
+        --table-bg-hover-color:
+        rgba(193, 192, 235, 0.15);
+        --pluto-tree-color:
+        rgb(209 207 207 / 61%);
 
         /*pluto cell styling*/
-        --disabled-cell-bg-color: rgba(139, 139, 139, 0.25);
-        --selected-cell-bg-color: rgb(42 115 205 / 78%);
-        --hover-scrollbar-color-1: rgba(0, 0, 0, 0.15);
-        --hover-scrollbar-color-2: rgba(0, 0, 0, 0.05);
+        --disabled-cell-bg-color:
+        rgba(139, 139, 139, 0.25);
+        --selected-cell-bg-color:
+        rgb(42 115 205 / 78%);
+        --hover-scrollbar-color-1:
+        rgba(0, 0, 0, 0.15);
+        --hover-scrollbar-color-2:
+        rgba(0, 0, 0, 0.05);
         --skip-as-script-background-color: #888;
         --depends-on-skip-as-script-background-color: #666;
 
         /* Pluto shoulders */
-        --shoulder-hover-bg-color: rgba(255, 255, 255, 0.05);
+        --shoulder-hover-bg-color:
+        rgba(255, 255, 255, 0.05);
 
         /* Logs */
-        --pluto-logs-bg-color: hsl(240deg 10% 29%);
+        --pluto-logs-bg-color:
+        hsl(0deg 0% 17%);
         --pluto-logs-progress-fill: #5f7f5b;
-        --pluto-logs-progress-border: hsl(210deg 35% 72%);
+        --pluto-logs-progress-border:
+        hsl(210deg 35% 72%);
 
         /*Top navbar styling*/
         --nav-h1-text-color: white;
         --nav-filepicker-color: #b6b6b6;
         --nav-filepicker-border-color: #c7c7c7;
-        --nav-process-status-bg-color: rgb(82, 82, 82);
-        --nav-process-status-color: var(--pluto-output-h-color);
+        --nav-process-status-bg-color:
+        rgb(82, 82, 82);
+        --nav-process-status-color:
+        var(--pluto-output-h-color);
 
         /*header*/
-        --restart-recc-header-color: rgb(44 106 157 / 56%);
-        --restart-req-header-color: rgb(145 66 60 / 56%);
-        --dead-process-header-color: rgba(250, 75, 21, 0.473);
-        --loading-header-color: hsl(0deg 0% 20% / 50%);
-        --disconnected-header-color: rgba(255, 169, 114, 0.56);
-        --binder-loading-header-color: hsl(51deg 64% 90% / 50%);
+        --restart-recc-header-color:
+        rgb(44 106 157 / 56%);
+        --restart-req-header-color:
+        rgb(145 66 60 / 56%);
+        --dead-process-header-color:
+        rgba(250, 75, 21, 0.473);
+        --loading-header-color:
+        hsl(0deg 0% 20% / 50%);
+        --disconnected-header-color:
+        rgba(255, 169, 114, 0.56);
+        --binder-loading-header-color:
+        hsl(51deg 64% 90% / 50%);
 
         /*loading bar*/
         --loading-grad-color-1: #a9d4f1;
@@ -95,82 +143,110 @@
         --overlay-button-color: white;
 
         /*input_context_menu*/
-        --input-context-menu-border-color: rgba(255, 255, 255, 0.1);
-        --input-context-menu-bg-color: rgb(39, 40, 47);
+        --input-context-menu-border-color:
+        rgba(255, 255, 255, 0.1);
+        --input-context-menu-bg-color:
+        rgb(39, 40, 47);
         --input-context-menu-soon-color: #b1b1b144;
-        --input-context-menu-hover-bg-color: rgba(255, 255, 255, 0.1);
+        --input-context-menu-hover-bg-color:
+        rgba(255, 255, 255, 0.1);
         --input-context-menu-li-color: #c7c7c7;
 
         /*Pkg status*/
         --pkg-popup-bg: #3d2f44;
         --pkg-popup-border-color: #574f56;
-        --pkg-popup-buttons-bg-color: var(--input-context-menu-bg-color);
+        --pkg-popup-buttons-bg-color:
+        var(--input-context-menu-bg-color);
         --black: white;
         --white: black;
         --pkg-terminal-bg-color: #252627;
         --pkg-terminal-border-color: #c3c3c388;
 
         /* run area*/
-        --pluto-runarea-bg-color: rgb(43, 43, 43);
-        --pluto-runarea-span-color: hsl(353, 5%, 64%);
+        --pluto-runarea-bg-color:
+        rgb(43, 43, 43);
+        --pluto-runarea-span-color:
+        hsl(353, 5%, 64%);
 
         /*drop ruler*/
-        --dropruler-bg-color: rgba(255, 255, 255, 0.1);
+        --dropruler-bg-color:
+        rgba(255, 255, 255, 0.1);
 
         /* jlerror */
         --jlerror-header-color: #d9baba;
-        --jlerror-mark-bg-color: rgb(0 0 0 / 18%);
-        --jlerror-a-bg-color: rgba(82, 58, 58, 0.5);
+        --jlerror-mark-bg-color:
+        rgb(0 0 0 / 18%);
+        --jlerror-a-bg-color:
+        rgba(82, 58, 58, 0.5);
         --jlerror-a-border-left-color: #704141;
         --jlerror-mark-color: #b1a9a9;
 
         /* helpbox */
-        --helpbox-bg-color: rgb(30 34 31);
+        --helpbox-bg-color:
+        rgb(30 34 31);
         --helpbox-box-shadow-color: #00000017;
         --helpbox-header-bg-color: #2c3e36;
-        --helpbox-header-color: rgb(255 248 235);
-        --helpbox-notfound-header-color: rgb(139, 139, 139);
-        --helpbox-text-color: rgb(230, 230, 230);
-        --code-section-bg-color: rgb(44, 44, 44);
+        --helpbox-header-color:
+        rgb(255 248 235);
+        --helpbox-notfound-header-color:
+        rgb(139, 139, 139);
+        --helpbox-text-color:
+        rgb(230, 230, 230);
+        --code-section-bg-color:
+        rgb(44, 44, 44);
         --code-section-border-color: #555a64;
 
         /*footer*/
         --footer-color: #cacaca;
-        --footer-bg-color: rgb(38, 39, 44);
-        --footer-atag-color: rgb(114, 161, 223);
+        --footer-bg-color:
+        rgb(38, 39, 44);
+        --footer-atag-color:
+        rgb(114, 161, 223);
         --footer-input-border-color: #6c6c6c;
         --footer-filepicker-button-color: black;
         --footer-filepicker-focus-color: #c1c1c1;
-        --footnote-border-color: rgba(114, 225, 231, 0.15);
+        --footnote-border-color:
+        rgba(114, 225, 231, 0.15);
 
         /* undo delete cell*/
-        --undo-delete-box-shadow-color: rgba(213, 213, 214, 0.2);
+        --undo-delete-box-shadow-color:
+        rgba(213, 213, 214, 0.2);
 
         /*codemirror hints*/
-        --cm-editor-tooltip-border-color: rgba(0, 0, 0, 0.2);
+        --cm-editor-tooltip-border-color:
+        rgba(0, 0, 0, 0.2);
         --cm-editor-li-aria-selected-bg-color: #3271e7;
         --cm-editor-li-aria-selected-color: white;
-        --cm-editor-li-notexported-color: rgba(255, 255, 255, 0.5);
-        --code-background: hsl(222deg 16% 19%);
-        --cm-code-differs-gutters-color: rgb(235 213 28 / 11%);
+        --cm-editor-li-notexported-color:
+        rgba(255, 255, 255, 0.5);
+        --code-background:
+        hsl(222deg 16% 19%);
+        --cm-code-differs-gutters-color:
+        rgb(235 213 28 / 11%);
         --cm-line-numbers-color: #8d86875e;
-        --cm-selection-background: hsl(215deg 64% 59% / 48%);
-        --cm-selection-background-blurred: hsl(215deg 0% 59% / 48%);
+        --cm-selection-background:
+        hsl(215deg 64% 59% / 48%);
+        --cm-selection-background-blurred:
+        hsl(215deg 0% 59% / 48%);
 
         /* code highlighting */
         --cm-editor-text-color: #ffe9fc;
         --cm-comment-color: #e96ba8;
-        --cm-atom-color: hsl(8deg 72% 62%);
-        --cm-number-color: hsl(271deg 45% 64%);
+        --cm-atom-color:
+        hsl(8deg 72% 62%);
+        --cm-number-color:
+        hsl(271deg 45% 64%);
         --cm-property-color: #f99b15;
         --cm-keyword-color: #ff7a6f;
-        --cm-string-color: hsl(20deg 69% 59%);
+        --cm-string-color:
+        hsl(20deg 69% 59%);
         --cm-var-color: #afb7d3;
         --cm-var2-color: #06b6ef;
         --cm-macro-color: #82b38b;
         --cm-builtin-color: #5e7ad3;
         --cm-function-color: #f99b15;
-        --cm-type-color: hsl(51deg 32% 44%);
+        --cm-type-color:
+        hsl(51deg 32% 44%);
         --cm-bracket-color: #a2a273;
         --cm-tag-color: #ef6155;
         --cm-link-color: #815ba4;
@@ -178,20 +254,27 @@
         --cm-error-color: #f7f7f7;
         --cm-matchingBracket-color: white;
         --cm-matchingBracket-bg-color: #c58c237a;
-        --cm-placeholder-text-color: rgb(255 255 255 / 20%);
+        --cm-placeholder-text-color:
+        rgb(255 255 255 / 20%);
 
         /*autocomplete menu*/
-        --autocomplete-menu-bg-color: var(--input-context-menu-bg-color);
+        --autocomplete-menu-bg-color:
+        var(--input-context-menu-bg-color);
 
         /* Landing colors */
-        --index-text-color: rgb(199, 199, 199);
-        --index-clickable-text-color: rgb(235, 235, 235);
+        --index-text-color:
+        rgb(199, 199, 199);
+        --index-clickable-text-color:
+        rgb(235, 235, 235);
         --index-card-bg: #313131;
-        --welcome-mywork-bg: var(--header-bg-color);
-        --welcome-newnotebook-bg: rgb(68 72 102);
+        --welcome-mywork-bg:
+        var(--header-bg-color);
+        --welcome-newnotebook-bg:
+        rgb(68 72 102);
         --welcome-recentnotebook-bg: #3b3b3b;
         --welcome-recentnotebook-border: #6e6e6e;
-        --welcome-open-bg: hsl(233deg 20% 33%);
+        --welcome-open-bg:
+        hsl(233deg 20% 33%);
         --welcome-card-author-backdrop: #0000006b;
 
         /* docs binding */

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -2341,7 +2341,7 @@ pluto-logs-container {
 
 pluto-logs-container:not(:empty) {
     background: var(--pluto-logs-bg-color);
-    /* padding: 10px; */
+    padding: 6px;
 }
 
 pluto-logs-container pluto-progress-bars pluto-progress:not(:first-child) {
@@ -2388,18 +2388,25 @@ pluto-log-dot {
 }
 
 pluto-log-dot-positioner {
-    border-bottom: 1px solid #71717140;
+    /* border-bottom: 1px solid #71717140; */
     display: flex;
     flex-direction: row;
-    --bg-color: var(--jl-info-color);
-    --accent-color: var(--jl-info-accent-color);
+    --bg-color:
+    var(--jl-info-color);
+    --accent-color:
+    var(--jl-info-accent-color);
     --icon-image: unset;
     background: var(--bg-color);
     color: var(--accent-color);
+    margin: 2px;
+    border-radius: 6px;
+    border: 2px solid var(--accent-color);
+    border: 2px solid #0000001c;
+    /* box-shadow: 0px 0px 6px #00000021; */
 }
 
 pluto-log-dot-positioner:last-child {
-    border-bottom: none;
+    /* border-bottom: none; */
 }
 
 pluto-log-icon::before {

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -2388,8 +2388,8 @@ pluto-log-dot-positioner {
     /* border-bottom: 1px solid #71717140; */
     display: flex;
     flex-direction: row;
-    --bg-color: var(--jl-info-color);
-    --accent-color: var(--jl-info-accent-color);
+    --bg-color: var(--pluto-logs-info-color);
+    --accent-color: var(--pluto-logs-info-accent-color);
     --icon-image: unset;
     background: var(--bg-color);
     color: var(--accent-color);
@@ -2433,18 +2433,18 @@ pluto-log-dot-positioner.Info pluto-log-icon::before {
     opacity: 0.4;
 }
 pluto-log-dot-positioner.Warn {
-    --bg-color: var(--jl-warn-color);
-    --accent-color: var(--jl-warn-accent-color);
+    --bg-color: var(--pluto-logs-warn-color);
+    --accent-color: var(--pluto-logs-warn-accent-color);
     --icon-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/warning-outline.svg");
 }
 pluto-log-dot-positioner.Error {
-    --bg-color: var(--jl-danger-color);
-    --accent-color: var(--jl-danger-accent-color);
+    --bg-color: var(--pluto-logs-danger-color);
+    --accent-color: var(--pluto-logs-danger-accent-color);
     --icon-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/close-circle-outline.svg");
 }
 pluto-log-dot-positioner.Debug {
-    --bg-color: var(--jl-debug-color);
-    --accent-color: var(--jl-debug-accent-color);
+    --bg-color: var(--pluto-logs-debug-color);
+    --accent-color: var(--pluto-logs-debug-accent-color);
     --icon-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/information-circle-outline.svg");
 }
 pluto-log-dot-positioner.Stdout {
@@ -2455,14 +2455,12 @@ pluto-log-dot-positioner.Stdout pluto-log-icon::before {
 }
 
 pluto-log-dot.Progress {
-    /* width: 100px; */
     overflow: hidden;
     padding: 0px;
     flex: 0 1 200px;
     display: flex;
     flex-direction: row;
     align-items: stretch;
-    /* padding: 5px; */
     align-self: center;
     outline: 3px solid var(--pluto-logs-progress-border);
     outline-offset: -2px;
@@ -2471,7 +2469,6 @@ pluto-log-dot.Progress {
     font-size: 0.7rem;
 }
 pluto-log-dot.Stdout {
-    /* filter: sepia(0.3); */
     --inner: hsl(36deg 20% 37%);
     --outer: hsl(31deg 12% 28%);
     background: radial-gradient(var(--inner), var(--inner) 20%, var(--outer));
@@ -2558,7 +2555,7 @@ pluto-log-dot-kwarg > * {
     flex: 0 1 auto;
 }
 pluto-log-dot-kwarg > pluto-key {
-    color: var(--pluto-schema-types-color);
+    color: var(--pluto-logs-key-color);
     margin-right: calc(1em - 30px);
 }
 pluto-log-dot-kwarg > pluto-key::after {

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -30,15 +30,11 @@
     /* use the value "contextual" to enable contextual ligatures `document.documentElement.style.setProperty('--pluto-operator-ligatures', 'contextual');`
         for julia mono see here: https://cormullion.github.io/pages/2020-07-26-JuliaMono/#contextual_and_stylistic_alternates_and_ligatures */
     --pluto-operator-ligatures: none;
-    --julia-mono-font-stack: JuliaMono, Menlo,
-    "Roboto Mono", "Lucida Sans Typewriter", "Source Code Pro", monospace;
-    --sans-serif-font-stack:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
-    --lato-ui-font-stack:
-    "Lato", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Cantarell, Helvetica, Arial, "Apple Color Emoji",
+    --julia-mono-font-stack: JuliaMono, Menlo, "Roboto Mono", "Lucida Sans Typewriter", "Source Code Pro", monospace;
+    --sans-serif-font-stack: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+    --lato-ui-font-stack: "Lato", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Cantarell, Helvetica, Arial, "Apple Color Emoji",
         "Segoe UI Emoji", "Segoe UI Symbol", system-ui, sans-serif;
-    --system-ui-font-stack:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Cantarell, Helvetica, Arial, "Apple Color Emoji",
+    --system-ui-font-stack: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Cantarell, Helvetica, Arial, "Apple Color Emoji",
         "Segoe UI Emoji", "Segoe UI Symbol", system-ui, sans-serif;
     color-scheme: light dark;
 }
@@ -2350,12 +2346,13 @@ pluto-logs-container pluto-progress-bars pluto-progress:not(:first-child) {
 
 pluto-logs-container pluto-progress-bar {
     --c: var(--pluto-logs-progress-fill);
-    padding: 1px 3px;
+    padding: 0.3em 0.6em;
     background: linear-gradient(90deg, var(--c), var(--c));
     background-repeat: no-repeat;
     width: 100%;
     transition: background-size cubic-bezier(0.14, 0.71, 0, 0.99) 2s, opacity linear 0.2s;
-    /* background-color: salmon; */
+    display: grid;
+    align-items: center;
 }
 
 pluto-logs-container pluto-progress-bar.collapsed {
@@ -2391,18 +2388,18 @@ pluto-log-dot-positioner {
     /* border-bottom: 1px solid #71717140; */
     display: flex;
     flex-direction: row;
-    --bg-color:
-    var(--jl-info-color);
-    --accent-color:
-    var(--jl-info-accent-color);
+    --bg-color: var(--jl-info-color);
+    --accent-color: var(--jl-info-accent-color);
     --icon-image: unset;
     background: var(--bg-color);
     color: var(--accent-color);
     margin: 2px;
     border-radius: 6px;
-    border: 2px solid var(--accent-color);
-    border: 2px solid #0000001c;
-    /* box-shadow: 0px 0px 6px #00000021; */
+    /* border: 2px solid var(--accent-color); */
+    /* border: 2px solid #0000001c; */
+    /* box-shadow: 0px 0px 6px #00000036; */
+    background: linear-gradient(148deg, var(--bg-color), transparent);
+    background-size: 200% 100%;
 }
 
 pluto-log-dot-positioner:last-child {
@@ -2441,23 +2438,41 @@ pluto-log-dot-positioner.Debug {
     --accent-color: var(--jl-debug-accent-color);
     --icon-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/information-circle-outline.svg");
 }
+pluto-log-dot-positioner.Stdout {
+    --icon-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/terminal-outline.svg");
+}
+pluto-log-dot-positioner.Stdout pluto-log-icon::before {
+    opacity: 0.4;
+}
 
 pluto-log-dot.Progress {
-    width: 100px;
-    background-color: #94949466;
-    border: var(--pluto-logs-progress-border);
+    /* width: 100px; */
     overflow: hidden;
     padding: 0px;
+    flex: 0 1 200px;
+    display: flex;
+    flex-direction: row;
+    align-items: stretch;
+    /* padding: 5px; */
+    align-self: center;
+    outline: 3px solid var(--pluto-logs-progress-border);
+    outline-offset: -2px;
+    border-radius: 6px;
+    background: var(--pluto-logs-progress-bg);
+    font-size: 0.7rem;
 }
 pluto-log-dot.Stdout {
     /* filter: sepia(0.3); */
-    --inner: hsl(36deg 20% 37%);
-    --outer: hsl(31deg 12% 28%);
+    --inner:
+    hsl(36deg 20% 37%);
+    --outer:
+    hsl(31deg 12% 28%);
     background: radial-gradient(var(--inner), var(--inner) 20%, var(--outer));
     color: #8ed975;
     border: 6px solid #b7b7b7;
     text-shadow: 1px 1px 2px #0000005e;
     min-width: 18em;
+    border-radius: 8px;
 }
 pluto-log-dot.Stdout::after,
 pluto-log-dot.Stdout::before {
@@ -2646,7 +2661,7 @@ pluto-input .cm-editor .cm-tooltip.cm-tooltip-autocomplete > ul > li {
     float: right;
     margin-right: 0.5em;
     font-size: 0.8em;
-    font-family: 'JuliaMono';
+    font-family: "JuliaMono";
     font-style: normal;
 }
 
@@ -2946,7 +2961,6 @@ pluto-cell.hooked_up pluto-output {
     justify-content: flex-end;
     gap: 0.5em;
 }
-
 
 pluto-logs-container > header {
     font-family: "Roboto Mono", monospace;

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -30,13 +30,16 @@
     /* use the value "contextual" to enable contextual ligatures `document.documentElement.style.setProperty('--pluto-operator-ligatures', 'contextual');`
         for julia mono see here: https://cormullion.github.io/pages/2020-07-26-JuliaMono/#contextual_and_stylistic_alternates_and_ligatures */
     --pluto-operator-ligatures: none;
-    --julia-mono-font-stack: JuliaMono, Menlo, "Roboto Mono", "Lucida Sans Typewriter", "Source Code Pro", monospace;
-    --sans-serif-font-stack: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
-    --lato-ui-font-stack: "Lato", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Cantarell, Helvetica, Arial, "Apple Color Emoji",
+    --julia-mono-font-stack: JuliaMono, Menlo,
+    "Roboto Mono", "Lucida Sans Typewriter", "Source Code Pro", monospace;
+    --sans-serif-font-stack:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
+    --lato-ui-font-stack:
+    "Lato", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Cantarell, Helvetica, Arial, "Apple Color Emoji",
         "Segoe UI Emoji", "Segoe UI Symbol", system-ui, sans-serif;
-    --system-ui-font-stack: "Lato", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Cantarell, Helvetica, Arial, "Apple Color Emoji",
+    --system-ui-font-stack:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Cantarell, Helvetica, Arial, "Apple Color Emoji",
         "Segoe UI Emoji", "Segoe UI Symbol", system-ui, sans-serif;
-
     color-scheme: light dark;
 }
 
@@ -2333,11 +2336,12 @@ pluto-logs-container {
     overflow-x: hidden;
     overflow-y: auto;
     max-height: 50vh;
+    margin-right: 1.3rem;
 }
 
 pluto-logs-container:not(:empty) {
     background: var(--pluto-logs-bg-color);
-    padding: 10px;
+    /* padding: 10px; */
 }
 
 pluto-logs-container pluto-progress-bars pluto-progress:not(:first-child) {
@@ -2373,33 +2377,68 @@ pluto-log-dot {
     font-family: "Roboto Mono", monospace;
     font-size: 0.6rem;
     position: relative;
-    display: inline-flex;
+    display: flex;
+    flex-grow: 1;
     flex-direction: column;
     padding: 1px 3px;
     min-width: 18px;
     min-height: 18px;
-    border-radius: 7px;
+    /* border-radius: 7px; */
+    padding: 0.6em 0.9em 0.6em 0.3em;
 }
-pluto-log-dot {
-    background: var(--jl-info-color);
-    border: 3px solid var(--jl-info-accent-color);
+
+pluto-log-dot-positioner {
+    border-bottom: 1px solid #71717140;
+    display: flex;
+    flex-direction: row;
+    --bg-color: var(--jl-info-color);
+    --accent-color: var(--jl-info-accent-color);
+    --icon-image: unset;
+    background: var(--bg-color);
+    color: var(--accent-color);
 }
-pluto-log-dot.Warn {
-    background: var(--jl-warn-color);
-    border: 3px solid var(--jl-warn-accent-color);
+
+pluto-log-dot-positioner:last-child {
+    border-bottom: none;
 }
-pluto-log-dot.Error {
-    background: var(--jl-danger-color);
-    border: 3px solid var(--jl-danger-accent-color);
+
+pluto-log-icon::before {
+    content: "";
+    width: 1em;
+    height: 1em;
+    background-image: var(--icon-image);
+    background-size: 1em;
+    filter: var(--image-filters);
+    display: inline-flex;
+    margin: 0.3em;
 }
-pluto-log-dot.Debug {
-    background: var(--jl-debug-color);
-    border: 3px solid var(--jl-debug-accent-color);
+
+pluto-log-dot-positioner.Info {
+    --icon-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/information-circle-outline.svg");
 }
+pluto-log-dot-positioner.Info pluto-log-icon::before {
+    opacity: 0.4;
+}
+pluto-log-dot-positioner.Warn {
+    --bg-color: var(--jl-warn-color);
+    --accent-color: var(--jl-warn-accent-color);
+    --icon-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/warning-outline.svg");
+}
+pluto-log-dot-positioner.Error {
+    --bg-color: var(--jl-danger-color);
+    --accent-color: var(--jl-danger-accent-color);
+    --icon-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/close-circle-outline.svg");
+}
+pluto-log-dot-positioner.Debug {
+    --bg-color: var(--jl-debug-color);
+    --accent-color: var(--jl-debug-accent-color);
+    --icon-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/information-circle-outline.svg");
+}
+
 pluto-log-dot.Progress {
     width: 100px;
-    background: #94949466;
-    border: 3px solid var(--pluto-logs-progress-border);
+    background-color: #94949466;
+    border: var(--pluto-logs-progress-border);
     overflow: hidden;
     padding: 0px;
 }
@@ -2892,4 +2931,15 @@ pluto-cell.hooked_up pluto-output {
     margin-top: 2rem;
     justify-content: flex-end;
     gap: 0.5em;
+}
+
+
+pluto-logs-container > header {
+    font-family: "Roboto Mono", monospace;
+    font-size: 1.3rem;
+    padding: 0.2em;
+    padding-bottom: 0;
+    opacity: 0.6;
+    font-weight: 700;
+    /* background: #494949; */
 }

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -2406,6 +2406,15 @@ pluto-log-dot-positioner:last-child {
     /* border-bottom: none; */
 }
 
+pluto-log-truncated {
+    display: grid;
+    place-items: center;
+    font-family: var(--system-ui-font-stack);
+    opacity: 0.7;
+    padding: 0.7em;
+    font-style: italic;
+}
+
 pluto-log-icon::before {
     content: "";
     width: 1em;
@@ -2463,10 +2472,8 @@ pluto-log-dot.Progress {
 }
 pluto-log-dot.Stdout {
     /* filter: sepia(0.3); */
-    --inner:
-    hsl(36deg 20% 37%);
-    --outer:
-    hsl(31deg 12% 28%);
+    --inner: hsl(36deg 20% 37%);
+    --outer: hsl(31deg 12% 28%);
     background: radial-gradient(var(--inner), var(--inner) 20%, var(--outer));
     color: #8ed975;
     border: 6px solid #b7b7b7;

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -2339,11 +2339,6 @@ pluto-logs-container {
     background: hsl(0deg 0% 100% / 81%);
 }
 
-/* @media screen and (max-width: calc(700px + 25px + 6px + 150px)) { */
-pluto-logs {
-    display: flex !important;
-}
-
 pluto-logs-container {
     position: static;
     /* right: min(-6px, 700px + 25px - 100vw); */
@@ -2357,41 +2352,6 @@ pluto-logs-container:not(:empty) {
     background: var(--pluto-logs-bg-color);
     padding: 10px;
 }
-
-pluto-logs-container:focus-within,
-pluto-logs-container:hover {
-    /* width: 30vw; */
-}
-
-pluto-logs-container pluto-logs {
-    /* grid-template-columns: repeat(auto-fill, 0px); */
-}
-pluto-logs-container:focus-within pluto-logs,
-pluto-logs-container:hover pluto-logs {
-    /* grid-template-columns: repeat(auto-fill, 10px); */
-}
-/* 
-    pluto-log-dot-positioner {
-        flex: 0 0 auto;
-        width: auto;
-    }
-    pluto-log-dot-sizer {
-        width: auto;
-    } */
-/* } */
-/* 
-@media screen and (min-width: calc(700px + 25px + 6px + 500px)) and (max-width: calc(700px + 25px + 6px + 500px + 500px)) {
-    pluto-logs-container {
-        right: calc(-500px - 6px);
-        width: calc(500px + 6px);
-    }
-}
-@media screen and (min-width: calc(700px + 25px + 6px + 500px + 500px)) {
-    pluto-logs-container {
-        width: calc(0.5 * (6px + 100vw - (700px + 25px)));
-        right: calc(-0.5 * (6px + 100vw - (700px + 25px)));
-    }
-} */
 
 pluto-logs-container pluto-progress-bars pluto-progress:not(:first-child) {
     margin-top: 10px;
@@ -2412,22 +2372,12 @@ pluto-logs-container pluto-progress-bar.collapsed {
 }
 
 pluto-logs {
-    display: grid;
-    grid-auto-rows: 15px;
-    flex-direction: row;
-    grid-template-rows: repeat(auto-fill, 15px);
-    grid-template-columns: repeat(auto-fill, 10px);
-    grid-auto-flow: column;
+    display: flex;
+    flex-direction: column;
 }
 
 pluto-logs:not(:first-child):not(:empty) {
     margin-top: 10px;
-}
-
-pluto-log-dot-positioner {
-    display: block;
-    width: 10px;
-    transition: transform 100ms ease-in-out;
 }
 
 pluto-log-dot-positioner:hover,
@@ -2436,34 +2386,12 @@ pluto-log-dot-positioner.inspecting {
     /* transform: translate(0px, -5px); */
 }
 
-/* pluto-log-dot-positioner {
-    transform: translateX(0px);
-} */
-pluto-log-dot-positioner.inspecting {
-    transform: translateX(5px);
-}
-pluto-log-dot-positioner.inspecting pluto-log-dot {
-    box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.2);
-}
-pluto-log-dot-positioner.inspecting ~ pluto-log-dot-positioner {
-    transform: translateX(10px);
-}
-
-pluto-log-dot-sizer {
-    display: block;
-    width: max-content;
-    transform: translateZ(10px);
-    max-width: 600px;
-    z-index: 300;
-    pointer-events: none; /* part 1: because the hit box is larger than the action log dot */
-}
 pluto-log-dot {
-    pointer-events: auto; /* part 2 */
-    box-shadow: -2px 0px 1px #00000014;
+    /* part 2 */
+    /* box-shadow: -2px 0px 1px #00000014; */
     font-family: "Roboto Mono", monospace;
     font-size: 0.6rem;
-
-    /* position: absolute; */
+    position: relative;
     display: inline-flex;
     flex-direction: column;
     padding: 1px 3px;
@@ -2507,10 +2435,10 @@ pluto-log-dot.Stdout {
 pluto-log-dot.Stdout::after,
 pluto-log-dot.Stdout::before {
     content: " ";
-    left: 6px;
-    right: 6px;
-    top: 6px;
-    bottom: 6px;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
     position: absolute;
     display: block;
     pointer-events: none;

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -2327,25 +2327,12 @@ nav#undo_delete.hidden {
 
 pluto-logs-container {
     display: block;
-    width: max(100px, 100vw - (700px + 25px));
-    /* Show logs up to the RunArea */
-    max-height: calc(100% + 14px);
-    position: absolute;
-    z-index: 25;
-    right: min(-100px, -100vw + (700px + 25px));
-    top: 1px;
-    overflow-x: auto;
-    /* overflow-y: hidden; */
-    background: hsl(0deg 0% 100% / 81%);
-}
 
-pluto-logs-container {
-    position: static;
-    /* right: min(-6px, 700px + 25px - 100vw); */
-    /* width: 20px; */
-    /* transition: width ease-in-out 100ms; */
-    /* padding-left: 80px; */
-    width: 100%;
+    /* Show logs up to the RunArea */
+    z-index: 25;
+    overflow-x: hidden;
+    overflow-y: auto;
+    max-height: 50vh;
 }
 
 pluto-logs-container:not(:empty) {
@@ -2378,12 +2365,6 @@ pluto-logs {
 
 pluto-logs:not(:first-child):not(:empty) {
     margin-top: 10px;
-}
-
-pluto-log-dot-positioner:hover,
-pluto-log-dot-positioner.inspecting {
-    z-index: 5;
-    /* transform: translate(0px, -5px); */
 }
 
 pluto-log-dot {

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -2563,6 +2563,7 @@ pluto-log-dot-kwarg > pluto-key::after {
 }
 pluto-log-dot-kwarg > pluto-value {
     margin-left: 30px;
+    overflow-x: auto;
 }
 /* PRESENTATION MODE */
 

--- a/frontend/light_color.css
+++ b/frontend/light_color.css
@@ -5,12 +5,10 @@
 
         /* Color scheme */
         --main-bg-color: white;
-        --rule-color:
-        rgba(0, 0, 0, 0.15);
+        --rule-color: rgba(0, 0, 0, 0.15);
         --kbd-border-color: #dfdfdf;
         --header-bg-color: white;
-        --header-border-color:
-        rgba(0, 0, 0, 0.1);
+        --header-border-color: rgba(0, 0, 0, 0.1);
         --ui-button-color: #2a2a2b;
         --cursor-color: black;
         --normal-cell: 0, 0, 0;
@@ -18,119 +16,78 @@
         --error-color: 240, 168, 168;
 
         /*Cells*/
-        --normal-cell-color:
-        rgba(var(--normal-cell), 0.1);
-        --dark-normal-cell-color:
-        rgba(var(--normal-cell), 0.2);
-        --selected-cell-color:
-        rgba(40, 78, 189, 0.4);
-        --code-differs-cell-color:
-        rgba(var(--code-differs), 0.68);
-        --error-cell-color:
-        rgba(var(--error-color), 0.7);
-        --bright-error-cell-color:
-        rgb(var(--error-color));
-        --light-error-cell-color:
-        rgba(var(--error-color), 0.05);
+        --normal-cell-color: rgba(var(--normal-cell), 0.1);
+        --dark-normal-cell-color: rgba(var(--normal-cell), 0.2);
+        --selected-cell-color: rgba(40, 78, 189, 0.4);
+        --code-differs-cell-color: rgba(var(--code-differs), 0.68);
+        --error-cell-color: rgba(var(--error-color), 0.7);
+        --bright-error-cell-color: rgb(var(--error-color));
+        --light-error-cell-color: rgba(var(--error-color), 0.05);
 
         /*Export styling*/
-        --export-bg-color:
-        rgb(60, 67, 101);
-        --export-color:
-        rgba(255, 255, 255, 0.7);
-        --export-card-bg-color:
-        rgba(255, 255, 255, 0.8);
-        --export-card-title-color:
-        rgba(0, 0, 0, 0.7);
-        --export-card-text-color:
-        rgba(0, 0, 0, 0.5);
+        --export-bg-color: rgb(60, 67, 101);
+        --export-color: rgba(255, 255, 255, 0.7);
+        --export-card-bg-color: rgba(255, 255, 255, 0.8);
+        --export-card-title-color: rgba(0, 0, 0, 0.7);
+        --export-card-text-color: rgba(0, 0, 0, 0.5);
         --export-card-shadow-color: #00000029;
 
         /*Pluto output styling */
-        --pluto-schema-types-color:
-        rgb(0 0 0 / 51%);
-        --pluto-schema-types-border-color:
-        rgba(0, 0, 0, 0.2);
-        --pluto-output-color:
-        hsl(0, 0%, 25%);
-        --pluto-output-h-color:
-        hsl(0, 0%, 12%);
+        --pluto-schema-types-color: rgb(0 0 0 / 51%);
+        --pluto-schema-types-border-color: rgba(0, 0, 0, 0.2);
+        --pluto-output-color: hsl(0, 0%, 25%);
+        --pluto-output-h-color: hsl(0, 0%, 12%);
         --pluto-output-bg-color: white;
         --a-underline: #00000059;
         --blockquote-color: #555;
         --blockquote-bg: #f2f2f2;
         --admonition-title-color: white;
-        --jl-message-color:
-        rgb(219 233 212);
-        --jl-message-accent-color:
-        rgb(158, 200, 137);
+        --jl-message-color: rgb(219 233 212);
+        --jl-message-accent-color: rgb(158, 200, 137);
         --jl-info-color: white;
         --jl-info-accent-color: inherit;
-        --jl-warn-color:
-        rgb(236 234 213);
+        --jl-warn-color: rgb(236 234 213);
         --jl-warn-accent-color: #665f26;
-        --jl-danger-color:
-        rgb(245 218 215);
-        --jl-danger-accent-color:
-        rgb(172 66 52);
-        --jl-debug-color:
-        rgb(236 223 247);
-        --jl-debug-accent-color:
-        rgb(100 50 179);
-        --footnote-border-color:
-        rgba(23, 115, 119, 0.15);
-        --table-border-color:
-        rgba(0, 0, 0, 0.2);
-        --table-bg-hover-color:
-        rgba(159, 158, 224, 0.15);
-        --pluto-tree-color:
-        rgb(0 0 0 / 38%);
+        --jl-danger-color: rgb(245 218 215);
+        --jl-danger-accent-color: rgb(172 66 52);
+        --jl-debug-color: rgb(236 223 247);
+        --jl-debug-accent-color: rgb(100 50 179);
+        --footnote-border-color: rgba(23, 115, 119, 0.15);
+        --table-border-color: rgba(0, 0, 0, 0.2);
+        --table-bg-hover-color: rgba(159, 158, 224, 0.15);
+        --pluto-tree-color: rgb(0 0 0 / 38%);
 
         /*pluto cell styling*/
-        --disabled-cell-bg-color:
-        rgba(139, 139, 139, 0.25);
-        --selected-cell-bg-color:
-        rgba(40, 78, 189, 0.24);
-        --hover-scrollbar-color-1:
-        rgba(0, 0, 0, 0.15);
-        --hover-scrollbar-color-2:
-        rgba(0, 0, 0, 0.05);
+        --disabled-cell-bg-color: rgba(139, 139, 139, 0.25);
+        --selected-cell-bg-color: rgba(40, 78, 189, 0.24);
+        --hover-scrollbar-color-1: rgba(0, 0, 0, 0.15);
+        --hover-scrollbar-color-2: rgba(0, 0, 0, 0.05);
         --skip-as-script-background-color: #ccc;
         --depends-on-skip-as-script-background-color: #eee;
 
         /* Pluto shoulders */
-        --shoulder-hover-bg-color:
-        rgba(0, 0, 0, 0.05);
+        --shoulder-hover-bg-color: rgba(0, 0, 0, 0.05);
 
         /* Logs */
-        --pluto-logs-bg-color:
-        hsl(0deg 0% 98%);
+        --pluto-logs-bg-color: hsl(0deg 0% 98%);
         --pluto-logs-progress-fill: #ffffff;
         --pluto-logs-progress-bg: #e7e7e7;
-        --pluto-logs-progress-border:
-        hsl(210deg 16% 74%);
+        --pluto-logs-progress-border: hsl(210deg 16% 74%);
 
         /*Top navbar styling*/
         --nav-h1-text-color: black;
         --nav-filepicker-color: #6f6f6f;
         --nav-filepicker-border-color: #b2b2b2;
         --nav-process-status-bg-color: white;
-        --nav-process-status-color:
-        var(--pluto-output-h-color);
+        --nav-process-status-color: var(--pluto-output-h-color);
 
         /*header*/
-        --restart-recc-header-color:
-        rgba(114, 192, 255, 0.56);
-        --restart-req-header-color:
-        rgba(170, 41, 32, 0.56);
-        --dead-process-header-color:
-        rgb(230 88 46 / 38%);
-        --loading-header-color:
-        hsla(290, 10%, 80%, 0.5);
-        --disconnected-header-color:
-        rgba(255, 169, 114, 0.56);
-        --binder-loading-header-color:
-        hsl(51deg 64% 90% / 50%);
+        --restart-recc-header-color: rgba(114, 192, 255, 0.56);
+        --restart-req-header-color: rgba(170, 41, 32, 0.56);
+        --dead-process-header-color: rgb(230 88 46 / 38%);
+        --loading-header-color: hsla(290, 10%, 80%, 0.5);
+        --disconnected-header-color: rgba(255, 169, 114, 0.56);
+        --binder-loading-header-color: hsl(51deg 64% 90% / 50%);
 
         /*loading bar*/
         --loading-grad-color-1: #f1dba9;
@@ -142,12 +99,10 @@
         --overlay-button-border-save: #f3f2f2;
 
         /*input_context_menu*/
-        --input-context-menu-border-color:
-        rgba(0, 0, 0, 0.1);
+        --input-context-menu-border-color: rgba(0, 0, 0, 0.1);
         --input-context-menu-bg-color: white;
         --input-context-menu-soon-color: #55555544;
-        --input-context-menu-hover-bg-color:
-        rgba(0, 0, 0, 0.1);
+        --input-context-menu-hover-bg-color: rgba(0, 0, 0, 0.1);
         --input-context-menu-li-color: #6b6a6a;
 
         /*Pkg status*/
@@ -160,19 +115,15 @@
         --pkg-terminal-border-color: #c3c3c3;
 
         /* run area*/
-        --pluto-runarea-bg-color:
-        hsl(0, 0, 97%);
-        --pluto-runarea-span-color:
-        hsl(353, 5%, 64%);
+        --pluto-runarea-bg-color: hsl(0, 0, 97%);
+        --pluto-runarea-span-color: hsl(353, 5%, 64%);
 
         /*drop ruler*/
-        --dropruler-bg-color:
-        rgba(0, 0, 0, 0.5);
+        --dropruler-bg-color: rgba(0, 0, 0, 0.5);
 
         /* jlerror */
         --jlerror-header-color: #4f1616;
-        --jlerror-mark-bg-color:
-        rgb(243 243 243);
+        --jlerror-mark-bg-color: rgb(243 243 243);
         --jlerror-a-bg-color: #f5efd9;
         --jlerror-a-border-left-color: #704141;
         --jlerror-mark-color: black;
@@ -181,10 +132,8 @@
         --helpbox-bg-color: white;
         --helpbox-box-shadow-color: #00000010;
         --helpbox-header-bg-color: #eef1f7;
-        --helpbox-header-color:
-        hsl(230, 14%, 11%);
-        --helpbox-notfound-header-color:
-        rgb(139, 139, 139);
+        --helpbox-header-color: hsl(230, 14%, 11%);
+        --helpbox-notfound-header-color: rgb(139, 139, 139);
         --helpbox-text-color: black;
         --code-section-bg-color: whitesmoke;
         --code-section-bg-color: #f3f3f3;
@@ -196,28 +145,21 @@
         --footer-input-border-color: #818181;
         --footer-filepicker-button-color: white;
         --footer-filepicker-focus-color: #896c6c;
-        --footnote-border-color:
-        rgba(23, 115, 119, 0.15);
+        --footnote-border-color: rgba(23, 115, 119, 0.15);
 
         /* undo delete cell*/
         --undo-delete-box-shadow-color: #0083;
 
         /*codemirror hints*/
-        --cm-editor-tooltip-border-color:
-        rgba(0, 0, 0, 0.2);
+        --cm-editor-tooltip-border-color: rgba(0, 0, 0, 0.2);
         --cm-editor-li-aria-selected-bg-color: #16659d;
         --cm-editor-li-aria-selected-color: white;
-        --cm-editor-li-notexported-color:
-        rgba(0, 0, 0, 0.5);
-        --code-background:
-        hsla(46, 90%, 98%, 1);
-        --cm-code-differs-gutters-color:
-        rgba(214, 172, 35, 0.2);
+        --cm-editor-li-notexported-color: rgba(0, 0, 0, 0.5);
+        --code-background: hsla(46, 90%, 98%, 1);
+        --cm-code-differs-gutters-color: rgba(214, 172, 35, 0.2);
         --cm-line-numbers-color: #8d86875e;
-        --cm-selection-background:
-        hsl(214deg 100% 73% / 48%);
-        --cm-selection-background-blurred:
-        hsl(214deg 0% 73% / 48%);
+        --cm-selection-background: hsl(214deg 100% 73% / 48%);
+        --cm-selection-background-blurred: hsl(214deg 0% 73% / 48%);
 
         /* code highlighting */
         --cm-editor-text-color: #41323f;
@@ -232,8 +174,7 @@
         --cm-var2-color: #37768a;
         --cm-builtin-color: #5e7ad3;
         --cm-function-color: #cc80ac;
-        --cm-type-color:
-        hsl(170deg 7% 56%);
+        --cm-type-color: hsl(170deg 7% 56%);
         --cm-bracket-color: #41323f;
         --cm-tag-color: #ef6155;
         --cm-link-color: #815ba4;
@@ -241,21 +182,17 @@
         --cm-error-color: #f7f7f7;
         --cm-matchingBracket-color: black;
         --cm-matchingBracket-bg-color: #1b4bbb21;
-        --cm-placeholder-text-color:
-        rgba(0, 0, 0, 0.2);
+        --cm-placeholder-text-color: rgba(0, 0, 0, 0.2);
 
         /*autocomplete menu*/
         --autocomplete-menu-bg-color: white;
 
         /* Landing colors */
-        --index-text-color:
-        hsl(0, 0, 60);
-        --index-clickable-text-color:
-        hsl(0, 0, 30);
+        --index-text-color: hsl(0, 0, 60);
+        --index-clickable-text-color: hsl(0, 0, 30);
         --docs-binding-bg: #8383830a;
         --index-card-bg: white;
-        --welcome-mywork-bg:
-        hsl(35deg 66% 93%);
+        --welcome-mywork-bg: hsl(35deg 66% 93%);
         --welcome-newnotebook-bg: whitesmoke;
         --welcome-recentnotebook-bg: white;
         --welcome-recentnotebook-border: #dfdfdf;

--- a/frontend/light_color.css
+++ b/frontend/light_color.css
@@ -48,7 +48,7 @@
 
         /*Pluto output styling */
         --pluto-schema-types-color:
-        rgba(0, 0, 0, 0.4);
+        rgb(0 0 0 / 51%);
         --pluto-schema-types-border-color:
         rgba(0, 0, 0, 0.2);
         --pluto-output-color:
@@ -104,8 +104,9 @@
 
         /* Logs */
         --pluto-logs-bg-color:
-        hsl(0deg 0% 97%);
+        hsl(0deg 0% 98%);
         --pluto-logs-progress-fill: #ffffff;
+        --pluto-logs-progress-bg: #e7e7e7;
         --pluto-logs-progress-border:
         hsl(210deg 16% 74%);
 

--- a/frontend/light_color.css
+++ b/frontend/light_color.css
@@ -33,7 +33,7 @@
         --export-card-shadow-color: #00000029;
 
         /*Pluto output styling */
-        --pluto-schema-types-color: rgb(0 0 0 / 51%);
+        --pluto-schema-types-color: rgba(0, 0, 0, 0.4);
         --pluto-schema-types-border-color: rgba(0, 0, 0, 0.2);
         --pluto-output-color: hsl(0, 0%, 25%);
         --pluto-output-h-color: hsl(0, 0%, 12%);
@@ -44,14 +44,14 @@
         --admonition-title-color: white;
         --jl-message-color: rgb(219 233 212);
         --jl-message-accent-color: rgb(158, 200, 137);
-        --jl-info-color: white;
-        --jl-info-accent-color: inherit;
+        --jl-info-color: rgb(214 227 244);
+        --jl-info-accent-color: rgb(148, 182, 226);
         --jl-warn-color: rgb(236 234 213);
-        --jl-warn-accent-color: #665f26;
+        --jl-warn-accent-color: rgb(207, 199, 138);
         --jl-danger-color: rgb(245 218 215);
-        --jl-danger-accent-color: rgb(172 66 52);
-        --jl-debug-color: rgb(236 223 247);
-        --jl-debug-accent-color: rgb(100 50 179);
+        --jl-danger-accent-color: rgb(226, 157, 148);
+        --jl-debug-color: rgb(245 218 215);
+        --jl-debug-accent-color: rgb(226, 157, 148);
         --footnote-border-color: rgba(23, 115, 119, 0.15);
         --table-border-color: rgba(0, 0, 0, 0.2);
         --table-bg-hover-color: rgba(159, 158, 224, 0.15);
@@ -70,9 +70,19 @@
 
         /* Logs */
         --pluto-logs-bg-color: hsl(0deg 0% 98%);
+        --pluto-logs-key-color: rgb(0 0 0 / 51%);
         --pluto-logs-progress-fill: #ffffff;
         --pluto-logs-progress-bg: #e7e7e7;
         --pluto-logs-progress-border: hsl(210deg 16% 74%);
+
+        --pluto-logs-info-color: white;
+        --pluto-logs-info-accent-color: inherit;
+        --pluto-logs-warn-color: rgb(236 234 213);
+        --pluto-logs-warn-accent-color: #665f26;
+        --pluto-logs-danger-color: rgb(245 218 215);
+        --pluto-logs-danger-accent-color: rgb(172 66 52);
+        --pluto-logs-debug-color: rgb(236 223 247);
+        --pluto-logs-debug-accent-color: rgb(100 50 179);
 
         /*Top navbar styling*/
         --nav-h1-text-color: black;

--- a/frontend/light_color.css
+++ b/frontend/light_color.css
@@ -5,10 +5,12 @@
 
         /* Color scheme */
         --main-bg-color: white;
-        --rule-color: rgba(0, 0, 0, 0.15);
+        --rule-color:
+        rgba(0, 0, 0, 0.15);
         --kbd-border-color: #dfdfdf;
         --header-bg-color: white;
-        --header-border-color: rgba(0, 0, 0, 0.1);
+        --header-border-color:
+        rgba(0, 0, 0, 0.1);
         --ui-button-color: #2a2a2b;
         --cursor-color: black;
         --normal-cell: 0, 0, 0;
@@ -16,77 +18,118 @@
         --error-color: 240, 168, 168;
 
         /*Cells*/
-        --normal-cell-color: rgba(var(--normal-cell), 0.1);
-        --dark-normal-cell-color: rgba(var(--normal-cell), 0.2);
-        --selected-cell-color: rgba(40, 78, 189, 0.4);
-        --code-differs-cell-color: rgba(var(--code-differs), 0.68);
-        --error-cell-color: rgba(var(--error-color), 0.7);
-        --bright-error-cell-color: rgb(var(--error-color));
-        --light-error-cell-color: rgba(var(--error-color), 0.05);
+        --normal-cell-color:
+        rgba(var(--normal-cell), 0.1);
+        --dark-normal-cell-color:
+        rgba(var(--normal-cell), 0.2);
+        --selected-cell-color:
+        rgba(40, 78, 189, 0.4);
+        --code-differs-cell-color:
+        rgba(var(--code-differs), 0.68);
+        --error-cell-color:
+        rgba(var(--error-color), 0.7);
+        --bright-error-cell-color:
+        rgb(var(--error-color));
+        --light-error-cell-color:
+        rgba(var(--error-color), 0.05);
 
         /*Export styling*/
-        --export-bg-color: rgb(60, 67, 101);
-        --export-color: rgba(255, 255, 255, 0.7);
-        --export-card-bg-color: rgba(255, 255, 255, 0.8);
-        --export-card-title-color: rgba(0, 0, 0, 0.7);
-        --export-card-text-color: rgba(0, 0, 0, 0.5);
+        --export-bg-color:
+        rgb(60, 67, 101);
+        --export-color:
+        rgba(255, 255, 255, 0.7);
+        --export-card-bg-color:
+        rgba(255, 255, 255, 0.8);
+        --export-card-title-color:
+        rgba(0, 0, 0, 0.7);
+        --export-card-text-color:
+        rgba(0, 0, 0, 0.5);
         --export-card-shadow-color: #00000029;
 
         /*Pluto output styling */
-        --pluto-schema-types-color: rgba(0, 0, 0, 0.4);
-        --pluto-schema-types-border-color: rgba(0, 0, 0, 0.2);
-        --pluto-output-color: hsl(0, 0%, 25%);
-        --pluto-output-h-color: hsl(0, 0%, 12%);
+        --pluto-schema-types-color:
+        rgba(0, 0, 0, 0.4);
+        --pluto-schema-types-border-color:
+        rgba(0, 0, 0, 0.2);
+        --pluto-output-color:
+        hsl(0, 0%, 25%);
+        --pluto-output-h-color:
+        hsl(0, 0%, 12%);
         --pluto-output-bg-color: white;
         --a-underline: #00000059;
         --blockquote-color: #555;
         --blockquote-bg: #f2f2f2;
         --admonition-title-color: white;
-        --jl-message-color: rgb(219 233 212);
-        --jl-message-accent-color: rgb(158, 200, 137);
-        --jl-info-color: rgb(214 227 244);
-        --jl-info-accent-color: rgb(148, 182, 226);
-        --jl-warn-color: rgb(236 234 213);
-        --jl-warn-accent-color: rgb(207, 199, 138);
-        --jl-danger-color: rgb(245 218 215);
-        --jl-danger-accent-color: rgb(226, 157, 148);
-        --jl-debug-color: rgb(245 218 215);
-        --jl-debug-accent-color: rgb(226, 157, 148);
-        --footnote-border-color: rgba(23, 115, 119, 0.15);
-        --table-border-color: rgba(0, 0, 0, 0.2);
-        --table-bg-hover-color: rgba(159, 158, 224, 0.15);
-        --pluto-tree-color: rgb(0 0 0 / 38%);
+        --jl-message-color:
+        rgb(219 233 212);
+        --jl-message-accent-color:
+        rgb(158, 200, 137);
+        --jl-info-color: transparent;
+        --jl-info-accent-color: inherit;
+        --jl-warn-color:
+        rgb(236 234 213);
+        --jl-warn-accent-color:
+        rgb(102 95 38);
+        --jl-danger-color:
+        rgb(245 218 215);
+        --jl-danger-accent-color:
+        rgb(172 66 52);
+        --jl-debug-color:
+        rgb(236 223 247);
+        --jl-debug-accent-color:
+        rgb(100 50 179);
+        --footnote-border-color:
+        rgba(23, 115, 119, 0.15);
+        --table-border-color:
+        rgba(0, 0, 0, 0.2);
+        --table-bg-hover-color:
+        rgba(159, 158, 224, 0.15);
+        --pluto-tree-color:
+        rgb(0 0 0 / 38%);
 
         /*pluto cell styling*/
-        --disabled-cell-bg-color: rgba(139, 139, 139, 0.25);
-        --selected-cell-bg-color: rgba(40, 78, 189, 0.24);
-        --hover-scrollbar-color-1: rgba(0, 0, 0, 0.15);
-        --hover-scrollbar-color-2: rgba(0, 0, 0, 0.05);
+        --disabled-cell-bg-color:
+        rgba(139, 139, 139, 0.25);
+        --selected-cell-bg-color:
+        rgba(40, 78, 189, 0.24);
+        --hover-scrollbar-color-1:
+        rgba(0, 0, 0, 0.15);
+        --hover-scrollbar-color-2:
+        rgba(0, 0, 0, 0.05);
         --skip-as-script-background-color: #ccc;
         --depends-on-skip-as-script-background-color: #eee;
 
         /* Pluto shoulders */
-        --shoulder-hover-bg-color: rgba(0, 0, 0, 0.05);
+        --shoulder-hover-bg-color:
+        rgba(0, 0, 0, 0.05);
 
         /* Logs */
-        --pluto-logs-bg-color: #efeff3;
+        --pluto-logs-bg-color: #f9f9f9;
         --pluto-logs-progress-fill: #ffffff;
-        --pluto-logs-progress-border: hsl(210deg 16% 74%);
+        --pluto-logs-progress-border:
+        hsl(210deg 16% 74%);
 
         /*Top navbar styling*/
         --nav-h1-text-color: black;
         --nav-filepicker-color: #6f6f6f;
         --nav-filepicker-border-color: #b2b2b2;
         --nav-process-status-bg-color: white;
-        --nav-process-status-color: var(--pluto-output-h-color);
+        --nav-process-status-color:
+        var(--pluto-output-h-color);
 
         /*header*/
-        --restart-recc-header-color: rgba(114, 192, 255, 0.56);
-        --restart-req-header-color: rgba(170, 41, 32, 0.56);
-        --dead-process-header-color: rgb(230 88 46 / 38%);
-        --loading-header-color: hsla(290, 10%, 80%, 0.5);
-        --disconnected-header-color: rgba(255, 169, 114, 0.56);
-        --binder-loading-header-color: hsl(51deg 64% 90% / 50%);
+        --restart-recc-header-color:
+        rgba(114, 192, 255, 0.56);
+        --restart-req-header-color:
+        rgba(170, 41, 32, 0.56);
+        --dead-process-header-color:
+        rgb(230 88 46 / 38%);
+        --loading-header-color:
+        hsla(290, 10%, 80%, 0.5);
+        --disconnected-header-color:
+        rgba(255, 169, 114, 0.56);
+        --binder-loading-header-color:
+        hsl(51deg 64% 90% / 50%);
 
         /*loading bar*/
         --loading-grad-color-1: #f1dba9;
@@ -98,10 +141,12 @@
         --overlay-button-border-save: #f3f2f2;
 
         /*input_context_menu*/
-        --input-context-menu-border-color: rgba(0, 0, 0, 0.1);
+        --input-context-menu-border-color:
+        rgba(0, 0, 0, 0.1);
         --input-context-menu-bg-color: white;
         --input-context-menu-soon-color: #55555544;
-        --input-context-menu-hover-bg-color: rgba(0, 0, 0, 0.1);
+        --input-context-menu-hover-bg-color:
+        rgba(0, 0, 0, 0.1);
         --input-context-menu-li-color: #6b6a6a;
 
         /*Pkg status*/
@@ -114,15 +159,19 @@
         --pkg-terminal-border-color: #c3c3c3;
 
         /* run area*/
-        --pluto-runarea-bg-color: hsl(0, 0, 97%);
-        --pluto-runarea-span-color: hsl(353, 5%, 64%);
+        --pluto-runarea-bg-color:
+        hsl(0, 0, 97%);
+        --pluto-runarea-span-color:
+        hsl(353, 5%, 64%);
 
         /*drop ruler*/
-        --dropruler-bg-color: rgba(0, 0, 0, 0.5);
+        --dropruler-bg-color:
+        rgba(0, 0, 0, 0.5);
 
         /* jlerror */
         --jlerror-header-color: #4f1616;
-        --jlerror-mark-bg-color: rgb(243 243 243);
+        --jlerror-mark-bg-color:
+        rgb(243 243 243);
         --jlerror-a-bg-color: #f5efd9;
         --jlerror-a-border-left-color: #704141;
         --jlerror-mark-color: black;
@@ -131,8 +180,10 @@
         --helpbox-bg-color: white;
         --helpbox-box-shadow-color: #00000010;
         --helpbox-header-bg-color: #eef1f7;
-        --helpbox-header-color: hsl(230, 14%, 11%);
-        --helpbox-notfound-header-color: rgb(139, 139, 139);
+        --helpbox-header-color:
+        hsl(230, 14%, 11%);
+        --helpbox-notfound-header-color:
+        rgb(139, 139, 139);
         --helpbox-text-color: black;
         --code-section-bg-color: whitesmoke;
         --code-section-bg-color: #f3f3f3;
@@ -144,21 +195,28 @@
         --footer-input-border-color: #818181;
         --footer-filepicker-button-color: white;
         --footer-filepicker-focus-color: #896c6c;
-        --footnote-border-color: rgba(23, 115, 119, 0.15);
+        --footnote-border-color:
+        rgba(23, 115, 119, 0.15);
 
         /* undo delete cell*/
         --undo-delete-box-shadow-color: #0083;
 
         /*codemirror hints*/
-        --cm-editor-tooltip-border-color: rgba(0, 0, 0, 0.2);
+        --cm-editor-tooltip-border-color:
+        rgba(0, 0, 0, 0.2);
         --cm-editor-li-aria-selected-bg-color: #16659d;
         --cm-editor-li-aria-selected-color: white;
-        --cm-editor-li-notexported-color: rgba(0, 0, 0, 0.5);
-        --code-background: hsla(46, 90%, 98%, 1);
-        --cm-code-differs-gutters-color: rgba(214, 172, 35, 0.2);
+        --cm-editor-li-notexported-color:
+        rgba(0, 0, 0, 0.5);
+        --code-background:
+        hsla(46, 90%, 98%, 1);
+        --cm-code-differs-gutters-color:
+        rgba(214, 172, 35, 0.2);
         --cm-line-numbers-color: #8d86875e;
-        --cm-selection-background: hsl(214deg 100% 73% / 48%);
-        --cm-selection-background-blurred: hsl(214deg 0% 73% / 48%);
+        --cm-selection-background:
+        hsl(214deg 100% 73% / 48%);
+        --cm-selection-background-blurred:
+        hsl(214deg 0% 73% / 48%);
 
         /* code highlighting */
         --cm-editor-text-color: #41323f;
@@ -173,7 +231,8 @@
         --cm-var2-color: #37768a;
         --cm-builtin-color: #5e7ad3;
         --cm-function-color: #cc80ac;
-        --cm-type-color: hsl(170deg 7% 56%);
+        --cm-type-color:
+        hsl(170deg 7% 56%);
         --cm-bracket-color: #41323f;
         --cm-tag-color: #ef6155;
         --cm-link-color: #815ba4;
@@ -181,17 +240,21 @@
         --cm-error-color: #f7f7f7;
         --cm-matchingBracket-color: black;
         --cm-matchingBracket-bg-color: #1b4bbb21;
-        --cm-placeholder-text-color: rgba(0, 0, 0, 0.2);
+        --cm-placeholder-text-color:
+        rgba(0, 0, 0, 0.2);
 
         /*autocomplete menu*/
         --autocomplete-menu-bg-color: white;
 
         /* Landing colors */
-        --index-text-color: hsl(0, 0, 60);
-        --index-clickable-text-color: hsl(0, 0, 30);
+        --index-text-color:
+        hsl(0, 0, 60);
+        --index-clickable-text-color:
+        hsl(0, 0, 30);
         --docs-binding-bg: #8383830a;
         --index-card-bg: white;
-        --welcome-mywork-bg: hsl(35deg 66% 93%);
+        --welcome-mywork-bg:
+        hsl(35deg 66% 93%);
         --welcome-newnotebook-bg: whitesmoke;
         --welcome-recentnotebook-bg: white;
         --welcome-recentnotebook-border: #dfdfdf;

--- a/frontend/light_color.css
+++ b/frontend/light_color.css
@@ -64,12 +64,11 @@
         rgb(219 233 212);
         --jl-message-accent-color:
         rgb(158, 200, 137);
-        --jl-info-color: transparent;
+        --jl-info-color: white;
         --jl-info-accent-color: inherit;
         --jl-warn-color:
         rgb(236 234 213);
-        --jl-warn-accent-color:
-        rgb(102 95 38);
+        --jl-warn-accent-color: #665f26;
         --jl-danger-color:
         rgb(245 218 215);
         --jl-danger-accent-color:
@@ -104,7 +103,8 @@
         rgba(0, 0, 0, 0.05);
 
         /* Logs */
-        --pluto-logs-bg-color: #f9f9f9;
+        --pluto-logs-bg-color:
+        hsl(0deg 0% 97%);
         --pluto-logs-progress-fill: #ffffff;
         --pluto-logs-progress-border:
         hsl(210deg 16% 74%);


### PR DESCRIPTION
Here is a much simpler design for the logs 🙃

The exciting ideas in #437 are not really working out: the horizontal timeline was too difficult to develop on my own. The main difficulty is that logs can vary greatly in size, and there are lots of tricky edge cases. The horizontal layout also needed an alternative for smaller screens, which was the vertical layout that we have before this PR. Difficult difficult!

This means that this PR loses the ability to see from which line a log originates, we need to add that back somehow...

![Schermafbeelding 2022-09-27 om 15 08 52](https://user-images.githubusercontent.com/6933510/192534976-2759df63-8ab0-4ee7-b85c-3d925fc05ac5.png)

![Schermafbeelding 2022-09-27 om 15 09 07](https://user-images.githubusercontent.com/6933510/192535040-8d5cb06c-be15-4754-981d-8c259b4684f1.png)

Still better than a terminal :)

https://user-images.githubusercontent.com/6933510/192535186-02f25fb9-72bf-4e8e-a0c0-c65f3f8a1b08.mov

![Schermafbeelding 2022-09-27 om 15 10 36](https://user-images.githubusercontent.com/6933510/192535368-b36a23be-bbf1-40fe-ae02-80014000ce2e.png)
![Schermafbeelding 2022-09-27 om 15 10 57](https://user-images.githubusercontent.com/6933510/192535450-a5047881-2a91-4135-987f-76a7af209e8b.png)
![Schermafbeelding 2022-09-27 om 15 11 06](https://user-images.githubusercontent.com/6933510/192535473-15531f7e-ddd4-4164-84b6-c5efc5bf3d04.png)


# TODO:
- [x] Disable lazy loading...
- [x] I also changed the `! info` markdown callout colors by accident