### PR TITLE
Allow forcing SliderServer POST request using notebook metadata

### DIFF
--- a/frontend/common/SliderServerClient.js
+++ b/frontend/common/SliderServerClient.js
@@ -66,7 +66,8 @@ export const slider_server_actions = ({ setStatePromise, launch_params, actions,
 
             let unpacked = null
             try {
-                const use_get = url.length + (packed.length * 4) / 3 + 20 < 8000
+                const force_post = get_current_state().metadata["sliderserver_use_post"] ?? false
+                const use_get = !force_post && url.length + (packed.length * 4) / 3 + 20 < 8000
 
                 const response = use_get
                     ? await fetch(url + (await base64url_arraybuffer(packed)), {

--- a/frontend/common/SliderServerClient.js
+++ b/frontend/common/SliderServerClient.js
@@ -66,7 +66,7 @@ export const slider_server_actions = ({ setStatePromise, launch_params, actions,
 
             let unpacked = null
             try {
-                const force_post = get_current_state().metadata["sliderserver_use_post"] ?? false
+                const force_post = get_current_state().metadata["sliderserver_force_post"] ?? false
                 const use_get = !force_post && url.length + (packed.length * 4) / 3 + 20 < 8000
 
                 const response = use_get


### PR DESCRIPTION
Add the possibility of forcing Pluto to always use POST requests when requesting updates from a SliderServer.

Done by using a custom field in the notebook metadata.

This is mostly useful to avoid caching of the reply in cases where one has results that depend on random values and prefers to always get new random results for the same bond variables.

It is also useful to have SliderServer work better when one uses `@bind` calls generated inside custom made macros that are not correctly parsed by PlutoSliderServer to generate the bond graph