### PR TITLE
Add column resizing functionality to Pluto tables.

### DIFF
--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -428,13 +428,28 @@ pluto-output table > tbody td code {
 pluto-output table td,
 pluto-output table th {
     padding: 0.2rem 0.5rem;
+    text-align: center;
+}
+
+pluto-output div.table-col-resizer {
+    /* Resizer displayed at the right end of column */
+    position: absolute;
+    top:0;
+    right:0;
+    width: 5px;
+    height: 100%; 
+    cursor: col-resize;
+}
+
+pluto-output div.table-col-resizer:hover{
+    border-right: 2px solid rgb(0, 149, 255);
 }
 
 pluto-output table > tbody tr:hover {
     background-color: var(--table-bg-hover-color);
 }
 pluto-output table pre {
-    white-space: pre;
+    white-space: pre-wrap;
 }
 
 pluto-output kbd,

--- a/frontend/treeview.css
+++ b/frontend/treeview.css
@@ -275,6 +275,10 @@ table.pluto-table {
     table-layout: fixed;
 }
 
+table.pluto-table th {
+    word-wrap: break-word;
+}
+
 table.pluto-table td {
     max-width: 300px;
     overflow: hidden;


### PR DESCRIPTION
This PR proposes a potential fix for #2190 and adds the following features to pluto tables :

1. Allows user to resize columns by dragging a div between column headers. 
2. Double clicking on the div between columns resizes that column to fit the longest string/item in that column.

https://user-images.githubusercontent.com/26337751/209561873-95df729d-2cf5-4e33-aa20-a0313d108fbd.mov

