### PR TITLE
Pkg.instantiate before initial resolve when opening a notebook

### DIFF
--- a/frontend/components/ProcessTab.js
+++ b/frontend/components/ProcessTab.js
@@ -55,6 +55,8 @@ const descriptions = {
     create_process: "Start Julia",
     init_process: "Initialize",
     pkg: "Package management",
+    instantiate1: "instantiate",
+    instantiate2: "instantiate",
     run: "Evaluating cells",
     evaluate: "Running code",
     registry_update: "Updating package registry",

--- a/test/packages/Basic.jl
+++ b/test/packages/Basic.jl
@@ -236,6 +236,31 @@ import Distributed
         WorkspaceManager.unmake_workspace((🍭, notebook))
     end
     
+    @testset "Package added by url" begin
+        url_notebook = read(joinpath(@__DIR__, "url_import.jl"), String)
+
+        🍭 = ServerSession()
+
+        dir = mktempdir()
+        path = joinpath(dir, "hello.jl")
+        write(path, url_notebook)
+
+        notebook = SessionActions.open(🍭, path; run_async=false)
+        
+        @test num_backups_in(dir) == 0
+
+        @test notebook.nbpkg_ctx !== nothing
+        @test notebook.nbpkg_restart_recommended_msg === nothing
+        @test notebook.nbpkg_restart_required_msg === nothing
+
+        @test noerror(notebook.cells[1])
+        @test noerror(notebook.cells[2])
+
+        @test notebook.cells[2].output.body == "1.0.0"
+
+        WorkspaceManager.unmake_workspace((🍭, notebook))
+    end
+    
     future_notebook = read(joinpath(@__DIR__, "future_nonexisting_version.jl"), String)
     @testset "Recovery from unavailable versions" begin
         🍭 = ServerSession()
@@ -393,6 +418,7 @@ import Distributed
 
     pre_pkg_notebook = read(joinpath(@__DIR__, "old_import.jl"), String)
     local post_pkg_notebook = nothing
+
     @testset "File format -- Backwards compat" begin
         🍭 = ServerSession()
 

--- a/test/packages/url_import.jl
+++ b/test/packages/url_import.jl
@@ -8,7 +8,7 @@ using InteractiveUtils
 import PlutoPkgTestF
 
 # ╔═╡ f6d8e48e-f400-4e27-8a83-f7bf2e72e992
-PlutoPkgTestF.MY_VERSION
+PlutoPkgTestF.MY_VERSION |> Text
 
 # ╔═╡ 00000000-0000-0000-0000-000000000001
 PLUTO_PROJECT_TOML_CONTENTS = """

--- a/test/packages/url_import.jl
+++ b/test/packages/url_import.jl
@@ -1,0 +1,151 @@
+### A Pluto.jl notebook ###
+# v0.19.18
+
+using Markdown
+using InteractiveUtils
+
+# ╔═╡ 3717ac9c-821f-11ed-14bc-d3b0f9fd1efe
+import PlutoPkgTestF
+
+# ╔═╡ f6d8e48e-f400-4e27-8a83-f7bf2e72e992
+PlutoPkgTestF.MY_VERSION
+
+# ╔═╡ 00000000-0000-0000-0000-000000000001
+PLUTO_PROJECT_TOML_CONTENTS = """
+[deps]
+PlutoPkgTestF = "7007ab80-a928-4ddc-1332-8dd20f5a112f"
+"""
+
+# ╔═╡ 00000000-0000-0000-0000-000000000002
+PLUTO_MANIFEST_TOML_CONTENTS = """
+# This file is machine-generated - editing it directly is not advised
+
+[[ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+
+[[Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[Downloads]]
+deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+
+[[LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+
+[[LibGit2]]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+
+[[MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+
+[[NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+
+[[Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[PlutoPkgTestA]]
+deps = ["Pkg"]
+git-tree-sha1 = "9615c7f69a1780f70fe32890ac370728afbcb2f6"
+uuid = "419c6f8d-b8cd-4309-abdc-cee491252f94"
+version = "0.3.1"
+
+[[PlutoPkgTestF]]
+deps = ["Pkg", "PlutoPkgTestA"]
+git-tree-sha1 = "f486ebc1188475df900413cbd570ff7fabed738f"
+repo-rev = "main"
+repo-url = "https://github.com/JuliaPluto/PlutoPkgTestF.jl"
+uuid = "7007ab80-a928-4ddc-1332-8dd20f5a112f"
+version = "1.0.0"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+[[Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+
+[[nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+
+[[p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+"""
+
+# ╔═╡ Cell order:
+# ╠═3717ac9c-821f-11ed-14bc-d3b0f9fd1efe
+# ╠═f6d8e48e-f400-4e27-8a83-f7bf2e72e992
+# ╟─00000000-0000-0000-0000-000000000001
+# ╟─00000000-0000-0000-0000-000000000002


### PR DESCRIPTION
When opening a notebook, we will now first call `Pkg.instantiate()` and *then* `Pkg.resolve()`. Right now, we do it the other way around.

I found out that it is necessary to instantiate before resolving when notebooks use a package directly from github. This makes sense: you need to download the repo (i.e. instantiate) so that you can read its Project.toml, before you could go through the entire dependency tree (i.e. resolve). 

Example of a notebook that does not load right now, but it loads after this PR:

https://github.com/MarkNahabedian/CRMII/blob/45a0867c89d071f00da2643340d1534d195a24b1/TowerClock/tower_clock_notebook.jl

Note that the author used `Pluto.activate_notebook_environment` to modify the notebook's env, adding the unregistered package by its github url:

https://github.com/MarkNahabedian/CRMII/blob/45a0867c89d071f00da2643340d1534d195a24b1/TowerClock/tower_clock_notebook.jl#L478-L484


---

Actually, I realise that our use of `resolve` is a bit odd: we use it as the first command we call when opening a new environment. According to the [limited docs](https://pkgdocs.julialang.org/v1/api/#Pkg.resolve), resolve will:

> Update the current manifest with potential changes to the dependency graph from packages that are tracking a path.

i.e. it is there for when your environment contains `dev`ed packages from a local path, which basically never happens in a Pluto-managed env (but we should do it anyways to be future-proof). 

We use it in a very different way, mostly to create a Manifest.toml if it does not exist.

# TODO
- [x] test case similar to the tower clock notebook
- [ ] Check if https://github.com/fonsp/Pluto.jl/pull/2298 still works
- [x] Check if https://github.com/fonsp/Pluto.jl/pull/2294 still works (this is covered by tests)