### PR TITLE
Fixes "UndefVarError: expr not defined" in replace_returns_with_error_in_interpolation

### DIFF
--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -254,9 +254,9 @@ module CantReturnInPluto
     replace_returns_with_error(other) = other
 
     "Go through a quoted expression and remove returns"
-    function replace_returns_with_error_in_interpolation(ex::Expr)
-        if ex.head == :$
-            Expr(:$, replace_returns_with_error_in_interpolation(ex.args[1]))
+    function replace_returns_with_error_in_interpolation(expr::Expr)
+        if expr.head == :$
+            Expr(:$, replace_returns_with_error_in_interpolation(expr.args[1]))
         else
             # We are still in a quote, so we do go deeper, but we keep ignoring everything except :$'s
             Expr(expr.head, map(arg -> replace_returns_with_error_in_interpolation(arg), expr.args)...)


### PR DESCRIPTION
In PlutoRunner.jl replace_returns_with_error_in_interpolation parameter ex was referred to using both ex and expr.  Changes ex->expr to solve "UndefVarError: expr not defined"

This only fixes this typo caused by the minimal example below, but it seems to allow to run.
```julia
module WAT
	quote
		
		
	end 
end
```