### PR TITLE
expose a function to return the bond names

### DIFF
--- a/src/evaluation/RunBonds.jl
+++ b/src/evaluation/RunBonds.jl
@@ -51,6 +51,11 @@ function set_bond_values_reactive(;
 end
 
 """
+Returns the names of all defined bonds
+"""
+get_bond_names(session::ServerSession, notebook::Notebook) = WorkspaceManager.get_bond_names((session,notebook))
+
+"""
 Returns the set of all possible values for the binded variable `n` as returned by the widget implementation using `AbstractPlutoDingetjes.possible_bond_values(element)`. This API is meant to be used by PlutoSliderServer.
 """
 possible_bond_values(session::ServerSession, notebook::Notebook, name::Symbol) = WorkspaceManager.possible_bond_values((session,notebook), name)

--- a/src/evaluation/RunBonds.jl
+++ b/src/evaluation/RunBonds.jl
@@ -57,7 +57,7 @@ function get_bond_names(session::ServerSession, notebook::Notebook)
     cells_bond_names = map(notebook.cell_order) do cell_id
         WorkspaceManager.get_bond_names((session,notebook), cell_id)
     end
-    return reduce(union, cells_bond_names)
+    union!(Set{Symbol}(), cells_bond_names...)
 end
 
 """

--- a/src/evaluation/RunBonds.jl
+++ b/src/evaluation/RunBonds.jl
@@ -53,7 +53,12 @@ end
 """
 Returns the names of all defined bonds
 """
-get_bond_names(session::ServerSession, notebook::Notebook) = WorkspaceManager.get_bond_names((session,notebook))
+function get_bond_names(session::ServerSession, notebook::Notebook)
+    cells_bond_names = map(notebook.cell_order) do cell_id
+        WorkspaceManager.get_bond_names((session,notebook), cell_id)
+    end
+    return reduce(union, cells_bond_names)
+end
 
 """
 Returns the set of all possible values for the binded variable `n` as returned by the widget implementation using `AbstractPlutoDingetjes.possible_bond_values(element)`. This API is meant to be used by PlutoSliderServer.

--- a/src/evaluation/WorkspaceManager.jl
+++ b/src/evaluation/WorkspaceManager.jl
@@ -240,11 +240,11 @@ function bump_workspace_module(session_notebook::SN)
     old_name, new_name
 end
 
-function get_bond_names(session_notebook::SN)
+function get_bond_names(session_notebook::SN, cell_id)
     workspace = get_workspace(session_notebook)
 
     Distributed.remotecall_eval(Main, workspace.pid, quote
-        PlutoRunner.get_bond_names()
+        PlutoRunner.get_bond_names($cell_id)
     end)
 end
 

--- a/src/evaluation/WorkspaceManager.jl
+++ b/src/evaluation/WorkspaceManager.jl
@@ -240,6 +240,14 @@ function bump_workspace_module(session_notebook::SN)
     old_name, new_name
 end
 
+function get_bond_names(session_notebook::SN)
+    workspace = get_workspace(session_notebook)
+
+    Distributed.remotecall_eval(Main, workspace.pid, quote
+        PlutoRunner.get_bond_names()
+    end)
+end
+
 function possible_bond_values(session_notebook::SN, n::Symbol; get_length::Bool=false)
     workspace = get_workspace(session_notebook)
 

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -1905,9 +1905,8 @@ function transform_bond_value(s::Symbol, value_from_js)
     end
 end
 
-function get_bond_names()
-    # We just get the keys of the already present dictionary storing the bond elements
-    return collect(keys(registered_bond_elements))
+function get_bond_names(cell_id)
+    get(cell_registered_bond_names, cell_id, Set{Symbol}())
 end
 
 function possible_bond_values(s::Symbol; get_length::Bool=false)

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -1905,6 +1905,11 @@ function transform_bond_value(s::Symbol, value_from_js)
     end
 end
 
+function get_bond_names()
+    # We just get the keys of the already present dictionary storing the bond elements
+    return collect(keys(registered_bond_elements))
+end
+
 function possible_bond_values(s::Symbol; get_length::Bool=false)
     element = registered_bond_elements[s]
     possible_values = possible_bond_values_ref[](element)

--- a/test/Bonds.jl
+++ b/test/Bonds.jl
@@ -358,6 +358,9 @@ import Distributed
         ])
         update_run!(🍭, notebook, notebook.cells)
 
+        # Test the get_bond_names function
+        @test Pluto.get_bond_names(🍭, notebook) == Set([:a, :b, :x, :y])
+
         function set_bond_values!(notebook:: Notebook, bonds:: Dict; is_first_value=false)
             for (name, value) in bonds
                 notebook.bonds[name] = Dict("value" => value)


### PR DESCRIPTION
This PR is a companion of the PlutoSliderServer one https://github.com/JuliaPluto/PlutoSliderServer.jl/pull/97.
On Pluto side, we expose a function that returns a vector of all the variable names (Symbols) currently bound in the notebook