### PR TITLE
Print secret to console if main page requested without it

### DIFF
--- a/src/webserver/Static.jl
+++ b/src/webserver/Static.jl
@@ -170,6 +170,7 @@ function http_router_for(session::ServerSession)
                 end
                 response
             else
+                println("A request to the Pluto server was made without providing a secret, here is the secret: $(session.secret)")
                 error_response(403, "Not yet authenticated", "<b>Open the link that was printed in the terminal where you launched Pluto.</b> It includes a <em>secret</em>, which is needed to access this server.<br><br>If you are running the server yourself and want to change this configuration, have a look at the keyword arguments to <em>Pluto.run</em>. <br><br>Please <a href='https://github.com/fonsp/Pluto.jl/issues'>report this error</a> if you did not expect it!")
             end
         end


### PR DESCRIPTION
This PR was motivated by this discussion on zulip: https://julialang.zulipchat.com/#narrow/stream/243342-pluto.2Ejl/topic/Lost.20the.20secret

I also found myself in a situation where long-running pluto session would result in my losing the secret and not being able to recover it easily.
This is at the moment a very bare-bone implementation, but it serves the purpose.
It is also a fast way to get this seen by @fonsp, @Pangoraw and @pankgeorg for comments.