### PR TITLE
Allow rich MIME override

### DIFF
--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -143,6 +143,7 @@ These options are not intended to be changed during normal use.
 - `workspace_use_distributed::Bool = $WORKSPACE_USE_DISTRIBUTED_DEFAULT` Whether to start notebooks in a separate process.
 - `lazy_workspace_creation::Bool = $LAZY_WORKSPACE_CREATION_DEFAULT`
 - `capture_stdout::Bool = $CAPTURE_STDOUT_DEFAULT`
+- `extra_preamble::Union{Nothing,Expr} = $EXTRA_PREAMBLE_DEFAULT`
 """
 @option mutable struct EvaluationOptions
     run_notebook_on_load::Bool = RUN_NOTEBOOK_ON_LOAD_DEFAULT

--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -131,11 +131,13 @@ const RUN_NOTEBOOK_ON_LOAD_DEFAULT = true
 const WORKSPACE_USE_DISTRIBUTED_DEFAULT = true
 const LAZY_WORKSPACE_CREATION_DEFAULT = false
 const CAPTURE_STDOUT_DEFAULT = true
+const EXTRA_PREAMBLE_DEFAULT = nothing
 
 """
     EvaluationOptions([; kwargs...])
 
-Options to change Pluto's evaluation behaviour during internal testing. These options are not intended to be changed during normal use.
+Options to change Pluto's evaluation behaviour during internal testing and by downstream packages.
+These options are not intended to be changed during normal use.
 
 - `run_notebook_on_load::Bool = $RUN_NOTEBOOK_ON_LOAD_DEFAULT` Whether to evaluate a notebook on load.
 - `workspace_use_distributed::Bool = $WORKSPACE_USE_DISTRIBUTED_DEFAULT` Whether to start notebooks in a separate process.
@@ -147,6 +149,7 @@ Options to change Pluto's evaluation behaviour during internal testing. These op
     workspace_use_distributed::Bool = WORKSPACE_USE_DISTRIBUTED_DEFAULT
     lazy_workspace_creation::Bool = LAZY_WORKSPACE_CREATION_DEFAULT
     capture_stdout::Bool = CAPTURE_STDOUT_DEFAULT
+    extra_preamble::Union{Nothing,Expr} = EXTRA_PREAMBLE_DEFAULT
 end
 
 const COMPILE_DEFAULT = nothing
