### PR TITLE
Fix method invalidations around `Base.convert`

### DIFF
--- a/src/notebook/Cell.jl
+++ b/src/notebook/Cell.jl
@@ -74,10 +74,6 @@ function Base.convert(::Type{Cell}, cell::Dict)
         metadata=cell["metadata"],
     )
 end
-function Base.convert(::Type{UUID}, string::String)
-    UUID(string)
-end
-
 
 "Returns whether or not the cell is **explicitely** disabled."
 is_disabled(c::Cell) = get(c.metadata, METADATA_DISABLED_KEY, DEFAULT_CELL_METADATA[METADATA_DISABLED_KEY])

--- a/src/webserver/Dynamic.jl
+++ b/src/webserver/Dynamic.jl
@@ -181,7 +181,7 @@ function send_notebook_changes!(🙋::ClientRequest; commentary::Any=nothing)
         if client.connected_notebook !== nothing && client.connected_notebook.notebook_id == 🙋.notebook.notebook_id
             current_dict = get(current_state_for_clients, client, :empty)
             patches = Firebasey.diff(current_dict, notebook_dict)
-            patches_as_dicts::Array{Dict} = patches
+            patches_as_dicts::Array{Dict} = Firebasey._convert(Array{Dict}, patches)
             current_state_for_clients[client] = deep_enough_copy(notebook_dict)
 
             # Make sure we do send a confirmation to the client who made the request, even without changes

--- a/src/webserver/Firebasey.jl
+++ b/src/webserver/Firebasey.jl
@@ -227,9 +227,6 @@ function Base.convert(::Type{Dict}, patch::RemovePatch)
 	Dict{String,Any}("op" => "remove", "path" => patch.path)
 end
 
-# ╔═╡ fafcb8b8-cde9-4f99-9bab-8128025953a4
-nothing
-
 # ╔═╡ 921a130e-b028-4f91-b077-3bd79dcb6c6d
 function Base.convert(::Type{JSONPatch}, patch_dict::Dict)
 	op = patch_dict["op"]
@@ -254,12 +251,6 @@ Base.convert(Dict, AddPatch([:x, :y], 10))
 # ╠═╡ skip_as_script = true
 #=╠═╡
 Base.convert(Dict, RemovePatch([:x, :y]))
-  ╠═╡ =#
-
-# ╔═╡ 7feeee3a-3aec-47ce-b8d7-74a0d9b0b381
-# ╠═╡ skip_as_script = true
-#=╠═╡
-Base.convert(Dict, ReplacePatch([:x, :y], 10))
   ╠═╡ =#
 
 # ╔═╡ 6d67f8a5-0e0c-4b6e-a267-96b34d580946
@@ -716,6 +707,12 @@ begin
     end
 end
 
+# ╔═╡ 7feeee3a-3aec-47ce-b8d7-74a0d9b0b381
+# ╠═╡ skip_as_script = true
+#=╠═╡
+_convert(Dict, ReplacePatch([:x, :y], 10))
+  ╠═╡ =#
+
 # ╔═╡ dd87ca7e-2de1-11eb-2ec3-d5721c32f192
 function applypatch!(value, patch::AddPatch)
 	if length(patch.path) == 0
@@ -1051,7 +1048,7 @@ end
 
 # ╔═╡ 34d86e02-dd34-4691-bb78-3023568a5d16
 #=╠═╡
-@track Base.convert(JSONPatch, convert(Dict, replace_patch)) == replace_patch
+@track Base.convert(JSONPatch, _convert(Dict, replace_patch)) == replace_patch
   ╠═╡ =#
 
 # ╔═╡ 95ff676d-73c8-44cb-ac35-af94418737e9
@@ -1161,7 +1158,6 @@ end
 # ╟─07eeb122-6706-4544-a007-1c8d6581eec8
 # ╠═b48e2c08-a94a-4247-877d-949d92dde626
 # ╟─c59b30b9-f702-41f1-bb2e-1736c8cd5ede
-# ╠═fafcb8b8-cde9-4f99-9bab-8128025953a4
 # ╟─7feeee3a-3aec-47ce-b8d7-74a0d9b0b381
 # ╠═921a130e-b028-4f91-b077-3bd79dcb6c6d
 # ╟─6d67f8a5-0e0c-4b6e-a267-96b34d580946

--- a/src/webserver/Firebasey.jl
+++ b/src/webserver/Firebasey.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.9
+# v0.19.12
 
 using Markdown
 using InteractiveUtils
