### PR TITLE
👆 Jump-to-definition on click without Ctrl/Cmd in static export

### DIFF
--- a/frontend/components/CellInput/go_to_definition_plugin.js
+++ b/frontend/components/CellInput/go_to_definition_plugin.js
@@ -103,11 +103,15 @@ export const go_to_definition_plugin = ViewPlugin.fromClass(
 
         eventHandlers: {
             click: (event, view) => {
-                if (has_ctrl_or_cmd_pressed(event) && event.target instanceof Element) {
+                if (event.target instanceof Element) {
                     let pluto_variable = event.target.closest("[data-pluto-variable]")
                     if (pluto_variable) {
                         let variable = pluto_variable.getAttribute("data-pluto-variable")
                         if (variable == null) {
+                            return false
+                        }
+
+                        if (!(has_ctrl_or_cmd_pressed(event) || view.state.readOnly)) {
                             return false
                         }
 

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -1294,6 +1294,8 @@ patch: ${JSON.stringify(
     componentDidUpdate(old_props, old_state) {
         //@ts-ignore
         window.editor_state = this.state
+        //@ts-ignore
+        window.editor_state_set = this.setStatePromise
 
         const new_state = this.state
 

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -3071,13 +3071,17 @@ Based on "Paraíso (Light)" by Jan T. Sott:
     }
 }
 
-[data-ctrl-down="true"][data-pluto-variable],
-[data-ctrl-down="true"][data-cell-variable] {
+body.disable_ui [data-pluto-variable],
+body.disable_ui [data-cell-variable] {
+    cursor: pointer;
+}
+body:not(.disable_ui) [data-ctrl-down="true"][data-pluto-variable],
+body:not(.disable_ui) [data-ctrl-down="true"][data-cell-variable] {
     text-decoration-color: #d177e6;
     cursor: pointer;
 }
-[data-ctrl-down="true"][data-pluto-variable]:hover,
-[data-ctrl-down="true"][data-pluto-variable]:hover * {
+body:not(.disable_ui) [data-ctrl-down="true"][data-pluto-variable]:hover,
+body:not(.disable_ui) [data-ctrl-down="true"][data-pluto-variable]:hover * {
     /* This basically `color: #af5bc3`, but it works for emoji too!! */
     color: transparent !important;
     text-shadow: 0 0 #af5bc3;


### PR DESCRIPTION
In a static HTML export, you can now click on underlined global variables to jump to its definition. Before this PR, you had to hold Ctrl/Cmd while clicking. After this PR, Ctrl/Cmd is only required in editing mode. (#2449 would help make this clear.)

Same as #2450, but for HTML instead of PDF. (We can't use the same mechanism because codemirror intercepts the `click` event and calls `.preventDefault()`. On the PDF, just using the `<a>` tag already works, because codemirror is not running when viewing the PDF.)

The tooltip is not changed (`Ctrl+Click to jump to the definition of hello_world.`), but holding down Ctrl while clicking simply has no effect, so it's still correct 😅