### PR TITLE
Don't run `static_resolve_topology()` to detect text cells

### DIFF
--- a/src/evaluation/Run.jl
+++ b/src/evaluation/Run.jl
@@ -374,13 +374,11 @@ function update_save_run!(
 			is_offline_renderer=true,
 		)
 
-		new = notebook.topology = static_resolve_topology(new)
-
 		to_run_offline = filter(c -> !c.running && is_just_text(new, c) && is_just_text(old, c), cells)
 		for cell in to_run_offline
 			run_single!(offline_workspace, cell, new.nodes[cell], new.codes[cell])
 		end
-		
+
 		cd(original_pwd)
 		setdiff(cells, to_run_offline)
 	end

--- a/test/Analysis.jl
+++ b/test/Analysis.jl
@@ -44,7 +44,7 @@ import Pluto: Notebook, Cell, updated_topology, static_resolve_topology, is_just
         ])
 
         old = notebook.topology
-        new = notebook.topology = updated_topology(old, notebook, notebook.cells) |> static_resolve_topology
+        new = notebook.topology = updated_topology(old, notebook, notebook.cells)
 
         @testset "Only-text detection" begin
             @test is_just_text(new, notebook.cells[1])


### PR DESCRIPTION
`ReactiveNode(::String)` is enough since ExpressionExplorer already handles the maybe_macroexpand case for `@md_str` & `@html_str`.