@@ -702,6 +702,18 @@ end
 md"### applypatch! AddPatch"
   ╠═╡ =#
 
+# ╔═╡ d7ea6052-9d9f-48e3-92fb-250afd69e417
+begin
+    _convert(::Type{Base.UUID}, s::String) = Base.UUID(s)
+    _convert(::Type{T}, a::AbstractArray) where {T<:Array} = _convert.(eltype(T), a)
+    _convert(x, y) = convert(x, y)
+
+    function _setproperty!(x, f::Symbol, v)
+        type = fieldtype(typeof(x), f)
+        return setfield!(x, f, _convert(type, v))
+    end
+end
+
 # ╔═╡ dd87ca7e-2de1-11eb-2ec3-d5721c32f192
 function applypatch!(value, patch::AddPatch)
 	if length(patch.path) == 0
@@ -721,7 +733,7 @@ function applypatch!(value, patch::AddPatch)
 			if strict_applypatch[]
 				@assert getproperty(subvalue, key) === nothing
 			end
-			setproperty!(subvalue, key, patch.value)
+			_setproperty!(subvalue, key, patch.value)
 		end
 	end
 	return value
@@ -758,7 +770,7 @@ function applypatch!(value, patch::ReplacePatch)
 			if strict_applypatch[]
 				@assert getproperty(subvalue, key) !== nothing
 			end
-			setproperty!(subvalue, key, patch.value)
+			_setproperty!(subvalue, key, patch.value)
 		end
 	end
 	return value
@@ -795,7 +807,7 @@ function applypatch!(value, patch::RemovePatch)
 			if strict_applypatch[]
 				@assert getproperty(subvalue, key) !== nothing
 			end
-			setproperty!(subvalue, key, nothing)
+			_setproperty!(subvalue, key, nothing)
 		end
 	end
 	return value
@@ -1220,6 +1232,7 @@ end
 # ╠═48a45941-2489-4666-b4e5-88d3f82e5145
 # ╠═752b2da3-ff24-4758-8843-186368069888
 # ╟─3e285076-1d97-4728-87cf-f71b22569e57
+# ╠═d7ea6052-9d9f-48e3-92fb-250afd69e417
 # ╠═dd87ca7e-2de1-11eb-2ec3-d5721c32f192
 # ╟─c3e4738f-4568-4910-a211-6a46a9d447ee
 # ╟─a11e4082-4ff4-4c1b-9c74-c8fa7dcceaa6

--- a/src/webserver/Firebasey.jl
+++ b/src/webserver/Firebasey.jl
@@ -227,11 +227,6 @@ function Base.convert(::Type{Dict}, patch::RemovePatch)
 	Dict{String,Any}("op" => "remove", "path" => patch.path)
 end
 
-# ╔═╡ fafcb8b8-cde9-4f99-9bab-8128025953a4
-function Base.convert(::Type{<:Dict}, patch::ReplacePatch)
-	Dict{String,Any}("op" => "replace", "path" => patch.path, "value" => patch.value)
-end
-
 # ╔═╡ 921a130e-b028-4f91-b077-3bd79dcb6c6d
 function Base.convert(::Type{JSONPatch}, patch_dict::Dict)
 	op = patch_dict["op"]
@@ -256,12 +251,6 @@ Base.convert(Dict, AddPatch([:x, :y], 10))
 # ╠═╡ skip_as_script = true
 #=╠═╡
 Base.convert(Dict, RemovePatch([:x, :y]))
-  ╠═╡ =#
-
-# ╔═╡ 7feeee3a-3aec-47ce-b8d7-74a0d9b0b381
-# ╠═╡ skip_as_script = true
-#=╠═╡
-Base.convert(Dict, ReplacePatch([:x, :y], 10))
   ╠═╡ =#
 
 # ╔═╡ 6d67f8a5-0e0c-4b6e-a267-96b34d580946
@@ -708,11 +697,21 @@ begin
     _convert(::Type{T}, a::AbstractArray) where {T<:Array} = _convert.(eltype(T), a)
     _convert(x, y) = convert(x, y)
 
+    function _convert(::Type{<:Dict}, patch::ReplacePatch)
+        Dict{String,Any}("op" => "replace", "path" => patch.path, "value" => patch.value)
+    end
+
     function _setproperty!(x, f::Symbol, v)
         type = fieldtype(typeof(x), f)
         return setfield!(x, f, _convert(type, v))
     end
 end
