### PR TITLE
Make featured notebook sources a frontend launch param

### DIFF
--- a/frontend/common/URLTools.js
+++ b/frontend/common/URLTools.js
@@ -1,4 +1,4 @@
-export const with_query_params = (/** @type {String | URL} */ url_str, /** @type {Record<string,string?>} */ params) => {
+export const with_query_params = (/** @type {String | URL} */ url_str, /** @type {Record<string,string | null | undefined>} */ params) => {
     const fake_base = "http://delete-me.com/"
     const url = new URL(url_str, fake_base)
     Object.entries(params).forEach(([key, val]) => {

--- a/frontend/components/welcome/Featured.js
+++ b/frontend/components/welcome/Featured.js
@@ -83,10 +83,11 @@ const offline_html = html`
 
 /**
  * @param {{
- * sources: FeaturedSource[]?
+ * sources: FeaturedSource[]?,
+ * direct_html_links: boolean,
  * }} props
  */
-export const Featured = ({ sources }) => {
+export const Featured = ({ sources, direct_html_links }) => {
     const [source_data, set_source_data] = useState(/** @type{Record<String,SourceManifest>} */ ({}))
 
     useEffect(() => {
@@ -150,7 +151,8 @@ export const Featured = ({ sources }) => {
                                       <p>${coll.description}</p>
                                       <div class="card-list">
                                           ${collection(Object.values(data.notebooks), coll.tags ?? []).map(
-                                              (entry) => html`<${FeaturedCard} entry=${entry} source_url=${data.source_url} />`
+                                              (entry) =>
+                                                  html`<${FeaturedCard} entry=${entry} source_url=${data.source_url} direct_html_links=${direct_html_links} />`
                                           )}
                                       </div>
                                   </div>

--- a/frontend/components/welcome/FeaturedCard.js
+++ b/frontend/components/welcome/FeaturedCard.js
@@ -10,27 +10,42 @@ const str_to_degree = (s) => ([...s].reduce((a, b) => a + b.charCodeAt(0), 0) * 
 /**
  * @param {{
  *  entry: import("./Featured.js").SourceManifestNotebookEntry,
- *  source_url: String,
+ *  source_url?: string,
+ *  direct_html_links: boolean,
  * }} props
  */
-export const FeaturedCard = ({ entry, source_url }) => {
+export const FeaturedCard = ({ entry, source_url, direct_html_links }) => {
     const title = entry.frontmatter?.title
-    const u = (x) => (x == null ? null : new URL(x, source_url).href)
 
-    const href = with_query_params(`editor.html`, {
-        statefile: u(entry.statefile_path),
-        notebookfile: u(entry.notebookfile_path),
-        notebookfile_integrity: `sha256-${base64url_to_base64(entry.hash)}`,
-        disable_ui: `true`,
-        pluto_server_url: `.`,
-        name: title == null ? null : `sample ${title}`,
-    })
+    const u = (/** @type {string | null | undefined} */ x) =>
+        source_url == null
+            ? x
+            : x == null
+            ? null
+            : // URLs are relative to the source URL...
+              new URL(
+                  x,
+                  // ...and the source URL is relative to the current location
+                  new URL(source_url, window.location.href)
+              ).href
+
+    // `direct_html_links` means that we will navigate you directly to the exported HTML file. Otherwise, we use our local editor, with the exported state as parameters. This lets users run the featured notebooks locally.
+    const href = direct_html_links
+        ? u(entry.html_path)
+        : with_query_params(`editor.html`, {
+              statefile: u(entry.statefile_path),
+              notebookfile: u(entry.notebookfile_path),
+              notebookfile_integrity: `sha256-${base64url_to_base64(entry.hash)}`,
+              disable_ui: `true`,
+              pluto_server_url: `.`,
+              name: title == null ? null : `sample ${title}`,
+          })
 
     const author = author_info(entry.frontmatter)
 
     return html`
         <featured-card style=${`--card-color-hue: ${str_to_degree(entry.id)}deg;`}>
-            <a class="banner" href=${href}><img src=${u(entry.frontmatter.image) ?? transparent_svg} /></a>
+            <a class="banner" href=${href}><img src=${u(entry?.frontmatter?.image) ?? transparent_svg} /></a>
             ${author?.name == null
                 ? null
                 : html`
@@ -38,8 +53,8 @@ export const FeaturedCard = ({ entry, source_url }) => {
                           <a href=${author.url}> <img src=${author.image ?? transparent_svg} /><span>${author.name}</span></a>
                       </div>
                   `}
-            <h3><a href=${href} title=${entry.frontmatter.title}>${entry.frontmatter.title}</a></h3>
-            <p title=${entry.frontmatter.description}>${entry.frontmatter.description}</p>
+            <h3><a href=${href} title=${entry?.frontmatter?.title}>${entry?.frontmatter?.title ?? entry.id}</a></h3>
+            <p title=${entry?.frontmatter?.description}>${entry?.frontmatter?.description}</p>
         </featured-card>
     `
 }

--- a/frontend/components/welcome/Welcome.js
+++ b/frontend/components/welcome/Welcome.js
@@ -26,7 +26,6 @@ import default_featured_sources from "../../featured_sources.js"
 /**
  * @typedef LaunchParameters
  * @type {{
- * featured_static: boolean,
  * featured_direct_html_links: boolean,
  * featured_sources: import("./Featured.js").FeaturedSource[]?,
  * featured_source_url?: string,
@@ -55,8 +54,6 @@ export const Welcome = ({ launch_params }) => {
     const client_ref = useRef(/** @type {import('../../common/PlutoConnection').PlutoConnection} */ ({}))
 
     useEffect(() => {
-        if (launch_params.featured_static) return
-
         const on_update = ({ message, type }) => {
             if (type === "notebook_list") {
                 // a notebook list updates happened while the welcome screen is open, because a notebook started running for example

--- a/frontend/components/welcome/Welcome.js
+++ b/frontend/components/welcome/Welcome.js
@@ -108,15 +108,18 @@ export const Welcome = ({ launch_params }) => {
         }
     }
 
-    /** @type {import("./Featured.js").FeaturedSource[]} */
+    /**
+     * These are the sources from which we will download the featured notebook titles and metadata.
+     * @type {import("./Featured.js").FeaturedSource[]}
+     */
     const featured_sources = preact.useMemo(
         () =>
-            // 1
+            // Option 1: configured directly
             launch_params.featured_sources ??
-            // 2
+            // Option 2: configured through url and integrity strings
             (launch_params.featured_source_url
                 ? [{ url: launch_params.featured_source_url, integrity: launch_params.featured_source_integrity }]
-                : // 3
+                : // Option 3: default
                   default_featured_sources.sources),
         [launch_params]
     )
@@ -162,16 +165,3 @@ export const Welcome = ({ launch_params }) => {
         </section>
     `
 }
-
-// Option 1: Dynamically load source list from a json:
-// const [sources, set_sources] = useState(/** @type{Array<{url: String, integrity: String?}>?} */ (null))
-// useEffect(() => {
-//     run(async () => {
-//         const data = await (await fetch("featured_sources.json")).json()
-
-//         set_sources(data.sources)
-//     })
-// }, [])
-
-// Option 2: From a JS file. This means that the source list can be bundled together.
-// const sources = featured_sources.sources

--- a/frontend/components/welcome/Welcome.js
+++ b/frontend/components/welcome/Welcome.js
@@ -131,44 +131,38 @@ export const Welcome = ({ launch_params }) => {
         `
     }
 
-    const featured_html = html`
+    return html`
+        <section id="title">
+            <h1>welcome to <img src=${url_logo_big} /></h1>
+        </section>
+        <section id="mywork">
+            <div>
+                <${Recent}
+                    client=${client_ref.current}
+                    connected=${connected}
+                    remote_notebooks=${remote_notebooks}
+                    CustomRecent=${CustomRecent}
+                    on_start_navigation=${on_start_navigation}
+                />
+            </div>
+        </section>
+        <section id="open">
+            <div>
+                <${Open}
+                    client=${client_ref.current}
+                    connected=${connected}
+                    CustomPicker=${CustomPicker}
+                    show_samples=${show_samples}
+                    on_start_navigation=${on_start_navigation}
+                />
+            </div>
+        </section>
         <section id="featured">
             <div>
                 <${Featured} sources=${featured_sources} direct_html_links=${launch_params.featured_direct_html_links} />
             </div>
         </section>
     `
-
-    return launch_params.featured_static
-        ? featured_html
-        : html`
-              <section id="title">
-                  <h1>welcome to <img src=${url_logo_big} /></h1>
-              </section>
-              <section id="mywork">
-                  <div>
-                      <${Recent}
-                          client=${client_ref.current}
-                          connected=${connected}
-                          remote_notebooks=${remote_notebooks}
-                          CustomRecent=${CustomRecent}
-                          on_start_navigation=${on_start_navigation}
-                      />
-                  </div>
-              </section>
-              <section id="open">
-                  <div>
-                      <${Open}
-                          client=${client_ref.current}
-                          connected=${connected}
-                          CustomPicker=${CustomPicker}
-                          show_samples=${show_samples}
-                          on_start_navigation=${on_start_navigation}
-                      />
-                  </div>
-              </section>
-              ${featured_html}
-          `
 }
 
 // Option 1: Dynamically load source list from a json:

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -11,8 +11,6 @@ const url_params = new URLSearchParams(window.location.search)
  */
 const launch_params = {
     //@ts-ignore
-    featured_static: !!(url_params.get("featured_static") ?? window.pluto_featured_static),
-    //@ts-ignore
     featured_direct_html_links: !!(url_params.get("featured_direct_html_links") ?? window.pluto_featured_direct_html_links),
 
     //@ts-ignore

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -11,6 +11,11 @@ const url_params = new URLSearchParams(window.location.search)
  */
 const launch_params = {
     //@ts-ignore
+    featured_static: !!(url_params.get("featured_static") ?? window.pluto_featured_static),
+    //@ts-ignore
+    featured_direct_html_links: !!(url_params.get("featured_direct_html_links") ?? window.pluto_featured_direct_html_links),
+
+    //@ts-ignore
     featured_sources: window.pluto_featured_sources,
 
     // Setting the featured_sources object is preferred, but you can also specify a single featured source using the URL (and integrity), which also supports being set as a URL parameter.
@@ -20,6 +25,8 @@ const launch_params = {
     //@ts-ignore
     featured_source_integrity: url_params.get("featured_source_integrity") ?? window.pluto_featured_source_integrity,
 }
+
+console.log("Launch parameters: ", launch_params)
 
 // @ts-ignore
 render(html`<${Welcome} launch_params=${launch_params} />`, document.querySelector("#app"))

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -3,5 +3,23 @@ import "./common/NodejsCompatibilityPolyfill.js"
 
 import { Welcome } from "./components/welcome/Welcome.js"
 
+const url_params = new URLSearchParams(window.location.search)
+
+/**
+ *
+ * @type {import("./components/welcome/Welcome.js").LaunchParameters}
+ */
+const launch_params = {
+    //@ts-ignore
+    featured_sources: window.pluto_featured_sources,
+
+    // Setting the featured_sources object is preferred, but you can also specify a single featured source using the URL (and integrity), which also supports being set as a URL parameter.
+
+    //@ts-ignore
+    featured_source_url: url_params.get("featured_source_url") ?? window.pluto_featured_source_url,
+    //@ts-ignore
+    featured_source_integrity: url_params.get("featured_source_integrity") ?? window.pluto_featured_source_integrity,
+}
+
 // @ts-ignore
-render(html`<${Welcome} />`, document.querySelector("#app"))
+render(html`<${Welcome} launch_params=${launch_params} />`, document.querySelector("#app"))

--- a/src/notebook/Export.jl
+++ b/src/notebook/Export.jl
@@ -215,7 +215,6 @@ function generate_index_html(;
     version::Union{Nothing,VersionNumber,AbstractString}=nothing, 
     pluto_cdn_root::Union{Nothing,AbstractString}=nothing,
 
-    featured_static::Bool=false,
     featured_direct_html_links::Bool=false,
     featured_sources_js::AbstractString="undefined",
 )
@@ -233,7 +232,6 @@ function generate_index_html(;
     
     parameters = """
     <script data-pluto-file="launch-parameters">
-    window.pluto_featured_static = $(featured_static ? "true" : "false");
     window.pluto_featured_direct_html_links = $(featured_direct_html_links ? "true" : "false");
     window.pluto_featured_sources = $(featured_sources_js);
     </script>

--- a/src/notebook/Export.jl
+++ b/src/notebook/Export.jl
@@ -64,7 +64,7 @@ inserted_html(original_contents::AbstractString;
         $(_insertion_meta)
         """
     ),
-    _insertion_meta => 
+    _insertion_parameters => 
     """
     $(parameters)
     $(_insertion_parameters)

--- a/src/notebook/Export.jl
+++ b/src/notebook/Export.jl
@@ -181,9 +181,6 @@ function frontmatter_html(frontmatter::Dict{String,Any}; default_frontmatter::Di
 end
 
 
-
-
-
 replace_substring(s::String, sub::SubString, newval::AbstractString) = *(
 	SubString(s, 1, prevind(s, sub.offset + 1, 1)), 
 	newval, 
@@ -209,4 +206,38 @@ function replace_with_cdn(cdnify::Function, s::String, idx::Integer=1)
 			))
 		end
 	end
+end
+
+"""
+Generate a custom index.html that is designed to display a custom set of featured notebooks, without the file UI or Pluto logo. This is to be used by [PlutoSliderServer.jl](https://github.com/JuliaPluto/PlutoSliderServer.jl) to show a fancy index page.
+"""
+function generate_index_html(;
+    version::Union{Nothing,VersionNumber,AbstractString}=nothing, 
+    pluto_cdn_root::Union{Nothing,AbstractString}=nothing,
+
+    featured_static::Bool=false,
+    featured_direct_html_links::Bool=false,
+    featured_sources_js::AbstractString="undefined",
+)
+    cdnified = cdnified_html("index.html"; version, pluto_cdn_root)
+    
+    meta = """
+    <style>
+    section#open,
+    section#mywork,
+    section#title {
+        display: none !important;
+    }
+    </style>
+    """
+    
+    parameters = """
+    <script data-pluto-file="launch-parameters">
+    window.pluto_featured_static = $(featured_static ? "true" : "false");
+    window.pluto_featured_direct_html_links = $(featured_direct_html_links ? "true" : "false");
+    window.pluto_featured_sources = $(featured_sources_js);
+    </script>
+    """
+    
+    inserted_html(cdnified; meta, parameters)
 end

--- a/src/notebook/path helpers.jl
+++ b/src/notebook/path helpers.jl
@@ -119,6 +119,9 @@ const pluto_file_extensions = [
 
 endswith_pluto_file_extension(s) = any(endswith(s, e) for e in pluto_file_extensions)
 
+"""
+Extract the Julia notebook file contents from a Pluto-exported HTML file.
+"""
 function embedded_notebookfile(html_contents::AbstractString)::String
 	if !occursin("</html>", html_contents)
 		throw(ArgumentError("Pass the contents of a Pluto-exported HTML file as argument."))

--- a/test/Notebook.jl
+++ b/test/Notebook.jl
@@ -541,7 +541,7 @@ end
         end
     end
 
-    @testset "Import & export HTML" begin
+    @testset "Export HTML" begin
         nb = basic_notebook()
         nb.metadata["frontmatter"] = Dict{String,Any}(
             "title" => "My<Title",
@@ -550,6 +550,7 @@ end
         )
         export_html = replace(Pluto.generate_html(nb), "'" => "\"")
         
+        @test occursin("<pluto-editor", export_html)
         @test occursin("<title>My&lt;Title</title>", export_html)
         @test occursin("""<meta name="description" content="ccc">""", export_html)
         @test occursin("""<meta property="og:description" content="ccc">""", export_html)
@@ -570,6 +571,15 @@ end
         export_html = Pluto.generate_html(nb; notebookfile_js=filename)
         @test occursin(filename, export_html)
         @test_throws ArgumentError Pluto.embedded_notebookfile(export_html)
+        
+        
+        export_html = Pluto.generate_index_html()
+        @test occursin("</html>", export_html)
+        @test !occursin("<pluto-editor", export_html)
+        
+        export_html = Pluto.generate_index_html(; featured_static=true, featured_direct_html_links=true, featured_sources_js="[{url:`./zozozo.json`}]")
+        
+        @test occursin("zozozo", export_html)
     end
 
     @testset "Utilities" begin

--- a/test/Notebook.jl
+++ b/test/Notebook.jl
@@ -577,7 +577,7 @@ end
         @test occursin("</html>", export_html)
         @test !occursin("<pluto-editor", export_html)
         
-        export_html = Pluto.generate_index_html(; featured_static=true, featured_direct_html_links=true, featured_sources_js="[{url:`./zozozo.json`}]")
+        export_html = Pluto.generate_index_html(; featured_direct_html_links=true, featured_sources_js="[{url:`./zozozo.json`}]")
         
         @test occursin("zozozo", export_html)
     end


### PR DESCRIPTION
This is necessary to render the featured notebooks directly on our WIP website :)


You can test it:
```
http://localhost:1234/?featured_source_url=https%3A%2F%2Fmit-c25.netlify.app%2Fpluto_export.json
```

This will show the regular index page, but with the notebooks from https://mit-c25.netlify.app/ as source! (These don't have images, because no image URLs are given in the frontmatters in that repository.)


Matching PlutoSliderServer PR: 
- https://github.com/JuliaPluto/PlutoSliderServer.jl/pull/100