### PR TITLE
fix: don't use `wslpath` if path is a regular file

### DIFF
--- a/src/notebook/path helpers.jl
+++ b/src/notebook/path helpers.jl
@@ -26,6 +26,7 @@ but "/mnt/c/Users/pankg/OneDrive/Desktop/pluto/bakery_pnl_ready2.jl" stays the s
 """
 function maybe_convert_path_to_wsl(path)
     try
+		isfile(path) && return path
         if detectwsl()
             # wslpath utility prints path to stderr if it fails to convert
             # (it used to fail for WSL-valid paths)

--- a/src/notebook/path helpers.jl
+++ b/src/notebook/path helpers.jl
@@ -26,7 +26,7 @@ but "/mnt/c/Users/pankg/OneDrive/Desktop/pluto/bakery_pnl_ready2.jl" stays the s
 """
 function maybe_convert_path_to_wsl(path)
     try
-		isfile(path) && return path
+        isfile(path) && return path
         if detectwsl()
             # wslpath utility prints path to stderr if it fails to convert
             # (it used to fail for WSL-valid paths)


### PR DESCRIPTION
Should fix https://github.com/fonsp/Pluto.jl/issues/2274

@kryptan can you test and let me know if it does the trick?