### PR TITLE
PlutoPkg: if Pkg.resolve fails, try updating the registries

### DIFF
--- a/src/Pluto.jl
+++ b/src/Pluto.jl
@@ -72,6 +72,7 @@ include("./analysis/MoreAnalysis.jl")
 
 include("./evaluation/WorkspaceManager.jl")
 include("./evaluation/MacroAnalysis.jl")
+include("./packages/IOListener.jl")
 include("./packages/Packages.jl")
 include("./packages/PkgUtils.jl")
 include("./evaluation/Run.jl")

--- a/src/packages/IOListener.jl
+++ b/src/packages/IOListener.jl
@@ -1,0 +1,32 @@
+
+"A polling system to watch for writes to an IOBuffer. Up-to-date content will be passed as string to the `callback` function."
+Base.@kwdef struct IOListener
+    callback::Function
+    buffer::IOBuffer=IOBuffer()
+    interval::Real=1.0/60
+    running::Ref{Bool}=Ref(false)
+    last_size::Ref{Int}=Ref(-1)
+end
+function trigger(listener::IOListener)
+    new_size = listener.buffer.size
+    if new_size > listener.last_size[]
+        listener.last_size[] = new_size
+        new_contents = String(listener.buffer.data[1:new_size])
+        listener.callback(new_contents)
+    end
+end
+function startlistening(listener::IOListener)
+    if !listener.running[]
+        listener.running[] = true
+        @async while listener.running[]
+            trigger(listener)
+            sleep(listener.interval)
+        end
+    end
+end
+function stoplistening(listener::IOListener)
+    if listener.running[]
+        listener.running[] = false
+        trigger(listener)
+    end
+end

--- a/src/packages/Packages.jl
+++ b/src/packages/Packages.jl
@@ -532,35 +532,3 @@ function withinteractive(f::Function, value::Bool)
         end
     end
 end
-
-"A polling system to watch for writes to an IOBuffer. Up-to-date content will be passed as string to the `callback` function."
-Base.@kwdef struct IOListener
-    callback::Function
-    buffer::IOBuffer=IOBuffer()
-    interval::Real=1.0/60
-    running::Ref{Bool}=Ref(false)
-    last_size::Ref{Int}=Ref(-1)
-end
-function trigger(listener::IOListener)
-    new_size = listener.buffer.size
-    if new_size > listener.last_size[]
-        listener.last_size[] = new_size
-        new_contents = String(listener.buffer.data[1:new_size])
-        listener.callback(new_contents)
-    end
-end
-function startlistening(listener::IOListener)
-    if !listener.running[]
-        listener.running[] = true
-        @async while listener.running[]
-            trigger(listener)
-            sleep(listener.interval)
-        end
-    end
-end
-function stoplistening(listener::IOListener)
-    if listener.running[]
-        listener.running[] = false
-        trigger(listener)
-    end
-end

--- a/src/packages/PkgCompat.jl
+++ b/src/packages/PkgCompat.jl
@@ -198,7 +198,7 @@ end
 """
 Check when the registries were last updated. If it is recent (max 7 days), then `Pkg.UPDATED_REGISTRY_THIS_SESSION[]` is set to `true`, which will prevent Pkg from doing an automatic registry update.
 
-Returns the new value of `Pkg.UPDATED_REGISTRY_THIS_SESSION`.
+Returns the new value of `Pkg.UPDATED_REGISTRY_THIS_SESSION[]`.
 """
 function check_registry_age(max_age_ms = 1000.0 * 60 * 60 * 24 * 7)::Bool
 	if get(ENV, "GITHUB_ACTIONS", "false") == "true"
@@ -208,7 +208,7 @@ function check_registry_age(max_age_ms = 1000.0 * 60 * 60 * 24 * 7)::Bool
 	paths = _get_registry_paths()
 	isempty(paths) && return _updated_registries_compat[]
 	
-	ages = map(paths) do p
+	mtimes = map(paths) do p
 		try
 			mtime(p)
 		catch
@@ -216,7 +216,7 @@ function check_registry_age(max_age_ms = 1000.0 * 60 * 60 * 24 * 7)::Bool
 		end
 	end
 	
-	if all(ages .> time() - max_age_ms)
+	if all(mtimes .> time() - max_age_ms)
 		_updated_registries_compat[] = true
 	end
 	_updated_registries_compat[]


### PR DESCRIPTION
When opening a notebook (e.g. from the web), we call `Pkg.resolve` on the notebook environment. If this fails, we try some strategies one-by-one to automatically fix the problem until it resolves. These strategies are:

1. Force update registries _(added in this PR)_
2. Remove the Manifest.toml
3. Remove the Manifest.toml and all `[compat]` entries from the Project.toml _(added in #2294)_

This should improve the situation of #2280. Before this PR, Pluto would try strategy 2, fail, then strategy 3 which works. But this removes all compat entries for all packages, including packages that had no problems, and installs latest versions for all. 
After this PR, strategy 1 would already work, and the notebook would run with the intended package versions.