### PR TITLE
Allow copying vars from Memoize.jl to new workspace

### DIFF
--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -632,6 +632,8 @@ end
 # DELETING GLOBALS
 ###
 
+# This function checks whether the symbol provided to it represents a name of a memoized_cache variable from Memoize.jl 
+is_memoized_cache(s::Symbol) = startswith(string(s), "##") && endswidth(string(s), "_memoized_cache")
 
 function do_reimports(workspace_name, module_imports_to_move::Set{Expr})
     for expr in module_imports_to_move
@@ -698,7 +700,7 @@ function move_vars(
             end
         else
             # var will not be redefined in the new workspace, move it over
-            if !(symbol == :eval || symbol == :include || string(symbol)[1] == '#' || startswith(string(symbol), "workspace#"))
+            if !(symbol == :eval || symbol == :include || (string(symbol)[1] == '#' && !is_memoized_cache(symbol)) || startswith(string(symbol), "workspace#"))
                 try
                     getfield(old_workspace, symbol)
 


### PR DESCRIPTION
This PR fixes #2305.

The issue is that when creating a new workspace and moving variables there, Pluto ignores all variables whose name starts with `#`.
Unfortunately Memoize.jl uses such a variable name to save the cache. This PR simply adds another check so that a variable whose name starts with `#` is actually copied over if it matches the name pattern of Memoize.jl