### PR TITLE
Run Bundle action on PRs

### DIFF
--- a/.github/workflows/Bundle.yml
+++ b/.github/workflows/Bundle.yml
@@ -5,6 +5,13 @@ on:
         branches:
             - main
     workflow_dispatch:
+    pull_request:
+        paths-ignore:
+            - "**.md"
+            - "**.jl"
+        branches-ignore:
+            - release
+
 concurrency:
     group: bundle
     cancel-in-progress: false
@@ -56,6 +63,7 @@ jobs:
             # Needs to be `add --force` because frontend-dist is normally gitignored.
             # Also needs `push --force` because we reset to main (which doesn't contain the previous frontend-dist)
             - name: Force push frontend-dist changes
+              if: github.event_name != 'pull_request'
               run: |
                   git add frontend-dist --force
                   git commit -m "$GITHUB_WORKFLOW" -m "Built from hash $GITHUB_SHA"


### PR DESCRIPTION
This PR will run the bundle action on each PR, without pushing the result to the `release` branch.

This will make sure that changes from a PR do not cause bundling issues. It will also check PRs like https://github.com/fonsp/Pluto.jl/pull/2411