### PR TITLE
⚡️ Run process start and pkg init in parallel

### DIFF
--- a/src/evaluation/Run.jl
+++ b/src/evaluation/Run.jl
@@ -416,7 +416,9 @@ function update_save_run!(
 			
 			if run_code
 				# this will trigger the notebook process to start. @async makes it run in the background, so that sync_nbpkg (below) can start running in parallel.
-				# (We don't need multithreading because the notebook runs is a separate process.)
+				# Some notes:
+				# - @async is enough, we don't need multithreading because the notebook runs in a separate process.
+				# - snyc_nbpkg manages the notebook package environment using Pkg on this server process. This means that sync_nbpkg does not need the notebook process at all, and it can run in parallel, before it has even started.
 				@async WorkspaceManager.get_workspace((session, notebook))
 			end
 			

--- a/src/evaluation/Run.jl
+++ b/src/evaluation/Run.jl
@@ -418,7 +418,7 @@ function update_save_run!(
 				# this will trigger the notebook process to start. @async makes it run in the background, so that sync_nbpkg (below) can start running in parallel.
 				# Some notes:
 				# - @async is enough, we don't need multithreading because the notebook runs in a separate process.
-				# - snyc_nbpkg manages the notebook package environment using Pkg on this server process. This means that sync_nbpkg does not need the notebook process at all, and it can run in parallel, before it has even started.
+				# - sync_nbpkg manages the notebook package environment using Pkg on this server process. This means that sync_nbpkg does not need the notebook process at all, and it can run in parallel, before it has even started.
 				@async WorkspaceManager.get_workspace((session, notebook))
 			end
 			


### PR DESCRIPTION
Fix #2405 

This will make a notebook launch 10 seconds faster in many cases!

Some notes:
- `@async` is enough, we don't need multithreading because the notebook runs in a separate process.
- `sync_nbpkg` manages the notebook package environment using Pkg on this server process. This means that `sync_nbpkg` does not need the notebook process at all, and it can run in parallel, before it has even started.


Proof that it works:

(This video was taken after deleting the `.julia` folder, that's why it's extra slow)

https://user-images.githubusercontent.com/6933510/204847618-2436b65d-c791-44fd-8d1f-79b7e7b38d16.mov