+
+# ╔═╡ 7feeee3a-3aec-47ce-b8d7-74a0d9b0b381
+# ╠═╡ skip_as_script = true
+#=╠═╡
+_convert(Dict, ReplacePatch([:x, :y], 10))
+  ╠═╡ =#
 
 # ╔═╡ dd87ca7e-2de1-11eb-2ec3-d5721c32f192
 function applypatch!(value, patch::AddPatch)
@@ -1049,7 +1048,7 @@ end
 
 # ╔═╡ 34d86e02-dd34-4691-bb78-3023568a5d16
 #=╠═╡
-@track Base.convert(JSONPatch, convert(Dict, replace_patch)) == replace_patch
+@track _convert(JSONPatch, convert(Dict, replace_patch)) == replace_patch
   ╠═╡ =#
 
 # ╔═╡ 95ff676d-73c8-44cb-ac35-af94418737e9
@@ -1159,7 +1158,6 @@ end
 # ╟─07eeb122-6706-4544-a007-1c8d6581eec8
 # ╠═b48e2c08-a94a-4247-877d-949d92dde626
 # ╟─c59b30b9-f702-41f1-bb2e-1736c8cd5ede
-# ╠═fafcb8b8-cde9-4f99-9bab-8128025953a4
 # ╟─7feeee3a-3aec-47ce-b8d7-74a0d9b0b381
 # ╠═921a130e-b028-4f91-b077-3bd79dcb6c6d
 # ╟─6d67f8a5-0e0c-4b6e-a267-96b34d580946

--- a/src/webserver/Firebasey.jl
+++ b/src/webserver/Firebasey.jl
@@ -227,6 +227,9 @@ function Base.convert(::Type{Dict}, patch::RemovePatch)
 	Dict{String,Any}("op" => "remove", "path" => patch.path)
 end
 
+# ╔═╡ fafcb8b8-cde9-4f99-9bab-8128025953a4
+nothing
+
 # ╔═╡ 921a130e-b028-4f91-b077-3bd79dcb6c6d
 function Base.convert(::Type{JSONPatch}, patch_dict::Dict)
 	op = patch_dict["op"]
@@ -251,6 +254,12 @@ Base.convert(Dict, AddPatch([:x, :y], 10))
 # ╠═╡ skip_as_script = true
 #=╠═╡
 Base.convert(Dict, RemovePatch([:x, :y]))
+  ╠═╡ =#
+
+# ╔═╡ 7feeee3a-3aec-47ce-b8d7-74a0d9b0b381
+# ╠═╡ skip_as_script = true
+#=╠═╡
+Base.convert(Dict, ReplacePatch([:x, :y], 10))
   ╠═╡ =#
 
 # ╔═╡ 6d67f8a5-0e0c-4b6e-a267-96b34d580946
@@ -707,12 +716,6 @@ begin
     end
 end
 
-# ╔═╡ 7feeee3a-3aec-47ce-b8d7-74a0d9b0b381
-# ╠═╡ skip_as_script = true
-#=╠═╡
-_convert(Dict, ReplacePatch([:x, :y], 10))
-  ╠═╡ =#
-
 # ╔═╡ dd87ca7e-2de1-11eb-2ec3-d5721c32f192
 function applypatch!(value, patch::AddPatch)
 	if length(patch.path) == 0
@@ -1048,7 +1051,7 @@ end
 
 # ╔═╡ 34d86e02-dd34-4691-bb78-3023568a5d16
 #=╠═╡
-@track _convert(JSONPatch, convert(Dict, replace_patch)) == replace_patch
+@track Base.convert(JSONPatch, convert(Dict, replace_patch)) == replace_patch
   ╠═╡ =#
 
 # ╔═╡ 95ff676d-73c8-44cb-ac35-af94418737e9
@@ -1158,6 +1161,7 @@ end
 # ╟─07eeb122-6706-4544-a007-1c8d6581eec8
 # ╠═b48e2c08-a94a-4247-877d-949d92dde626
 # ╟─c59b30b9-f702-41f1-bb2e-1736c8cd5ede
+# ╠═fafcb8b8-cde9-4f99-9bab-8128025953a4
 # ╟─7feeee3a-3aec-47ce-b8d7-74a0d9b0b381
 # ╠═921a130e-b028-4f91-b077-3bd79dcb6c6d
 # ╟─6d67f8a5-0e0c-4b6e-a267-96b34d580946


### PR DESCRIPTION
This PR fixes about 257 + 180 + 248 + 68 = 753 method invalidations.

