### PR TITLE
📚 Tree viewer: Limit size of <pre> inside collapsed node

### DIFF
--- a/frontend/treeview.css
+++ b/frontend/treeview.css
@@ -338,3 +338,8 @@ table.pluto-table .pluto-tree-more-td pluto-tree-more {
     top: 2rem;
     max-width: 650px;
 }
+
+pluto-tree.collapsed p-v > pre {
+    max-height: 2em;
+    overflow-y: hidden;
+}


### PR DESCRIPTION
# Before

Notice the large amount of empty vertical space: this is being taken up by a `<pre>` way to the right, out of the screen


https://user-images.githubusercontent.com/6933510/213546405-0513348b-5d6e-4f4f-8fbf-0025953ba598.mov



# After


https://user-images.githubusercontent.com/6933510/213546394-b6a632f5-34cf-4905-99b1-01e6a20c8c1f.mov

