### PR TITLE
Bundle action: check for empty files

### DIFF
--- a/.github/workflows/Bundle.yml
+++ b/.github/workflows/Bundle.yml
@@ -36,6 +36,7 @@ jobs:
                   node-version: 17.x
                   cache: "npm"
                   cache-dependency-path: frontend-bundler/package-lock.json
+
             - run: npm install
               working-directory: frontend-bundler
             
@@ -43,6 +44,13 @@ jobs:
               working-directory: frontend-bundler
               run: |
                 (npm run build) || (npm run build) || (npm run build)
+                
+            - name: Check for corrupt files
+              working-directory: frontend-dist
+              run: |
+                if [[ $(find . -empty) ]]; then
+                    exit 1
+                fi
 
             # Push the rebuild frontend-dist to the release branch.
             # Needs to be `add --force` because frontend-dist is normally gitignored.


### PR DESCRIPTION
Fix #2313

This added step simply checks that there are no empty files. Empty files in the `dist` folder is a problem that we have observed more often in the past. This problem is not found by our offline test (https://github.com/fonsp/Pluto.jl/pull/1737), because a missing SVG or stylesheet causes no functional issue.

It would have caught the 0.19.13 bug:
```
➜  frontend-dist git:(469ca04f) git checkout v0.19.13
Previous HEAD position was 469ca04f Bundle Web Assets
HEAD is now at 164dc5e6 Bundle Web Assets
➜  frontend-dist git:(164dc5e6) find . -empty        
./caret-forward-circle-outline.38d394c2.svg
➜  frontend-dist git:(164dc5e6) git checkout v0.19.12          
Previous HEAD position was 164dc5e6 Bundle Web Assets
HEAD is now at 469ca04f Bundle Web Assets
➜  frontend-dist git:(469ca04f) find . -empty        
➜  frontend-dist git:(469ca04f)
```

Still, it is **very weird** that this happened in the first place, because we already have code that checks for empty files... See https://github.com/fonsp/Pluto.jl/issues/2313#issuecomment-1279179501

Well... must have been a cosmic ray! Maybe there are some cats walking around the github datacenter tapping on the keyboards?  Hmmm no it's probably what I thought since day 1 of learning programming: computers are actually totally random and don't do what you write in your code!!