### PR TITLE
Rework Live Docs layout to support new tabs in future

### DIFF
--- a/frontend/components/BottomRightPanel.js
+++ b/frontend/components/BottomRightPanel.js
@@ -3,7 +3,7 @@ import { cl } from "../common/ClassTable.js"
 
 import { LiveDocsTab } from "./LiveDocsTab.js"
 
-export let LiveDocs = ({ desired_doc_query, on_update_doc_query, notebook }) => {
+export let BottomRightPanel = ({ desired_doc_query, on_update_doc_query, notebook }) => {
     let container_ref = useRef()
 
     const focus_docs_on_open_ref = useRef(false)
@@ -29,6 +29,7 @@ export let LiveDocs = ({ desired_doc_query, on_update_doc_query, notebook }) => 
             <pluto-helpbox class=${cl({ hidden, [`helpbox-${open_tab ?? hidden}`]: true })}>
                 <header translate=${false}>
                     <button
+                        title="Live Docs: Search for Julia documentation, and get live documentation of everything you type."
                         class=${cl({
                             "helpbox-tab-key": true,
                             "helpbox-docs": true,
@@ -43,6 +44,8 @@ export let LiveDocs = ({ desired_doc_query, on_update_doc_query, notebook }) => 
                         <span>Live Docs</span>
                     </button>
                     <button
+                        disabled
+                        title="We are still working on this feature. Check back soon!"
                         class=${cl({
                             "helpbox-tab-key": true,
                             "helpbox-process": true,
@@ -52,7 +55,7 @@ export let LiveDocs = ({ desired_doc_query, on_update_doc_query, notebook }) => 
                             set_open_tab(open_tab === "process" ? null : "process")
                         }}
                     >
-                        <span>Process</span>
+                        <span>Coming soon</span>
                     </button>
                     ${hidden
                         ? null

--- a/frontend/components/BottomRightPanel.js
+++ b/frontend/components/BottomRightPanel.js
@@ -3,6 +3,23 @@ import { cl } from "../common/ClassTable.js"
 
 import { LiveDocsTab } from "./LiveDocsTab.js"
 
+export const ENABLE_PROCESS_TAB = window.localStorage.getItem("ENABLE_PROCESS_TAB") === "true"
+
+if (ENABLE_PROCESS_TAB) {
+    console.log(`YOU ENABLED THE PROCESS TAB
+Thanks! Awesome!
+Please let us know if you find any bugs...
+If enough people do this, we turn it on by default. 💛
+`)
+}
+
+// Added this so we can have people test the mixed parser, because I LIKE IT SO MUCH - DRAL
+// @ts-ignore
+window.PLUTO_TOGGLE_PROCESS_TAB = () => {
+    window.localStorage.setItem("ENABLE_PROCESS_TAB", String(!ENABLE_PROCESS_TAB))
+    window.location.reload()
+}
+
 export let BottomRightPanel = ({ desired_doc_query, on_update_doc_query, notebook }) => {
     let container_ref = useRef()
 
@@ -44,8 +61,8 @@ export let BottomRightPanel = ({ desired_doc_query, on_update_doc_query, noteboo
                         <span>Live Docs</span>
                     </button>
                     <button
-                        disabled
-                        title="We are still working on this feature. Check back soon!"
+                        disabled=${!ENABLE_PROCESS_TAB}
+                        title=${ENABLE_PROCESS_TAB ? "Process status" : "We are still working on this feature. Check back soon!"}
                         class=${cl({
                             "helpbox-tab-key": true,
                             "helpbox-process": true,
@@ -55,7 +72,7 @@ export let BottomRightPanel = ({ desired_doc_query, on_update_doc_query, noteboo
                             set_open_tab(open_tab === "process" ? null : "process")
                         }}
                     >
-                        <span>Coming soon</span>
+                        <span>${ENABLE_PROCESS_TAB ? "Status" : "Coming soon"}</span>
                     </button>
                     ${hidden
                         ? null

--- a/frontend/components/BottomRightPanel.js
+++ b/frontend/components/BottomRightPanel.js
@@ -76,7 +76,16 @@ export let BottomRightPanel = ({ desired_doc_query, on_update_doc_query, noteboo
                           notebook=${notebook}
                       />`
                     : open_tab === "process"
-                    ? html`<section>Process TODO</section>`
+                    ? html`<section>
+                          <p>Congratulations, you found the secret!</p>
+                          <p>
+                              Have you considered becoming a Pluto.jl open source contributor? We are always looking for creative people with JavaScript
+                              experience! Take a look at our${" "}
+                              <a href="https://github.com/fonsp/Pluto.jl/issues?q=is%3Aopen+label%3A%22good+first+issue%22+sort%3Aupdated-desc"
+                                  >good first issues</a
+                              >, and our ${" "}<a href="https://juliapluto.github.io/weekly-call-notes/">weekly community call</a>.
+                          </p>
+                      </section>`
                     : null}
             </pluto-helpbox>
         </aside>

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -11,7 +11,7 @@ import { serialize_cells, deserialize_cells, detect_deserializer } from "../comm
 import { FilePicker } from "./FilePicker.js"
 import { Preamble } from "./Preamble.js"
 import { NotebookMemo as Notebook } from "./Notebook.js"
-import { LiveDocs } from "./LiveDocs.js"
+import { BottomRightPanel } from "./BottomRightPanel.js"
 import { DropRuler } from "./DropRuler.js"
 import { SelectionArea } from "./SelectionArea.js"
 import { RecentlyDisabledInfo, UndoDelete } from "./UndoDelete.js"
@@ -1528,7 +1528,7 @@ patch: ${JSON.stringify(
                             notebook_id=${this.state.notebook.notebook_id} 
                             environment_component=${this.state.extended_components.NonCellOutputComponents} />
                     </${Main}>
-                    <${LiveDocs}
+                    <${BottomRightPanel}
                         desired_doc_query=${this.state.desired_doc_query}
                         on_update_doc_query=${this.actions.set_doc_query}
                         notebook=${this.state.notebook}

--- a/frontend/components/LiveDocs.js
+++ b/frontend/components/LiveDocs.js
@@ -6,6 +6,7 @@ import { LiveDocsTab } from "./LiveDocsTab.js"
 export let LiveDocs = ({ desired_doc_query, on_update_doc_query, notebook }) => {
     let container_ref = useRef()
 
+    const focus_docs_on_open_ref = useRef(false)
     const [open_tab, set_open_tab] = useState(/** @type { "docs" | "process" | null} */ (null))
     const hidden = open_tab == null
 
@@ -13,6 +14,7 @@ export let LiveDocs = ({ desired_doc_query, on_update_doc_query, notebook }) => 
     useEffect(() => {
         let handler = () => {
             // https://github.com/fonsp/Pluto.jl/issues/321
+            focus_docs_on_open_ref.current = false
             set_open_tab("docs")
             if (window.getComputedStyle(container_ref.current).display === "none") {
                 alert("This browser window is too small to show docs.\n\nMake the window bigger, or try zooming out.")
@@ -33,6 +35,7 @@ export let LiveDocs = ({ desired_doc_query, on_update_doc_query, notebook }) => 
                             "active": open_tab === "docs",
                         })}
                         onClick=${() => {
+                            focus_docs_on_open_ref.current = true
                             set_open_tab(open_tab === "docs" ? null : "docs")
                             // TODO: focus the docs input
                         }}
@@ -63,7 +66,12 @@ export let LiveDocs = ({ desired_doc_query, on_update_doc_query, notebook }) => 
                           </button>`}
                 </header>
                 ${open_tab === "docs"
-                    ? html`<${LiveDocsTab} desired_doc_query=${desired_doc_query} on_update_doc_query=${on_update_doc_query} notebook=${notebook} />`
+                    ? html`<${LiveDocsTab}
+                          focus_on_open=${focus_docs_on_open_ref.current}
+                          desired_doc_query=${desired_doc_query}
+                          on_update_doc_query=${on_update_doc_query}
+                          notebook=${notebook}
+                      />`
                     : open_tab === "process"
                     ? html`<section>Process TODO</section>`
                     : null}

--- a/frontend/components/LiveDocs.js
+++ b/frontend/components/LiveDocs.js
@@ -1,39 +1,19 @@
-import { html, useState, useRef, useLayoutEffect, useEffect, useMemo, useContext } from "../imports/Preact.js"
-import immer from "../imports/immer.js"
-import observablehq from "../common/SetupCellEnvironment.js"
+import { html, useState, useRef, useEffect } from "../imports/Preact.js"
 import { cl } from "../common/ClassTable.js"
 
-import { RawHTMLContainer, highlight } from "./CellOutput.js"
-import { PlutoActionsContext } from "../common/PlutoContext.js"
-
-const without_workspace_stuff = (str) =>
-    str
-        .replace(/Main\.var&quot;workspace\#\d+&quot;\./g, "") // remove workspace modules from variable names
-        .replace(/Main\.workspace\#\d+\./g, "") // remove workspace modules from variable names
-        .replace(/ in Main\.var&quot;workspace\#\d+&quot;/g, "") // remove workspace modules from method lists
-        .replace(/ in Main\.workspace\#\d+/g, "") // remove workspace modules from method lists
-        .replace(/#&#61;&#61;#[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\:\d+/g, "") // remove UUIDs from filenames
+import { LiveDocsTab } from "./LiveDocsTab.js"
 
 export let LiveDocs = ({ desired_doc_query, on_update_doc_query, notebook }) => {
-    let pluto_actions = useContext(PlutoActionsContext)
     let container_ref = useRef()
-    let live_doc_search_ref = useRef()
-    let [state, set_state] = useState({
-        shown_query: null,
-        searched_query: null,
-        body: "<p>Welcome to the <b>Live docs</b>! Keep this little window open while you work on the notebook, and you will get documentation of everything you type!</p><p>You can also type a query above.</p><hr><p><em>Still stuck? Here are <a href='https://julialang.org/about/help/' target='_blank'>some tips</a>.</em></p>",
-        hidden: true,
-        loading: false,
-    })
-    let update_state = (mutation) => set_state(immer((state) => mutation(state)))
+
+    const [open_tab, set_open_tab] = useState(/** @type { "docs" | "process" | null} */ (null))
+    const hidden = open_tab == null
 
     // Open docs when "open_live_docs" event is triggered
     useEffect(() => {
         let handler = () => {
             // https://github.com/fonsp/Pluto.jl/issues/321
-            update_state((state) => {
-                state.hidden = false
-            })
+            set_open_tab("docs")
             if (window.getComputedStyle(container_ref.current).display === "none") {
                 alert("This browser window is too small to show docs.\n\nMake the window bigger, or try zooming out.")
             }
@@ -42,119 +22,52 @@ export let LiveDocs = ({ desired_doc_query, on_update_doc_query, notebook }) => 
         return () => window.removeEventListener("open_live_docs", handler)
     }, [])
 
-    // Apply syntax highlighting to code blocks:
-    // In the standard HTML container we already do this for code.language-julia blocks,
-    // but in the docs it's safe to extend to to all highlighting I think
-    useLayoutEffect(() => {
-        // Actually, showing the jldoctest stuff wasn't as pretty... should make a mode for that sometimes
-        // for (let code_element of container_ref.current.querySelectorAll("code.language-jldoctest")) {
-        //     highlight(code_element, "julia")
-        // }
-        for (let code_element of container_ref.current.querySelectorAll("code:not([class])")) {
-            highlight(code_element, "julia")
-        }
-    }, [state.body])
-
-    useEffect(() => {
-        if (state.hidden || state.loading) {
-            return
-        }
-        if (!/[^\s]/.test(desired_doc_query)) {
-            // only whitespace
-            return
-        }
-
-        if (state.searched_query !== desired_doc_query) {
-            fetch_docs(desired_doc_query)
-        }
-    }, [desired_doc_query, state.hidden, state.loading, state.searched_query])
-
-    let fetch_docs = (new_query) => {
-        update_state((state) => {
-            state.loading = true
-            state.searched_query = new_query
-        })
-        Promise.race([
-            observablehq.Promises.delay(2000, false),
-            pluto_actions.send("docs", { query: new_query.replace(/^\?/, "") }, { notebook_id: notebook.notebook_id }).then((u) => {
-                if (u.message.status === "⌛") {
-                    return false
-                }
-                if (u.message.status === "👍") {
-                    update_state((state) => {
-                        state.shown_query = new_query
-                        state.body = u.message.doc
-                    })
-                    return true
-                }
-            }),
-        ]).then(() => {
-            update_state((state) => {
-                state.loading = false
-            })
-        })
-    }
-
-    let docs_element = useMemo(() => html` <${RawHTMLContainer} body=${without_workspace_stuff(state.body)} /> `, [state.body])
-    let no_docs_found = state.loading === false && state.searched_query !== "" && state.searched_query !== state.shown_query
-
     return html`
         <aside id="helpbox-wrapper" ref=${container_ref}>
-            <pluto-helpbox class=${cl({ hidden: state.hidden, loading: state.loading, notfound: no_docs_found })}>
-                <header
-                    translate=${false}
-                    onClick=${() => {
-                        if (state.hidden) {
-                            set_state((state) => ({ ...state, hidden: false }))
-                            // wait for next event loop
-                            setTimeout(
-                                () =>
-                                    live_doc_search_ref.current &&
-                                    live_doc_search_ref.current.focus({
-                                        preventScroll: true,
-                                    }),
-                                0
-                            )
-                        }
-                    }}
-                >
-                    ${state.hidden
-                        ? "Live docs"
-                        : html`
-                        <input
-                            title=${no_docs_found ? `"${state.searched_query}" not found` : ""}
-                            id="live-docs-search"
-                            placeholder="Search docs..."
-                            ref=${live_doc_search_ref}
-                            onInput=${(e) => on_update_doc_query(e.target.value)}
-                            value=${desired_doc_query}
-                            type="text"
-                        ></input>
-                        <button onClick=${(e) => {
-                            set_state((state) => ({ ...state, hidden: true }))
-                            e.stopPropagation()
-                            setTimeout(() => live_doc_search_ref.current && live_doc_search_ref.current.focus(), 0)
-                        }}><span></span></button>
-                    `}
+            <pluto-helpbox class=${cl({ hidden, [`helpbox-${open_tab ?? hidden}`]: true })}>
+                <header translate=${false}>
+                    <button
+                        class=${cl({
+                            "helpbox-tab-key": true,
+                            "helpbox-docs": true,
+                            "active": open_tab === "docs",
+                        })}
+                        onClick=${() => {
+                            set_open_tab(open_tab === "docs" ? null : "docs")
+                            // TODO: focus the docs input
+                        }}
+                    >
+                        <span>Live Docs</span>
+                    </button>
+                    <button
+                        class=${cl({
+                            "helpbox-tab-key": true,
+                            "helpbox-process": true,
+                            "active": open_tab === "process",
+                        })}
+                        onClick=${() => {
+                            set_open_tab(open_tab === "process" ? null : "process")
+                        }}
+                    >
+                        <span>Process</span>
+                    </button>
+                    ${hidden
+                        ? null
+                        : html`<button
+                              class="helpbox-close"
+                              onClick=${() => {
+                                  set_open_tab(null)
+                              }}
+                          >
+                              <span></span>
+                          </button>`}
                 </header>
-                <section ref=${(ref) => ref != null && resolve_doc_reference_links(ref, on_update_doc_query)}>
-                    <h1><code>${state.shown_query}</code></h1>
-                    ${docs_element}
-                </section>
+                ${open_tab === "docs"
+                    ? html`<${LiveDocsTab} desired_doc_query=${desired_doc_query} on_update_doc_query=${on_update_doc_query} notebook=${notebook} />`
+                    : open_tab === "process"
+                    ? html`<section>Process TODO</section>`
+                    : null}
             </pluto-helpbox>
         </aside>
     `
-}
-
-const resolve_doc_reference_links = (node, on_update_doc_query) => {
-    for (let anchor of node.querySelectorAll("a")) {
-        const href = anchor.getAttribute("href")
-        if (href != null && href.startsWith("@ref")) {
-            const query = href.length > 4 ? href.substr(5) : anchor.textContent
-            anchor.onclick = (e) => {
-                on_update_doc_query(query)
-                e.preventDefault()
-            }
-        }
-    }
 }

--- a/frontend/components/LiveDocsTab.js
+++ b/frontend/components/LiveDocsTab.js
@@ -6,9 +6,19 @@ import { RawHTMLContainer, highlight } from "./CellOutput.js"
 import { PlutoActionsContext } from "../common/PlutoContext.js"
 import { cl } from "../common/ClassTable.js"
 
-export let LiveDocsTab = ({ desired_doc_query, on_update_doc_query, notebook }) => {
+/**
+ * @param {{
+ * focus_on_open: boolean,
+ * desired_doc_query: string?,
+ * on_update_doc_query: (query: string) => void,
+ * notebook: import("./Editor.js").NotebookData,
+ * }} props
+ */
+export let LiveDocsTab = ({ focus_on_open, desired_doc_query, on_update_doc_query, notebook }) => {
     let pluto_actions = useContext(PlutoActionsContext)
-    let live_doc_search_ref = useRef()
+    let live_doc_search_ref = useRef(/** @type {HTMLInputElement?} */ (null))
+
+    // This is all in a single state object so that we can update multiple field simultaneously
     let [state, set_state] = useState({
         shown_query: null,
         searched_query: null,
@@ -21,7 +31,7 @@ export let LiveDocsTab = ({ desired_doc_query, on_update_doc_query, notebook }) 
         if (state.loading) {
             return
         }
-        if (!/[^\s]/.test(desired_doc_query)) {
+        if (desired_doc_query != null && !/[^\s]/.test(desired_doc_query)) {
             // only whitespace
             return
         }
@@ -30,6 +40,13 @@ export let LiveDocsTab = ({ desired_doc_query, on_update_doc_query, notebook }) 
             fetch_docs(desired_doc_query)
         }
     }, [desired_doc_query, state.loading, state.searched_query])
+
+    useLayoutEffect(() => {
+        if (focus_on_open && live_doc_search_ref.current) {
+            live_doc_search_ref.current.focus()
+            live_doc_search_ref.current.select()
+        }
+    }, [focus_on_open, live_doc_search_ref.current])
 
     let fetch_docs = (new_query) => {
         update_state((state) => {
@@ -76,7 +93,7 @@ export let LiveDocsTab = ({ desired_doc_query, on_update_doc_query, notebook }) 
                 ref=${live_doc_search_ref}
                 onInput=${(e) => on_update_doc_query(e.target.value)}
                 value=${desired_doc_query}
-                type="text"
+                type="search"
             ></input>
             
         </div>

--- a/frontend/components/LiveDocsTab.js
+++ b/frontend/components/LiveDocsTab.js
@@ -1,0 +1,122 @@
+import { html, useState, useRef, useLayoutEffect, useEffect, useMemo, useContext } from "../imports/Preact.js"
+import immer from "../imports/immer.js"
+import observablehq from "../common/SetupCellEnvironment.js"
+
+import { RawHTMLContainer, highlight } from "./CellOutput.js"
+import { PlutoActionsContext } from "../common/PlutoContext.js"
+import { cl } from "../common/ClassTable.js"
+
+export let LiveDocsTab = ({ desired_doc_query, on_update_doc_query, notebook }) => {
+    let pluto_actions = useContext(PlutoActionsContext)
+    let live_doc_search_ref = useRef()
+    let [state, set_state] = useState({
+        shown_query: null,
+        searched_query: null,
+        body: "<p>Welcome to the <b>Live docs</b>! Keep this little window open while you work on the notebook, and you will get documentation of everything you type!</p><p>You can also type a query above.</p><hr><p><em>Still stuck? Here are <a href='https://julialang.org/about/help/' target='_blank'>some tips</a>.</em></p>",
+        loading: false,
+    })
+    let update_state = (mutation) => set_state(immer((state) => mutation(state)))
+
+    useEffect(() => {
+        if (state.loading) {
+            return
+        }
+        if (!/[^\s]/.test(desired_doc_query)) {
+            // only whitespace
+            return
+        }
+
+        if (state.searched_query !== desired_doc_query) {
+            fetch_docs(desired_doc_query)
+        }
+    }, [desired_doc_query, state.loading, state.searched_query])
+
+    let fetch_docs = (new_query) => {
+        update_state((state) => {
+            state.loading = true
+            state.searched_query = new_query
+        })
+        Promise.race([
+            observablehq.Promises.delay(2000, false),
+            pluto_actions.send("docs", { query: new_query.replace(/^\?/, "") }, { notebook_id: notebook.notebook_id }).then((u) => {
+                if (u.message.status === "⌛") {
+                    return false
+                }
+                if (u.message.status === "👍") {
+                    update_state((state) => {
+                        state.shown_query = new_query
+                        state.body = u.message.doc
+                    })
+                    return true
+                }
+            }),
+        ]).then(() => {
+            update_state((state) => {
+                state.loading = false
+            })
+        })
+    }
+
+    let docs_element = useMemo(() => html`<${RawHTMLContainer} body=${without_workspace_stuff(state.body)} />`, [state.body])
+    let no_docs_found = state.loading === false && state.searched_query !== "" && state.searched_query !== state.shown_query
+
+    return html`
+        <div
+            class=${cl({
+                "live-docs-searchbox": true,
+                "loading": state.loading,
+                "notfound": no_docs_found,
+            })}
+            translate=${false}
+        >
+            <input
+                title=${no_docs_found ? `"${state.searched_query}" not found` : ""}
+                id="live-docs-search"
+                placeholder="Search docs..."
+                ref=${live_doc_search_ref}
+                onInput=${(e) => on_update_doc_query(e.target.value)}
+                value=${desired_doc_query}
+                type="text"
+            ></input>
+            
+        </div>
+        <section ref=${(ref) => ref != null && post_process_doc_node(ref, on_update_doc_query)}>
+            <h1><code>${state.shown_query}</code></h1>
+            ${docs_element}
+        </section>
+    `
+}
+
+const post_process_doc_node = (node, on_update_doc_query) => {
+    // Apply syntax highlighting to code blocks:
+
+    // In the standard HTML container we already do this for code.language-julia blocks,
+    // but in the docs it's safe to extend to to all highlighting I think
+    // Actually, showing the jldoctest stuff wasn't as pretty... should make a mode for that sometimes
+    // for (let code_element of container_ref.current.querySelectorAll("code.language-jldoctest")) {
+    //     highlight(code_element, "julia")
+    // }
+    for (let code_element of node.querySelectorAll("code:not([class])")) {
+        highlight(code_element, "julia")
+    }
+
+    // Resolve @doc reference links:
+    for (let anchor of node.querySelectorAll("a")) {
+        const href = anchor.getAttribute("href")
+        if (href != null && href.startsWith("@ref")) {
+            const query = href.length > 4 ? href.substr(5) : anchor.textContent
+            anchor.onclick = (e) => {
+                on_update_doc_query(query)
+                e.preventDefault()
+            }
+        }
+    }
+}
+
+const without_workspace_stuff = (str) =>
+    str
+        .replace(/Main\.var&quot;workspace\#\d+&quot;\./g, "") // remove workspace modules from variable names
+        .replace(/Main\.workspace\#\d+\./g, "") // remove workspace modules from variable names
+        .replace(/ in Main\.var&quot;workspace\#\d+&quot;/g, "") // remove workspace modules from method lists
+        .replace(/ in Main\.workspace\#\d+/g, "") // remove workspace modules from method lists
+        .replace(/#&#61;&#61;#[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\:\d+/g, "") // remove UUIDs from filenames

--- a/frontend/dark_color.css
+++ b/frontend/dark_color.css
@@ -141,7 +141,9 @@
         --helpbox-header-bg-color: #2c3e36;
         --helpbox-header-tab-bg-color: #554e4e;
         --helpbox-header-color: rgb(255 248 235);
-        --helpbox-notfound-header-color: rgb(139, 139, 139);
+        --helpbox-search-bg-color: #2c2c2c;
+        --helpbox-search-border-color: #757575;
+        --helpbox-notfound-search-color: rgb(139, 139, 139);
         --helpbox-text-color: rgb(230, 230, 230);
         --code-section-bg-color: rgb(44, 44, 44);
         --code-section-border-color: #555a64;

--- a/frontend/dark_color.css
+++ b/frontend/dark_color.css
@@ -139,6 +139,7 @@
         --helpbox-bg-color: rgb(30 34 31);
         --helpbox-box-shadow-color: #00000017;
         --helpbox-header-bg-color: #2c3e36;
+        --helpbox-header-tab-bg-color: #554e4e;
         --helpbox-header-color: rgb(255 248 235);
         --helpbox-notfound-header-color: rgb(139, 139, 139);
         --helpbox-text-color: rgb(230, 230, 230);

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -2082,7 +2082,13 @@ pluto-helpbox > header > button.helpbox-docs.active::before {
 }
 pluto-helpbox > header > button.helpbox-process::before {
     background-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/terminal.svg");
+    background-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/pulse.svg");
     /* content: "💻 "; */
+}
+
+pluto-helpbox > header > button.helpbox-tab-key:disabled::before {
+    /* display: none; */
+    opacity: 0.5;
 }
 
 pluto-helpbox .live-docs-searchbox input {
@@ -2115,6 +2121,9 @@ button.helpbox-tab-key {
     border-radius: var(--border-radius);
     border: none;
     background: var(--helpbox-header-tab-bg-color);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
 
 pluto-helpbox > header > button.helpbox-close {
@@ -3050,8 +3059,4 @@ button.active.helpbox-tab-key {
 .live-docs-searchbox {
     display: flex;
     margin: 1em;
-}
-
-button.helpbox-process.helpbox-tab-key {
-    /* display: none; */
 }

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -2054,7 +2054,7 @@ pluto-helpbox > header {
     font-family: var(--system-ui-font-stack);
     font-size: 0.9rem;
     --border-radius: 0.4em;
-    font-weight: 700;
+    font-weight: 500;
     border-top-left-radius: var(--border-radius);
     border-top-right-radius: var(--border-radius);
     /* border-top: 4px solid #8a8a8a; */
@@ -2062,16 +2062,27 @@ pluto-helpbox > header {
 }
 
 pluto-helpbox > header > button.helpbox-tab-key::before {
-    margin-right: 10px;
+    content: "";
+    /* font-size: 1em; */
+    --size: 1.1em;
+    width: var(--size);
+    height: var(--size);
+    background-size: var(--size);
+    margin-bottom: calc(-0.15 * var(--size));
+    filter: var(--image-filters);
+    margin-right: 0.6em;
+    display: inline-block;
 }
 pluto-helpbox > header > button.helpbox-docs::before {
-    content: "📚 ";
+    background-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/search.svg");
+    /* content: "📚 "; */
 }
 pluto-helpbox > header > button.helpbox-docs.active::before {
-    content: "📖 ";
+    /* content: "📖 "; */
 }
 pluto-helpbox > header > button.helpbox-process::before {
-    content: "💻 ";
+    background-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/terminal.svg");
+    /* content: "💻 "; */
 }
 
 pluto-helpbox .live-docs-searchbox input {
@@ -2095,11 +2106,12 @@ pluto-helpbox .live-docs-searchbox input:focus {
 }
 
 button.helpbox-tab-key {
-    padding: 0.5em 0.8em;
+    padding: 0.5em 0.6em;
     cursor: pointer;
     font-family: inherit;
     font-weight: inherit;
     font-style: inherit;
+    font-size: inherit;
     border-radius: var(--border-radius);
     border: none;
     background: var(--helpbox-header-tab-bg-color);
@@ -3041,5 +3053,5 @@ button.active.helpbox-tab-key {
 }
 
 button.helpbox-process.helpbox-tab-key {
-    display: none;
+    /* display: none; */
 }

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -2034,7 +2034,7 @@ pluto-helpbox {
     flex-direction: column;
     width: calc(100vw - 50px - (700px + 25px + 6px)); /* compat */
     width: clamp(300px, calc(100vw - 50px - (700px + 25px + 6px)), 450px);
-    height: 70vh; /* compat */
+    height: 95vh; /* compat */
     height: min(70vh, 900px);
     /* overflow: hidden; */
     background-color: var(--helpbox-bg-color);
@@ -2048,44 +2048,64 @@ pluto-helpbox {
 }
 pluto-helpbox > header {
     display: flex;
-    padding: 15px;
+    padding: 0.6em;
     background-color: var(--helpbox-header-bg-color);
     color: var(--helpbox-header-color);
-    font-family: "Roboto Mono", monospace;
+    font-family: var(--system-ui-font-stack);
     font-size: 0.9rem;
+    --border-radius: 0.4em;
     font-weight: 700;
-    border-top-left-radius: 6px;
-    border-top-right-radius: 6px;
+    border-top-left-radius: var(--border-radius);
+    border-top-right-radius: var(--border-radius);
     /* border-top: 4px solid #8a8a8a; */
+    gap: 0.5em;
 }
-pluto-helpbox > header::before {
-    content: "📖 ";
+
+pluto-helpbox > header > button.helpbox-tab-key::before {
     margin-right: 10px;
 }
-/* pluto-helpbox.loading>header::before{
-    content: "⌛ ";
-    margin-right: 10px;
-} */
-pluto-helpbox.hidden > header::before {
+pluto-helpbox > header > button.helpbox-docs::before {
     content: "📚 ";
-    margin-right: 10px;
 }
-pluto-helpbox > header > input {
+pluto-helpbox > header > button.helpbox-docs.active::before {
+    content: "📖 ";
+}
+pluto-helpbox > header > button.helpbox-process::before {
+    content: "💻 ";
+}
+
+pluto-helpbox .live-docs-searchbox input {
     flex-grow: 1;
     background-color: inherit;
     color: inherit;
-    font-family: inherit;
-    font-weight: inherit;
-    font-size: inherit;
     border: none;
+    padding: 0.5em;
+    margin: auto;
+    border: 3px solid #757575;
+    border-radius: .3em;
+    background: #2c2c2c;
+    font-family: var(--julia-mono-font-stack);
+    font-size: 0.9rem;
 }
-pluto-helpbox.notfound > header > input {
+pluto-helpbox .live-docs-searchbox.notfound input {
     color: var(--helpbox-notfound-header-color);
 }
-pluto-helpbox > header > input:focus {
+pluto-helpbox .live-docs-searchbox input:focus {
     outline: none;
 }
-pluto-helpbox > header > button {
+
+button.helpbox-tab-key {
+    padding: 0.5em 0.8em;
+    cursor: pointer;
+    font-family: inherit;
+    font-weight: inherit;
+    font-style: inherit;
+    border-radius: var(--border-radius);
+    border: none;
+    background: var(--helpbox-header-tab-bg-color);
+}
+
+pluto-helpbox > header > button.helpbox-close {
     border: none;
     background: none;
     cursor: pointer;
@@ -2093,8 +2113,10 @@ pluto-helpbox > header > button {
     /* for bigger hitbox */
     margin: -15px;
     border: 15px solid transparent;
+    margin-left: auto;
 }
-pluto-helpbox > header > button > span {
+
+pluto-helpbox > header > button.helpbox-close > span {
     display: block;
     content: " " !important;
     background-size: 1em 1em;
@@ -2106,6 +2128,7 @@ pluto-helpbox > header > button > span {
 pluto-helpbox.hidden {
     height: initial;
     cursor: pointer;
+    width: auto;
 }
 pluto-helpbox.hidden > section {
     display: none;
@@ -3007,4 +3030,14 @@ pluto-logs-container > header {
     opacity: 0.6;
     font-weight: 700;
     /* background: #494949; */
+}
+
+button.active.helpbox-tab-key {
+    outline: 3px solid #99afb9;
+}
+
+
+.live-docs-searchbox {
+    display: flex;
+    margin: 1em;
 }

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -2081,14 +2081,14 @@ pluto-helpbox .live-docs-searchbox input {
     border: none;
     padding: 0.5em;
     margin: auto;
-    border: 3px solid #757575;
-    border-radius: .3em;
-    background: #2c2c2c;
+    border: 3px solid var(--helpbox-search-border-color);
+    border-radius: 0.3em;
+    background: var(--helpbox-search-bg-color);
     font-family: var(--julia-mono-font-stack);
     font-size: 0.9rem;
 }
 pluto-helpbox .live-docs-searchbox.notfound input {
-    color: var(--helpbox-notfound-header-color);
+    color: var(--helpbox-notfound-search-color);
 }
 pluto-helpbox .live-docs-searchbox input:focus {
     outline: none;
@@ -2127,7 +2127,6 @@ pluto-helpbox > header > button.helpbox-close > span {
 }
 pluto-helpbox.hidden {
     height: initial;
-    cursor: pointer;
     width: auto;
 }
 pluto-helpbox.hidden > section {
@@ -3036,8 +3035,11 @@ button.active.helpbox-tab-key {
     outline: 3px solid #99afb9;
 }
 
-
 .live-docs-searchbox {
     display: flex;
     margin: 1em;
+}
+
+button.helpbox-process.helpbox-tab-key {
+    display: none;
 }

--- a/frontend/light_color.css
+++ b/frontend/light_color.css
@@ -5,10 +5,12 @@
 
         /* Color scheme */
         --main-bg-color: white;
-        --rule-color: rgba(0, 0, 0, 0.15);
+        --rule-color:
+        rgba(0, 0, 0, 0.15);
         --kbd-border-color: #dfdfdf;
         --header-bg-color: white;
-        --header-border-color: rgba(0, 0, 0, 0.1);
+        --header-border-color:
+        rgba(0, 0, 0, 0.1);
         --ui-button-color: #2a2a2b;
         --cursor-color: black;
         --normal-cell: 0, 0, 0;
@@ -16,88 +18,138 @@
         --error-color: 240, 168, 168;
 
         /*Cells*/
-        --normal-cell-color: rgba(var(--normal-cell), 0.1);
-        --dark-normal-cell-color: rgba(var(--normal-cell), 0.2);
-        --selected-cell-color: rgba(40, 78, 189, 0.4);
-        --code-differs-cell-color: rgba(var(--code-differs), 0.68);
-        --error-cell-color: rgba(var(--error-color), 0.7);
-        --bright-error-cell-color: rgb(var(--error-color));
-        --light-error-cell-color: rgba(var(--error-color), 0.05);
+        --normal-cell-color:
+        rgba(var(--normal-cell), 0.1);
+        --dark-normal-cell-color:
+        rgba(var(--normal-cell), 0.2);
+        --selected-cell-color:
+        rgba(40, 78, 189, 0.4);
+        --code-differs-cell-color:
+        rgba(var(--code-differs), 0.68);
+        --error-cell-color:
+        rgba(var(--error-color), 0.7);
+        --bright-error-cell-color:
+        rgb(var(--error-color));
+        --light-error-cell-color:
+        rgba(var(--error-color), 0.05);
 
         /*Export styling*/
-        --export-bg-color: rgb(60, 67, 101);
-        --export-color: rgba(255, 255, 255, 0.7);
-        --export-card-bg-color: rgba(255, 255, 255, 0.8);
-        --export-card-title-color: rgba(0, 0, 0, 0.7);
-        --export-card-text-color: rgba(0, 0, 0, 0.5);
+        --export-bg-color:
+        rgb(60, 67, 101);
+        --export-color:
+        rgba(255, 255, 255, 0.7);
+        --export-card-bg-color:
+        rgba(255, 255, 255, 0.8);
+        --export-card-title-color:
+        rgba(0, 0, 0, 0.7);
+        --export-card-text-color:
+        rgba(0, 0, 0, 0.5);
         --export-card-shadow-color: #00000029;
 
         /*Pluto output styling */
-        --pluto-schema-types-color: rgba(0, 0, 0, 0.4);
-        --pluto-schema-types-border-color: rgba(0, 0, 0, 0.2);
-        --pluto-output-color: hsl(0, 0%, 25%);
-        --pluto-output-h-color: hsl(0, 0%, 12%);
+        --pluto-schema-types-color:
+        rgba(0, 0, 0, 0.4);
+        --pluto-schema-types-border-color:
+        rgba(0, 0, 0, 0.2);
+        --pluto-output-color:
+        hsl(0, 0%, 25%);
+        --pluto-output-h-color:
+        hsl(0, 0%, 12%);
         --pluto-output-bg-color: white;
         --a-underline: #00000059;
         --blockquote-color: #555;
         --blockquote-bg: #f2f2f2;
         --admonition-title-color: white;
-        --jl-message-color: rgb(219 233 212);
-        --jl-message-accent-color: rgb(158, 200, 137);
-        --jl-info-color: rgb(214 227 244);
-        --jl-info-accent-color: rgb(148, 182, 226);
-        --jl-warn-color: rgb(236 234 213);
-        --jl-warn-accent-color: rgb(207, 199, 138);
-        --jl-danger-color: rgb(245 218 215);
-        --jl-danger-accent-color: rgb(226, 157, 148);
-        --jl-debug-color: rgb(245 218 215);
-        --jl-debug-accent-color: rgb(226, 157, 148);
-        --footnote-border-color: rgba(23, 115, 119, 0.15);
-        --table-border-color: rgba(0, 0, 0, 0.2);
-        --table-bg-hover-color: rgba(159, 158, 224, 0.15);
-        --pluto-tree-color: rgb(0 0 0 / 38%);
+        --jl-message-color:
+        rgb(219 233 212);
+        --jl-message-accent-color:
+        rgb(158, 200, 137);
+        --jl-info-color:
+        rgb(214 227 244);
+        --jl-info-accent-color:
+        rgb(148, 182, 226);
+        --jl-warn-color:
+        rgb(236 234 213);
+        --jl-warn-accent-color:
+        rgb(207, 199, 138);
+        --jl-danger-color:
+        rgb(245 218 215);
+        --jl-danger-accent-color:
+        rgb(226, 157, 148);
+        --jl-debug-color:
+        rgb(245 218 215);
+        --jl-debug-accent-color:
+        rgb(226, 157, 148);
+        --footnote-border-color:
+        rgba(23, 115, 119, 0.15);
+        --table-border-color:
+        rgba(0, 0, 0, 0.2);
+        --table-bg-hover-color:
+        rgba(159, 158, 224, 0.15);
+        --pluto-tree-color:
+        rgb(0 0 0 / 38%);
 
         /*pluto cell styling*/
-        --disabled-cell-bg-color: rgba(139, 139, 139, 0.25);
-        --selected-cell-bg-color: rgba(40, 78, 189, 0.24);
-        --hover-scrollbar-color-1: rgba(0, 0, 0, 0.15);
-        --hover-scrollbar-color-2: rgba(0, 0, 0, 0.05);
+        --disabled-cell-bg-color:
+        rgba(139, 139, 139, 0.25);
+        --selected-cell-bg-color:
+        rgba(40, 78, 189, 0.24);
+        --hover-scrollbar-color-1:
+        rgba(0, 0, 0, 0.15);
+        --hover-scrollbar-color-2:
+        rgba(0, 0, 0, 0.05);
         --skip-as-script-background-color: #ccc;
         --depends-on-skip-as-script-background-color: #eee;
 
         /* Pluto shoulders */
-        --shoulder-hover-bg-color: rgba(0, 0, 0, 0.05);
+        --shoulder-hover-bg-color:
+        rgba(0, 0, 0, 0.05);
 
         /* Logs */
-        --pluto-logs-bg-color: hsl(0deg 0% 98%);
-        --pluto-logs-key-color: rgb(0 0 0 / 51%);
+        --pluto-logs-bg-color:
+        hsl(0deg 0% 98%);
+        --pluto-logs-key-color:
+        rgb(0 0 0 / 51%);
         --pluto-logs-progress-fill: #ffffff;
         --pluto-logs-progress-bg: #e7e7e7;
-        --pluto-logs-progress-border: hsl(210deg 16% 74%);
+        --pluto-logs-progress-border:
+        hsl(210deg 16% 74%);
 
         --pluto-logs-info-color: white;
         --pluto-logs-info-accent-color: inherit;
-        --pluto-logs-warn-color: rgb(236 234 213);
+        --pluto-logs-warn-color:
+        rgb(236 234 213);
         --pluto-logs-warn-accent-color: #665f26;
-        --pluto-logs-danger-color: rgb(245 218 215);
-        --pluto-logs-danger-accent-color: rgb(172 66 52);
-        --pluto-logs-debug-color: rgb(236 223 247);
-        --pluto-logs-debug-accent-color: rgb(100 50 179);
+        --pluto-logs-danger-color:
+        rgb(245 218 215);
+        --pluto-logs-danger-accent-color:
+        rgb(172 66 52);
+        --pluto-logs-debug-color:
+        rgb(236 223 247);
+        --pluto-logs-debug-accent-color:
+        rgb(100 50 179);
 
         /*Top navbar styling*/
         --nav-h1-text-color: black;
         --nav-filepicker-color: #6f6f6f;
         --nav-filepicker-border-color: #b2b2b2;
         --nav-process-status-bg-color: white;
-        --nav-process-status-color: var(--pluto-output-h-color);
+        --nav-process-status-color:
+        var(--pluto-output-h-color);
 
         /*header*/
-        --restart-recc-header-color: rgba(114, 192, 255, 0.56);
-        --restart-req-header-color: rgba(170, 41, 32, 0.56);
-        --dead-process-header-color: rgb(230 88 46 / 38%);
-        --loading-header-color: hsla(290, 10%, 80%, 0.5);
-        --disconnected-header-color: rgba(255, 169, 114, 0.56);
-        --binder-loading-header-color: hsl(51deg 64% 90% / 50%);
+        --restart-recc-header-color:
+        rgba(114, 192, 255, 0.56);
+        --restart-req-header-color:
+        rgba(170, 41, 32, 0.56);
+        --dead-process-header-color:
+        rgb(230 88 46 / 38%);
+        --loading-header-color:
+        hsla(290, 10%, 80%, 0.5);
+        --disconnected-header-color:
+        rgba(255, 169, 114, 0.56);
+        --binder-loading-header-color:
+        hsl(51deg 64% 90% / 50%);
 
         /*loading bar*/
         --loading-grad-color-1: #f1dba9;
@@ -109,10 +161,12 @@
         --overlay-button-border-save: #f3f2f2;
 
         /*input_context_menu*/
-        --input-context-menu-border-color: rgba(0, 0, 0, 0.1);
+        --input-context-menu-border-color:
+        rgba(0, 0, 0, 0.1);
         --input-context-menu-bg-color: white;
         --input-context-menu-soon-color: #55555544;
-        --input-context-menu-hover-bg-color: rgba(0, 0, 0, 0.1);
+        --input-context-menu-hover-bg-color:
+        rgba(0, 0, 0, 0.1);
         --input-context-menu-li-color: #6b6a6a;
 
         /*Pkg status*/
@@ -125,15 +179,19 @@
         --pkg-terminal-border-color: #c3c3c3;
 
         /* run area*/
-        --pluto-runarea-bg-color: hsl(0, 0, 97%);
-        --pluto-runarea-span-color: hsl(353, 5%, 64%);
+        --pluto-runarea-bg-color:
+        hsl(0, 0, 97%);
+        --pluto-runarea-span-color:
+        hsl(353, 5%, 64%);
 
         /*drop ruler*/
-        --dropruler-bg-color: rgba(0, 0, 0, 0.5);
+        --dropruler-bg-color:
+        rgba(0, 0, 0, 0.5);
 
         /* jlerror */
         --jlerror-header-color: #4f1616;
-        --jlerror-mark-bg-color: rgb(243 243 243);
+        --jlerror-mark-bg-color:
+        rgb(243 243 243);
         --jlerror-a-bg-color: #f5efd9;
         --jlerror-a-border-left-color: #704141;
         --jlerror-mark-color: black;
@@ -141,10 +199,16 @@
         /* helpbox */
         --helpbox-bg-color: white;
         --helpbox-box-shadow-color: #00000010;
-        --helpbox-header-bg-color: hsl(0deg 0% 92%);
+        --helpbox-header-bg-color:
+        hsl(0deg 0% 92%);
         --helpbox-header-tab-bg-color: white;
-        --helpbox-header-color: hsl(230, 14%, 11%);
-        --helpbox-notfound-header-color: rgb(139, 139, 139);
+        --helpbox-header-color:
+        hsl(230, 14%, 11%);
+        --helpbox-search-bg-color: #fbfbfb;
+        --helpbox-search-border-color:
+        hsl(207deg 24% 87%);
+        --helpbox-notfound-search-color:
+        rgb(139, 139, 139);
         --helpbox-text-color: black;
         --code-section-bg-color: whitesmoke;
         --code-section-bg-color: #f3f3f3;
@@ -156,21 +220,28 @@
         --footer-input-border-color: #818181;
         --footer-filepicker-button-color: white;
         --footer-filepicker-focus-color: #896c6c;
-        --footnote-border-color: rgba(23, 115, 119, 0.15);
+        --footnote-border-color:
+        rgba(23, 115, 119, 0.15);
 
         /* undo delete cell*/
         --undo-delete-box-shadow-color: #0083;
 
         /*codemirror hints*/
-        --cm-editor-tooltip-border-color: rgba(0, 0, 0, 0.2);
+        --cm-editor-tooltip-border-color:
+        rgba(0, 0, 0, 0.2);
         --cm-editor-li-aria-selected-bg-color: #16659d;
         --cm-editor-li-aria-selected-color: white;
-        --cm-editor-li-notexported-color: rgba(0, 0, 0, 0.5);
-        --code-background: hsla(46, 90%, 98%, 1);
-        --cm-code-differs-gutters-color: rgba(214, 172, 35, 0.2);
+        --cm-editor-li-notexported-color:
+        rgba(0, 0, 0, 0.5);
+        --code-background:
+        hsla(46, 90%, 98%, 1);
+        --cm-code-differs-gutters-color:
+        rgba(214, 172, 35, 0.2);
         --cm-line-numbers-color: #8d86875e;
-        --cm-selection-background: hsl(214deg 100% 73% / 48%);
-        --cm-selection-background-blurred: hsl(214deg 0% 73% / 48%);
+        --cm-selection-background:
+        hsl(214deg 100% 73% / 48%);
+        --cm-selection-background-blurred:
+        hsl(214deg 0% 73% / 48%);
 
         /* code highlighting */
         --cm-editor-text-color: #41323f;
@@ -185,7 +256,8 @@
         --cm-var2-color: #37768a;
         --cm-builtin-color: #5e7ad3;
         --cm-function-color: #cc80ac;
-        --cm-type-color: hsl(170deg 7% 56%);
+        --cm-type-color:
+        hsl(170deg 7% 56%);
         --cm-bracket-color: #41323f;
         --cm-tag-color: #ef6155;
         --cm-link-color: #815ba4;
@@ -193,17 +265,21 @@
         --cm-error-color: #f7f7f7;
         --cm-matchingBracket-color: black;
         --cm-matchingBracket-bg-color: #1b4bbb21;
-        --cm-placeholder-text-color: rgba(0, 0, 0, 0.2);
+        --cm-placeholder-text-color:
+        rgba(0, 0, 0, 0.2);
 
         /*autocomplete menu*/
         --autocomplete-menu-bg-color: white;
 
         /* Landing colors */
-        --index-text-color: hsl(0, 0, 60);
-        --index-clickable-text-color: hsl(0, 0, 30);
+        --index-text-color:
+        hsl(0, 0, 60);
+        --index-clickable-text-color:
+        hsl(0, 0, 30);
         --docs-binding-bg: #8383830a;
         --index-card-bg: white;
-        --welcome-mywork-bg: hsl(35deg 66% 93%);
+        --welcome-mywork-bg:
+        hsl(35deg 66% 93%);
         --welcome-newnotebook-bg: whitesmoke;
         --welcome-recentnotebook-bg: white;
         --welcome-recentnotebook-border: #dfdfdf;

--- a/frontend/light_color.css
+++ b/frontend/light_color.css
@@ -141,7 +141,8 @@
         /* helpbox */
         --helpbox-bg-color: white;
         --helpbox-box-shadow-color: #00000010;
-        --helpbox-header-bg-color: #eef1f7;
+        --helpbox-header-bg-color: hsl(0deg 0% 92%);
+        --helpbox-header-tab-bg-color: white;
         --helpbox-header-color: hsl(230, 14%, 11%);
         --helpbox-notfound-header-color: rgb(139, 139, 139);
         --helpbox-text-color: black;


### PR DESCRIPTION
We are adding a new "Process status" tab to the bottom right popup (see https://juliapluto.github.io/weekly-call-notes/2022/11-15/notes.html ), and the first step is to change the layout of the Live Docs to make space for the new tab:


https://user-images.githubusercontent.com/6933510/202486151-d04ec4f2-7fd2-4885-9df8-63353e69eb20.mov


This PR does not actually add the _Process_ tab yet.
