### PR TITLE
Allow solving multiple definitions by disabling one, attempt 2

### DIFF
--- a/src/analysis/Topology.jl
+++ b/src/analysis/Topology.jl
@@ -53,3 +53,14 @@ function set_unresolved(topology::NotebookTopology, unresolved_cells::Vector{Cel
         disabled_cells=topology.disabled_cells,
     )
 end
+
+
+function Base.setdiff(topology::NotebookTopology, cells::Vector{Cell})
+    NotebookTopology(
+        nodes=setdiffkeys(topology.nodes, cells),
+        codes=setdiffkeys(topology.codes, cells),
+        unresolved_cells=ImmutableSet{Cell}(setdiff(topology.unresolved_cells.c, cells); skip_copy=true),
+        cell_order=ImmutableVector{Cell}(setdiff(topology.cell_order.c, cells); skip_copy=true),
+        disabled_cells=ImmutableSet{Cell}(setdiff(topology.disabled_cells.c, cells); skip_copy=true),
+    )
+end

--- a/src/analysis/topological_order.jl
+++ b/src/analysis/topological_order.jl
@@ -12,12 +12,15 @@ Return a `TopologicalOrder` that lists the cells to be evaluated in a single rea
 
 # Keyword arguments
 
-- `allow_multiple_defs::Bool = false` \
-  If `false` (default), multiple definitions are not allowed. When a cell is found that defines a variable that is also defined by another cell (this other cell is called a *fellow assigner*), then both cells are marked as `errable` and not `runnable`. \
+- `allow_multiple_defs::Bool = false`
+  
+  If `false` (default), multiple definitions are not allowed. When a cell is found that defines a variable that is also defined by another cell (this other cell is called a *fellow assigner*), then both cells are marked as `errable` and not `runnable`.
+  
   If `true`, then multiple definitions are allowed, in the sense that we ignore the existance of other cells that define the same variable.
 
 
-- `skip_at_partial_multiple_defs::Bool = false` \
+- `skip_at_partial_multiple_defs::Bool = false`
+  
   If `true` (not default), and `allow_multiple_defs = true` (not default), then the search stops going downward when finding a cell that has fellow assigners, *unless all fellow assigners can be reached by the `roots`*, in which case we continue searching downward.
 
   In other words, if there is a set of fellow assigners that can only be reached **partially** by the roots, then this set blocks the search, and cells that depend on the set are not found.

--- a/src/analysis/topological_order.jl
+++ b/src/analysis/topological_order.jl
@@ -13,7 +13,7 @@ Return a `TopologicalOrder` that lists the cells to be evaluated in a single rea
 # Keyword arguments
 
 - `allow_multiple_defs::Bool = false` \
-  If `false` (default), multiple definitions are not allowed. When a cell is found that defines a variable that is also defined by another cell (this other cell is called a *fellow assigner*), then both cells are marked as `errable` and not `runnable. \
+  If `false` (default), multiple definitions are not allowed. When a cell is found that defines a variable that is also defined by another cell (this other cell is called a *fellow assigner*), then both cells are marked as `errable` and not `runnable`. \
   If `true`, then multiple definitions are allowed, in the sense that we ignore the existance of other cells that define the same variable.
 
 

--- a/test/cell_disabling.jl
+++ b/test/cell_disabling.jl
@@ -11,20 +11,20 @@ using Pluto: update_run!, ServerSession, ClientSession, Cell, Notebook, set_disa
     🍭.options.evaluation.workspace_use_distributed = false
 
     notebook = Notebook([
-                Cell("a = 1")
-                Cell("b = 2")
-                Cell("c = 3")
-                Cell("d = 4")
+                Cell("const a = 1")
+                Cell("const b = 2")
+                Cell("const c = 3")
+                Cell("const d = 4")
                 
-                Cell("x = a")    # 5
+                Cell("const x = a")    # 5
                 # these cells will be uncommented later
-                Cell("# x = b")  # 6
-                Cell("# x = c")  # 7
+                Cell("# const x = b")  # 6
+                Cell("# const x = c")  # 7
                 
-                Cell("z = x")    # 8
-                Cell("# z = d")  # 9
+                Cell("const z = x")    # 8
+                Cell("# const z = d")  # 9
                 
-                Cell("y = z")    # 10
+                Cell("const y = z")    # 10
             ])
     update_run!(🍭, notebook, notebook.cells)
 
@@ -40,7 +40,7 @@ using Pluto: update_run!, ServerSession, ClientSession, Cell, Notebook, set_disa
     @test all(noerror, notebook.cells)
     
     ###
-    setcode!(c(6), "x = b")
+    setcode!(c(6), "const x = b")
     update_run!(🍭, notebook, c(6))
     
     @test c(5).errored
@@ -100,7 +100,7 @@ using Pluto: update_run!, ServerSession, ClientSession, Cell, Notebook, set_disa
     
     ###
     set_disabled(c(5), false)
-    setcode!(c(7), "x = c")
+    setcode!(c(7), "const x = c")
     update_run!(🍭, notebook, c([5,7]))
     
     @test c(5).errored


### PR DESCRIPTION
# What it is

Fix #1386

https://user-images.githubusercontent.com/6933510/194161745-31ec7a52-9543-4825-b85c-49214408ce2f.mov

*This video shows some cells still grayed out after re-enabling them, that problem has been fixed*

# How it works

*I wrote this down a bit quickly, you probably first need to understand the old source code to understand this abstract piece of text*

To know which cells will run, given some `roots`, we currently:

1. do a search down from `roots`
2. do a search down from `filter(is_disabled, notebook.cells)` to find all indirectly disabled cells, and those are removed from the result of 1.

Instead, we should:

1. do a *special* search down from `filter(is_disabled, notebook.cells)` to find all indirectly disabled cells
2. now do your actual search down from the given `roots`, ignoring all (in)directly disabled cells

and 1. is a modified version of `topological_order`:

a. whenever `bfs` finds `length(assigners) > 1` (i.e. it is exploring a cell that defines one of the multiply defined `x`s) you only continue searching down (i.e. enter the `for c in ...` loop) if `all(c -> c === cell || c ∈ exits, assigners)`.

b. we set `allow_multiple_defs = true` 

## Example

For example, if you have `y = x + x`, but there are three definitions of `x`: `x = a`, `x = b`, `x = c`, with `a = 1`, `b = 2`, `c = 3`.  If `a` and `b` are disabled, then 1. will do a search down from the cells `[a, b]`. This will find `x = a` and `x = b`, but it will not continue searching down from `x` to find `y`, so ✅. 

If you also disable `c = 3`, then the search down from `[a, b, c]` will find `x = a`, then `x = b`, and when it hits `x = c`, the condition a. is true and it continues down from `x` to find `y`.

# TODO

- [x] Test for https://github.com/fonsp/Pluto.jl/pull/2268#issuecomment-1240031659
