### PR TITLE
🐝 Fix nested embed_display, by fixing return values of "nested" <script>

### DIFF
--- a/frontend/components/CellOutput.js
+++ b/frontend/components/CellOutput.js
@@ -235,6 +235,8 @@ let execute_dynamic_function = async ({ environment, code }) => {
  * It is possible for `execute_scripttags` to run during the execution of `execute_scripttags`, and this variable counts the depth of this nesting.
  *
  * One case where nesting occurs is when using PlutoRunner.embed_display. In its HTML render, it outputs a `<script>`, which will render a `<pluto-display>` element with content. If that content contains a `<script>` tag, then it will be executed during the execution of the original script, etc.
+ *
+ * See https://github.com/fonsp/Pluto.jl/pull/2329
  */
 let nested_script_execution_level = 0
 

--- a/frontend/components/CellOutput.js
+++ b/frontend/components/CellOutput.js
@@ -232,6 +232,13 @@ let execute_dynamic_function = async ({ environment, code }) => {
 }
 
 /**
+ * It is possible for `execute_scripttags` to run during the execution of `execute_scripttags`, and this variable counts the depth of this nesting.
+ *
+ * One case where nesting occurs is when using PlutoRunner.embed_display. In its HTML render, it outputs a `<script>`, which will render a `<pluto-display>` element with content. If that content contains a `<script>` tag, then it will be executed during the execution of the original script, etc.
+ */
+let nested_script_execution_level = 0
+
+/**
  * Runs the code `fn` with `document.currentScript` being set to a new script_element thats
  * is placed on the page where `script_element` was.
  *
@@ -251,13 +258,14 @@ let execute_inside_script_tag_that_replaces = async (script_element, fn) => {
         //@ts-ignore because of https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/1260
         new_script_tag.attributes.setNamedItem(attr.cloneNode(true))
     }
+    const container_name = `____FUNCTION_TO_RUN_INSIDE_SCRIPT_${nested_script_execution_level}`
     new_script_tag.textContent = `{
-        window.____FUNCTION_TO_RUN_INSIDE_SCRIPT.result = window.____FUNCTION_TO_RUN_INSIDE_SCRIPT.function_to_run(window.____FUNCTION_TO_RUN_INSIDE_SCRIPT.currentScript)
+        window.${container_name}.result = window.${container_name}.function_to_run(window.${container_name}.currentScript)
     }`
 
     // @ts-ignore
     // I use this long variable name to pass the function and result to and from the script we created
-    window.____FUNCTION_TO_RUN_INSIDE_SCRIPT = { function_to_run: fn, currentScript: new_script_tag, result: null }
+    window[container_name] = { function_to_run: fn, currentScript: new_script_tag, result: null }
     // Put the script in the DOM, this will run the script
     const parent = script_element.parentNode
     if (parent == null) {
@@ -265,9 +273,9 @@ let execute_inside_script_tag_that_replaces = async (script_element, fn) => {
     }
     parent.replaceChild(new_script_tag, script_element)
     // @ts-ignore - Get the result back
-    let result = await window.____FUNCTION_TO_RUN_INSIDE_SCRIPT.result
+    let result = await window[container_name].result
     // @ts-ignore - Reset the global variable "just in case"
-    window.____FUNCTION_TO_RUN_INSIDE_SCRIPT = { function_to_run: fn, result: null }
+    window[container_name] = { function_to_run: fn, result: null }
 
     return { node: new_script_tag, result: result }
 }
@@ -307,6 +315,7 @@ const execute_scripttags = async ({ root_node, script_nodes, previous_results_ma
 
     // Run scripts sequentially
     for (let node of script_nodes) {
+        nested_script_execution_level += 1
         if (node.src != null && node.src !== "") {
             // If it has a remote src="", de-dupe and copy the script to head
             let script_el = Array.from(document.head.querySelectorAll("script")).find((s) => s.src === node.src)
@@ -334,6 +343,7 @@ const execute_scripttags = async ({ root_node, script_nodes, previous_results_ma
         } else {
             // If there is no src="", we take the content and run it in an observablehq-like environment
             try {
+                let code = node.innerText
                 let script_id = node.id
                 let old_result = script_id ? previous_results_map.get(script_id) : null
 
@@ -372,7 +382,7 @@ const execute_scripttags = async ({ root_node, script_nodes, previous_results_ma
 
                                 ...observablehq_for_cells,
                             },
-                            code: node.innerText,
+                            code,
                         })
                     })
 
@@ -397,6 +407,7 @@ const execute_scripttags = async ({ root_node, script_nodes, previous_results_ma
                 // TODO: relay to user
             }
         }
+        nested_script_execution_level -= 1
     }
     return results_map
 }


### PR DESCRIPTION
Using `embed_display` recursively was broken: it would place the HTML element of the (last) inner nested display as a direct child of the outer display. This caused problems like the one in this screenshot.

<table>
<tr>
	<td> Before
	<td> After
<tr>
	<td> <img width="281" alt="Schermafbeelding 2022-10-19 om 20 31 59" src="https://user-images.githubusercontent.com/6933510/196775120-27264b70-b419-45d8-a7b9-e5d4ef2004dc.png">
	<td> <img width="312" alt="Schermafbeelding 2022-10-19 om 20 32 44" src="https://user-images.githubusercontent.com/6933510/196775256-5e7635fa-5ffa-457d-9295-1ac1b813c9e8.png">
</table>

It turns out that the object `____FUNCTION_TO_RUN_INSIDE_SCRIPT` was being modified by multiple scripts. During the run of the outer embed_display, the inner embed_display would be rendered, and it would run its own `<script>` tag, modifying `____FUNCTION_TO_RUN_INSIDE_SCRIPT` and setting the `result` attribute.

The solution is to use a different object for each nesting level. Rather than randomly generating a name each time, I decided to count the nesting level, and use that as a suffix to the variable name.