Found via the following code on Julia 1.8.2:
```julia
julia> using SnoopCompileCore

julia> invs = @snoopr using Pluto;

julia> using SnoopCompile

julia> trees = invalidation_trees(invs);

julia> trees[end]
inserting convert(::Type{Base.UUID}, string::String) in Pluto at /home/rik/git/Pluto.jl/src/notebook/Cell.jl:77 invalidated:
   mt_backedges: 1: signature Tuple{typeof(convert), Type{Base.UUID}, Any} triggered MethodInstance for setindex!(::Dict{Base.UUID, Tuple{String, Union{Nothing, VersionNumber}}}, ::Any, ::Any) (2 children)
                 2: signature Tuple{typeof(convert), Type{Base.UUID}, Any} triggered MethodInstance for (::Base.var"#cvt1#1"{Tuple{String, String, Base.UUID}})(::Int64) (5 children)
                 3: signature Tuple{typeof(convert), Type{Base.UUID}, Any} triggered MethodInstance for (::Base.var"#cvt1#1"{Tuple{Base.UUID, String, String, VersionNumber}})(::Int64) (5 children)
                 4: signature Tuple{typeof(convert), Type{Base.UUID}, String} triggered MethodInstance for convert(::Type{Union{Nothing, Base.UUID}}, ::String) (27 children)
                 5: signature Tuple{typeof(convert), Type{Base.UUID}, Any} triggered MethodInstance for setindex!(::Dict{Base.UUID, Tuple{String, Union{Nothing, VersionNumber}}}, ::Tuple{String, Any}, ::Any) (180 children)
                 6: signature Tuple{typeof(convert), Type{Base.UUID}, Any} triggered MethodInstance for setindex!(::Dict{String, Base.UUID}, ::Any, ::String) (257 children)
```
and

```julia
julia> trees[end-1]
inserting convert(::Type{<:Dict}, patch::Pluto.Firebasey.ReplacePatch) in Pluto.Firebasey at /home/rik/git/PlutoFork.jl/src/webserver/Firebasey.jl:231 invalidated:
   mt_backedges:  1: signature Tuple{typeof(convert), Type{Dict{String, Union{String, Vector{String}}}}, Any} triggered MethodInstance for setindex!(::Vector{Dict{String, Union{String, Vector{String}}}}, ::Any, ::Int64) (0 children)
                  2: signature Tuple{typeof(convert), Type{Dict{String, String}}, Any} triggered MethodInstance for setindex!(::Vector{Dict{String, String}}, ::Any, ::Int64) (0 children)
                  3: signature Tuple{typeof(convert), Type{Dict{String, Any}}, Any} triggered MethodInstance for Artifacts._artifact_str(::Module, ::String, ::SubString{String}, ::String, ::Dict{String, Any}, ::Base.SHA1, ::Base.BinaryPlatforms.Platform, ::Any) (0 children)
                  4: signature Tuple{typeof(convert), Union{Type{Dict{Char, Any}}, Type{REPL.LineEdit.CompletionProvider}, Type{REPL.LineEdit.HistoryProvider}}, Any} triggered MethodInstance for setproperty!(::REPL.LineEdit.HistoryPrompt, ::Symbol, ::Any) (1 children)
                  5: signature Tuple{typeof(convert), Type{Dict{String, String}}, Any} triggered MethodInstance for setindex!(::Dict{String, Dict{String, String}}, ::Any, ::String) (3 children)
                  6: signature Tuple{typeof(convert), Type{Dict{Symbol, REPL.LineEdit.Prompt}}, Any} triggered MethodInstance for REPL.REPLHistoryProvider(::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any) (4 children)
                  7: signature Tuple{typeof(convert), Type{Dict{Char, Any}}, Any} triggered MethodInstance for REPL.LineEdit.Prompt(::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any, ::Any) (5 children)
                  8: signature Tuple{typeof(convert), Type{Dict{Symbol, Any}}, Any} triggered MethodInstance for setindex!(::IdDict{Function, Dict{Symbol, Any}}, ::Any, ::Any) (8 children)
                  9: signature Tuple{typeof(convert), Type{Dict{String, Any}}, Any} triggered MethodInstance for setindex!(::Dict{Base.BinaryPlatforms.AbstractPlatform, Dict{String, Any}}, ::Any, ::Base.BinaryPlatforms.Platform) (68 children)
                 10: signature Tuple{typeof(convert), Type{Dict{String, Union{String, Vector{String}}}}, Any} triggered MethodInstance for setindex!(::Dict{String, Dict{String, Union{String, Vector{String}}}}, ::Any, ::String) (248 children)
```