@@ -253,6 +256,7 @@ function from_flat_kwargs(;
         workspace_use_distributed::Bool = WORKSPACE_USE_DISTRIBUTED_DEFAULT,
         lazy_workspace_creation::Bool = LAZY_WORKSPACE_CREATION_DEFAULT,
         capture_stdout::Bool = CAPTURE_STDOUT_DEFAULT,
+        extra_preamble::Expr = EXTRA_PREAMBLE_DEFAULT,
         compile::Union{Nothing,String} = COMPILE_DEFAULT,
         sysimage::Union{Nothing,String} = SYSIMAGE_DEFAULT,
         banner::Union{Nothing,String} = BANNER_DEFAULT,
@@ -292,6 +296,7 @@ function from_flat_kwargs(;
         workspace_use_distributed,
         lazy_workspace_creation,
         capture_stdout,
+        extra_preamble,
     )
     compiler = CompilerOptions(;
         compile,

--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -256,7 +256,7 @@ function from_flat_kwargs(;
         workspace_use_distributed::Bool = WORKSPACE_USE_DISTRIBUTED_DEFAULT,
         lazy_workspace_creation::Bool = LAZY_WORKSPACE_CREATION_DEFAULT,
         capture_stdout::Bool = CAPTURE_STDOUT_DEFAULT,
-        extra_preamble::Expr = EXTRA_PREAMBLE_DEFAULT,
+        extra_preamble::Union{Nothing,Expr} = EXTRA_PREAMBLE_DEFAULT,
         compile::Union{Nothing,String} = COMPILE_DEFAULT,
         sysimage::Union{Nothing,String} = SYSIMAGE_DEFAULT,
         banner::Union{Nothing,String} = BANNER_DEFAULT,

--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -131,7 +131,7 @@ const RUN_NOTEBOOK_ON_LOAD_DEFAULT = true
 const WORKSPACE_USE_DISTRIBUTED_DEFAULT = true
 const LAZY_WORKSPACE_CREATION_DEFAULT = false
 const CAPTURE_STDOUT_DEFAULT = true
-const EXTRA_PREAMBLE_DEFAULT = nothing
+const WORKSPACE_CUSTOM_STARTUP_EXPR_DEFAULT = nothing
 
 """
     EvaluationOptions([; kwargs...])
@@ -143,14 +143,14 @@ These options are not intended to be changed during normal use.
 - `workspace_use_distributed::Bool = $WORKSPACE_USE_DISTRIBUTED_DEFAULT` Whether to start notebooks in a separate process.
 - `lazy_workspace_creation::Bool = $LAZY_WORKSPACE_CREATION_DEFAULT`
 - `capture_stdout::Bool = $CAPTURE_STDOUT_DEFAULT`
-- `extra_preamble::Union{Nothing,Expr} = $EXTRA_PREAMBLE_DEFAULT`
+- `workspace_custom_startup_expr::Union{Nothing,Expr} = $WORKSPACE_CUSTOM_STARTUP_EXPR_DEFAULT` An expression to be evaluated in the workspace process before running notebook code.
 """
 @option mutable struct EvaluationOptions
     run_notebook_on_load::Bool = RUN_NOTEBOOK_ON_LOAD_DEFAULT
     workspace_use_distributed::Bool = WORKSPACE_USE_DISTRIBUTED_DEFAULT
     lazy_workspace_creation::Bool = LAZY_WORKSPACE_CREATION_DEFAULT
     capture_stdout::Bool = CAPTURE_STDOUT_DEFAULT
-    extra_preamble::Union{Nothing,Expr} = EXTRA_PREAMBLE_DEFAULT
+    workspace_custom_startup_expr::Union{Nothing,Expr} = WORKSPACE_CUSTOM_STARTUP_EXPR_DEFAULT
 end
 
 const COMPILE_DEFAULT = nothing
@@ -257,7 +257,7 @@ function from_flat_kwargs(;
         workspace_use_distributed::Bool = WORKSPACE_USE_DISTRIBUTED_DEFAULT,
         lazy_workspace_creation::Bool = LAZY_WORKSPACE_CREATION_DEFAULT,
         capture_stdout::Bool = CAPTURE_STDOUT_DEFAULT,
-        extra_preamble::Union{Nothing,Expr} = EXTRA_PREAMBLE_DEFAULT,
+        workspace_custom_startup_expr::Union{Nothing,Expr} = WORKSPACE_CUSTOM_STARTUP_EXPR_DEFAULT,
         compile::Union{Nothing,String} = COMPILE_DEFAULT,
         sysimage::Union{Nothing,String} = SYSIMAGE_DEFAULT,
         banner::Union{Nothing,String} = BANNER_DEFAULT,
@@ -297,7 +297,7 @@ function from_flat_kwargs(;
         workspace_use_distributed,
         lazy_workspace_creation,
         capture_stdout,
-        extra_preamble,
+        workspace_custom_startup_expr,
     )
     compiler = CompilerOptions(;
         compile,

--- a/src/evaluation/WorkspaceManager.jl
+++ b/src/evaluation/WorkspaceManager.jl
@@ -60,14 +60,9 @@ function make_workspace((session, notebook)::SN; is_offline_renderer::Bool=false
         pid
     end
 
-    Distributed.remotecall_eval(Main, [pid], :(PlutoRunner.notebook_id[] = $(notebook.notebook_id)))
+    Distributed.remotecall_eval(Main, [pid], session.options.evaluation.workspace_custom_startup_expr)
 
-    let
-        extra_preamble = session.options.evaluation.extra_preamble
-        if !isnothing(extra_preamble)
-            Distributed.remotecall_eval(Main, [pid], extra_preamble)
-        end
-    end
+    Distributed.remotecall_eval(Main, [pid], :(PlutoRunner.notebook_id[] = $(notebook.notebook_id)))
 
     remote_log_channel = Core.eval(Main, quote
         $(Distributed).RemoteChannel(() -> eval(quote

--- a/src/evaluation/WorkspaceManager.jl
+++ b/src/evaluation/WorkspaceManager.jl
@@ -62,6 +62,13 @@ function make_workspace((session, notebook)::SN; is_offline_renderer::Bool=false
 
     Distributed.remotecall_eval(Main, [pid], :(PlutoRunner.notebook_id[] = $(notebook.notebook_id)))
 
+    let
+        extra_preamble = session.options.evaluation.extra_preamble
+        if !isnothing(extra_preamble)
+            Distributed.remotecall_eval(Main, [pid], extra_preamble)
+        end
+    end
+
     remote_log_channel = Core.eval(Main, quote
         $(Distributed).RemoteChannel(() -> eval(quote
         

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -1094,14 +1094,6 @@ This defaults to `true`, but additional dispatches can be set to `false` by down
 """
 is_mime_enabled(::MIME) = true
 
-"""
-    is_tree_viewer_enabled(::MIME) -> Bool
-
-Return whether Pluto's tree viewer should be used for the argument's mimetype.
-This defaults to `true`, but additional dispatches can be set to `false` by downstream packages.
-"""
-is_tree_viewer_enabled(::MIME) = true
-
 "Return the first mimetype in `allmimes` which can show `x`."
 function mimetype(x)
     # ugly code to fix an ugly performance problem
@@ -1121,7 +1113,7 @@ Like two-argument `Base.show`, except:
 function show_richest(io::IO, @nospecialize(x))::Tuple{<:Any,MIME}
     mime = mimetype(x)
 
-    if mime isa MIME"text/plain" && is_tree_viewer_enabled(mime) && use_tree_viewer_for_struct(x)
+    if mime isa MIME"text/plain" && is_mime_enabled(MIME"application/vnd.pluto.tree+object"()) && use_tree_viewer_for_struct(x)
         tree_data(x, io), MIME"application/vnd.pluto.tree+object"()
     elseif mime isa MIME"application/vnd.pluto.tree+object"
         try

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -947,7 +947,7 @@ const default_stdout_iocontext = IOContext(devnull,
     :is_pluto => false,
 )
 
-const imagemimes = [MIME"image/svg+xml"(), MIME"image/png"(), MIME"image/jpg"(), MIME"image/jpeg"(), MIME"image/bmp"(), MIME"image/gif"()]
+const imagemimes = MIME[MIME"image/svg+xml"(), MIME"image/png"(), MIME"image/jpg"(), MIME"image/jpeg"(), MIME"image/bmp"(), MIME"image/gif"()]
 # in descending order of coolness
 # text/plain always matches - almost always
 """

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -955,7 +955,7 @@ The MIMEs that Pluto supports, in order of how much I like them.
 
 `text/plain` should always match - the difference between `show(::IO, ::MIME"text/plain", x)` and `show(::IO, x)` is an unsolved mystery.
 """
-const allmimes = [MIME"application/vnd.pluto.table+object"(); MIME"application/vnd.pluto.divelement+object"(); MIME"text/html"(); imagemimes; MIME"application/vnd.pluto.tree+object"(); MIME"text/latex"(); MIME"text/plain"()]
+const allmimes = MIME[MIME"application/vnd.pluto.table+object"(); MIME"application/vnd.pluto.divelement+object"(); MIME"text/html"(); imagemimes; MIME"application/vnd.pluto.tree+object"(); MIME"text/latex"(); MIME"text/plain"()]
 
 
 """
@@ -1086,11 +1086,27 @@ function use_tree_viewer_for_struct(@nospecialize(x::T))::Bool where T
     end
 end
 
+"""
+    is_mime_enabled(::MIME) -> Bool
+
+Return whether the argument's mimetype is enabled.
+This defaults to `true`, but additional dispatches can be set to `false` by downstream packages.
+"""
+is_mime_enabled(::MIME) = true
+
+"""
+    is_tree_viewer_enabled(::MIME) -> Bool
+
+Return whether Pluto's tree viewer should be used for the argument's mimetype.
+This defaults to `true`, but additional dispatches can be set to `false` by downstream packages.
+"""
+is_tree_viewer_enabled(::MIME) = true
+
 "Return the first mimetype in `allmimes` which can show `x`."
 function mimetype(x)
     # ugly code to fix an ugly performance problem
     for m in allmimes
-        if pluto_showable(m, x)
+        if pluto_showable(m, x) && is_mime_enabled(m)
             return m
         end
     end
@@ -1105,7 +1121,7 @@ Like two-argument `Base.show`, except:
 function show_richest(io::IO, @nospecialize(x))::Tuple{<:Any,MIME}
     mime = mimetype(x)
 
-    if mime isa MIME"text/plain" && use_tree_viewer_for_struct(x)
+    if mime isa MIME"text/plain" && is_tree_viewer_enabled(mime) && use_tree_viewer_for_struct(x)
         tree_data(x, io), MIME"application/vnd.pluto.tree+object"()
     elseif mime isa MIME"application/vnd.pluto.tree+object"
         try

--- a/test/Configuration.jl
+++ b/test/Configuration.jl
@@ -164,6 +164,26 @@ end
 
 end
 
+@testset "extra_preamble" begin
+    client = ClientSession(:fake, nothing)
+    🍭 = ServerSession()
+    🍭.options.evaluation.workspace_use_distributed = true
+    🍭.options.evaluation.extra_preamble = quote
+        PlutoRunner.is_mime_enabled(::MIME"foobar") = false
+    end
+    🍭.connected_clients[client.id] = client
+
+    nb = Pluto.Notebook([
+        Pluto.Cell("""@assert !PlutoRunner.is_mime_enabled(MIME"foobar"())""")
+    ])
+    client.connected_notebook = nb
+
+    Pluto.update_run!(🍭, nb, nb.cells)
+    @test nb.cells[1] |> noerror
+
+    Pluto.WorkspaceManager.unmake_workspace((🍭, nb))
+end
+
 # TODO are the processes closed properly?
 # TODO we reuse the same port without awaiting the shutdown of the previous server
 

--- a/test/Configuration.jl
+++ b/test/Configuration.jl
@@ -171,11 +171,14 @@ end
 
     nb = Pluto.Notebook([
         Pluto.Cell("x = [1, 2]")
+        Pluto.Cell("struct Foo; x; end")
+        Pluto.Cell("Foo(x)")
     ])
 
     Pluto.update_run!(🍭, nb, nb.cells)
     @test nb.cells[1].output.body == repr(MIME"text/plain"(), [1,2])
     @test nb.cells[1].output.mime isa MIME"text/plain"
+    @test nb.cells[3].output.mime isa MIME"text/plain"
 
     Pluto.WorkspaceManager.unmake_workspace((🍭, nb))
 end

--- a/test/Configuration.jl
+++ b/test/Configuration.jl
@@ -164,22 +164,22 @@ end
 
 end
 
-@testset "extra_preamble" begin
+@testset "disable mimetype via extra_preamble" begin
     client = ClientSession(:fake, nothing)
     🍭 = ServerSession()
     🍭.options.evaluation.workspace_use_distributed = true
     🍭.options.evaluation.extra_preamble = quote
-        PlutoRunner.is_mime_enabled(::MIME"foobar") = false
+        PlutoRunner.is_mime_enabled(m::MIME"application/vnd.pluto.tree+object") = false
     end
     🍭.connected_clients[client.id] = client
 
     nb = Pluto.Notebook([
-        Pluto.Cell("""@assert !PlutoRunner.is_mime_enabled(MIME"foobar"())""")
+        Pluto.Cell("x = [1, 2]")
     ])
     client.connected_notebook = nb
 
     Pluto.update_run!(🍭, nb, nb.cells)
-    @test nb.cells[1] |> noerror
+    @test nb.cells[1].output.body == "2-element Vector{Int64}:\n 1\n 2"
 
     Pluto.WorkspaceManager.unmake_workspace((🍭, nb))
 end


### PR DESCRIPTION
As discussed with you (Fons) earlier, [PlutoStaticHTML.jl](https://github.com/rikhuijzer/PlutoStaticHTML.jl/) and a project of yours have a bit difficulty with some of the transformations that the `PlutoRunner` applies. Some of the transformations create complex objects which are difficult to convert back to simpler output formats such as HTML and Markdown. Downstream packages can override functions as a workaround, but that results in "incremental compilation may be fatally broken" warnings.

This PR allows downstream packages to override some settings inside `PlutoRunner` by passing an `Expr` to `session.options.evaluation.extra_preamble`. The benefit of passing this `Expr` option is that different overrides can be passed to different distributed workers. In other words, the benefit of passing is that it doesn't require global modifications of the method tables.

A companion PR is at https://github.com/rikhuijzer/PlutoStaticHTML.jl/pull/145. Note the simplification of `src/mimeoverride.jl`. This PR doesn't fix "incremental compilation fatally broken" yet, but it is a step in the right direction.