### PR TITLE
Use <a> tag for global variable links

### DIFF
--- a/frontend/components/CellInput/go_to_definition_plugin.js
+++ b/frontend/components/CellInput/go_to_definition_plugin.js
@@ -19,11 +19,7 @@ let get_variable_marks = (state, { scopestate, global_definitions }) => {
                     // .... Because now it will only show variables after it has run once
                     if (global_definitions[name]) {
                         return Decoration.mark({
-                            // TODO This used to be tagName: "a", but codemirror doesn't like that...
-                            // .... https://github.com/fonsp/Pluto.jl/issues/1790
-                            // .... Ideally we'd change it back to `a` (feels better), but functionally there is no difference..
-                            // .... When I ever happen to find a lot of time I can spend on this, I'll debug and change it back to `a`
-                            tagName: "pluto-variable-link",
+                            tagName: "a",
                             attributes: {
                                 "title": `${ctrl_or_cmd_name}-Click to jump to the definition of ${name}.`,
                                 "data-pluto-variable": name,
@@ -46,7 +42,7 @@ let get_variable_marks = (state, { scopestate, global_definitions }) => {
                 } else {
                     // Could be used to select the definition of a variable inside the current cell
                     return Decoration.mark({
-                        tagName: "pluto-variable-link",
+                        tagName: "a",
                         attributes: {
                             "title": `${ctrl_or_cmd_name}-Click to jump to the definition of ${name}.`,
                             "data-cell-variable": name,

--- a/frontend/components/CellInput/go_to_definition_plugin.js
+++ b/frontend/components/CellInput/go_to_definition_plugin.js
@@ -102,8 +102,8 @@ export const go_to_definition_plugin = ViewPlugin.fromClass(
         decorations: (v) => v.decorations,
 
         eventHandlers: {
-            pointerdown: (event, view) => {
-                if (has_ctrl_or_cmd_pressed(event) && event.button === 0 && event.target instanceof Element) {
+            click: (event, view) => {
+                if (has_ctrl_or_cmd_pressed(event) && event.target instanceof Element) {
                     let pluto_variable = event.target.closest("[data-pluto-variable]")
                     if (pluto_variable) {
                         let variable = pluto_variable.getAttribute("data-pluto-variable")

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -1122,7 +1122,7 @@ patch: ${JSON.stringify(
         const set_ctrl_down = (value) => {
             if (value !== ctrl_down_last_val.current) {
                 ctrl_down_last_val.current = value
-                document.body.querySelectorAll("pluto-variable-link").forEach((el) => {
+                document.body.querySelectorAll("[data-pluto-variable]").forEach((el) => {
                     el.setAttribute("data-ctrl-down", value ? "true" : "false")
                 })
             }

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -3051,6 +3051,7 @@ Based on "Paraíso (Light)" by Jan T. Sott:
 }
 
 [data-pluto-variable],
+[data-pluto-variable]:hover,
 .cm-editor .cm-tooltip.cm-tooltip-autocomplete li.c_from_notebook .cm-completionLabel {
     font-weight: bold;
     text-decoration: underline;
@@ -3060,7 +3061,8 @@ Based on "Paraíso (Light)" by Jan T. Sott:
 }
 
 @media (prefers-color-scheme: dark) {
-    [data-pluto-variable] {
+    [data-pluto-variable],
+    [data-pluto-variable]:hover {
         text-decoration-color: #5d5f70;
     }
 }


### PR DESCRIPTION
This makes global variable links **clickable in PDF exports** 🎉

Video below is my PDF viewer, reading a PDF generated by Pluto:


https://user-images.githubusercontent.com/6933510/213533856-60910f15-4448-45a3-8613-b42007b04a6d.mov



We initially used `<a>`, but because of https://github.com/fonsp/Pluto.jl/issues/1790 we changed it to `<pluto-variable-link>`. I noticed that we can change it back to `<a>` without getting https://github.com/fonsp/Pluto.jl/issues/1790 again, this was probably fixed in the codemirror 6.0 release. (cc @dralletje )

# TODO:
- [x] Test clickable in PDF (tested on iOS, MacOS Preview, Firefox and Chrome)
- [x] Prevent opening a new tab 😅
- [x] Test that https://github.com/fonsp/Pluto.jl/issues/1790 is still solved (tested on iOS, MacOS Safari, Chrome)
- [ ] Check carefully for new bugs