### PR TITLE
fix pluto_showable for Tables.jl without iterate

### DIFF
--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -1573,7 +1573,7 @@ const integrations = Integration[
             end
 
 
-            pluto_showable(::MIME"application/vnd.pluto.table+object", x::Any) = try Tables.rowaccess(x)::Bool && !isempty(x) catch; false end
+            pluto_showable(::MIME"application/vnd.pluto.table+object", x::Any) = try Tables.rowaccess(x)::Bool && !isempty(Tables.rows(x)) catch; false end
             pluto_showable(::MIME"application/vnd.pluto.table+object", t::Type) = false
             pluto_showable(::MIME"application/vnd.pluto.table+object", t::AbstractVector{<:NamedTuple}) = false
             pluto_showable(::MIME"application/vnd.pluto.table+object", t::AbstractVector{<:Dict{Symbol,<:Any}}) = false


### PR DESCRIPTION
Fixes https://github.com/fonsp/Pluto.jl/issues/2309#issuecomment-1342774073 @juliohm can you check it?

`isempty` depends on `iterate` on the general case, which is _not_ guaranteed to exist for Table objects; rather, we're guaranteed to be able to get an iterator by requesting `Table.rows` on the object.

@fonsp do you have any reason in particular to avoid that, except performance? I'm a bit worried that for _some_ objects (e.g. database cursors) this will move a cursor or something; but in the general case it should be fine.