### PR TITLE
Fix cell input scrollbars showing on Chrome Linux

### DIFF
--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -2779,7 +2779,7 @@ Based on "Paraíso (Light)" by Jan T. Sott:
 }
 
 pluto-input .cm-editor .cm-scroller {
-    overflow-x: hidden;
+    overflow-y: hidden;
 }
 
 pluto-input .cm-editor .cm-content,

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -649,6 +649,7 @@ nav#at_the_top > div.desktop_picker span {
 
 pluto-filepicker .cm-scroller {
     scrollbar-width: none; /* Firefox */
+    overflow-x: hidden;
 }
 pluto-filepicker .cm-scroller::-webkit-scrollbar {
     display: none; /* Safari and Chrome */

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -649,7 +649,6 @@ nav#at_the_top > div.desktop_picker span {
 
 pluto-filepicker .cm-scroller {
     scrollbar-width: none; /* Firefox */
-    overflow-x: hidden;
 }
 pluto-filepicker .cm-scroller::-webkit-scrollbar {
     display: none; /* Safari and Chrome */
@@ -2777,6 +2776,10 @@ Based on "Paraíso (Light)" by Jan T. Sott:
     padding: 0;
     margin-left: -1.5em;
     background: var(--autocomplete-menu-bg-color);
+}
+
+pluto-input .cm-editor .cm-scroller {
+    overflow-x: hidden;
 }
 
 pluto-input .cm-editor .cm-content,


### PR DESCRIPTION
Fix #2373

I am _fairly_ sure that this has no unintended side effects. The following still work:

- auto sizing cells
- wrapping
- the Pkg bubble popping out of the cell on the right