### PR TITLE
Unregister Bonds at the start of the reactive run.

### DIFF
--- a/src/evaluation/WorkspaceManager.jl
+++ b/src/evaluation/WorkspaceManager.jl
@@ -596,7 +596,8 @@ function move_vars(
     to_delete::Set{Symbol},
     methods_to_delete::Set{Tuple{UUID,FunctionName}},
     module_imports_to_move::Set{Expr},
-    invalidated_cell_uuids::Set{UUID};
+    invalidated_cell_uuids::Set{UUID},
+    keep_registered::Set{Symbol}=Set{Symbol}();
     kwargs...
     )
 
@@ -611,6 +612,7 @@ function move_vars(
             $methods_to_delete,
             $module_imports_to_move,
             $invalidated_cell_uuids,
+            $keep_registered,
         )
     end)
 end

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -2014,8 +2014,8 @@ struct Bond
     Bond(element, defines::Symbol) = showable(MIME"text/html"(), element) ? new(element, defines, Base64.base64encode(rand(UInt8,9))) : error("""Can only bind to html-showable objects, ie types T for which show(io, ::MIME"text/html", x::T) is defined.""")
 end
 
-function create_bond(element, defines::Symbol)
-    push!(cell_registered_bond_names[currently_running_cell_id[]], defines)
+function create_bond(element, defines::Symbol, cell_id::UUID)
+    push!(cell_registered_bond_names[cell_id], defines)
     registered_bond_elements[defines] = element
     Bond(element, defines)
 end
@@ -2053,10 +2053,10 @@ The second cell will show the square of `x`, and is updated in real-time as the 
 macro bind(def, element)    
 	if def isa Symbol
 		quote
-            $(load_integrations_if_needed)()
+			$(load_integrations_if_needed)()
 			local el = $(esc(element))
-            global $(esc(def)) = Core.applicable(Base.get, el) ? Base.get(el) : $(initial_value_getter_ref)[](el)
-			PlutoRunner.create_bond(el, $(Meta.quot(def)))
+			global $(esc(def)) = Core.applicable(Base.get, el) ? Base.get(el) : $(initial_value_getter_ref)[](el)
+			PlutoRunner.create_bond(el, $(Meta.quot(def)), $(GiveMeCellID()))
 		end
 	else
 		:(throw(ArgumentError("""\nMacro example usage: \n\n\t@bind my_number html"<input type='range'>"\n\n""")))

--- a/test/Bonds.jl
+++ b/test/Bonds.jl
@@ -44,8 +44,7 @@ import Distributed
                 # 1
                 Cell("""
                 begin
-                    import AbstractPlutoDingetjes
-                    const APD = AbstractPlutoDingetjes
+                    import AbstractPlutoDingetjes as APD
                     import AbstractPlutoDingetjes.Bonds
                 end
                 """),
@@ -205,9 +204,13 @@ import Distributed
                 Cell("@bind pv4 PossibleValuesTest((x+1 for x in 1:10))"),
                 # 34
                 Cell("@bind pv5 PossibleValuesTest(1:10)"),
+
+                # 35 - https://github.com/fonsp/Pluto.jl/issues/2465
+                Cell(""),
+                Cell("@bind ts2465 TransformSlider()"),
+                Cell("ts2465"),
             ])
-        
-        
+
         function set_bond_value(name, value, is_first_value=false)
             notebook.bonds[name] = Dict("value" => value)
             Pluto.set_bond_values_reactive(; session=🍭, notebook, bound_sym_names=[name],
@@ -225,8 +228,7 @@ import Distributed
         @test notebook.cells[10].output.body == "missing"
         set_bond_value(:x_simple, 1, true)
         @test notebook.cells[10].output.body == "1"
-        
-        
+
         update_run!(🍭, notebook, notebook.cells)
 
         @test noerror(notebook.cells[1])
@@ -271,7 +273,7 @@ import Distributed
         @test noerror(notebook.cells[32])
         @test noerror(notebook.cells[33])
         @test noerror(notebook.cells[34])
-        @test length(notebook.cells) == 34
+        @test length(notebook.cells) == 37
         
         
         @test Pluto.possible_bond_values(🍭, notebook, :x_new) == [1,2,3]
@@ -326,8 +328,30 @@ import Distributed
         @test notebook.cells[25].output.body == "1"
         set_bond_value(:x_counter, 7, false)
         @test notebook.cells[25].output.body == "2"
-        
-        
+
+        # https://github.com/fonsp/Pluto.jl/issues/2465
+        update_run!(🍭, notebook, notebook.cells[35:37])
+
+        @test noerror(notebook.cells[35])
+        @test noerror(notebook.cells[36])
+        @test noerror(notebook.cells[37])
+        @test notebook.cells[37].output.body == "\"x\""
+        @test isempty(notebook.cells[35].code)
+
+        # this should not deregister the TransformSlider
+        setcode!(notebook.cells[35], notebook.cells[36].code)
+        setcode!(notebook.cells[36], "")
+
+        update_run!(🍭, notebook, notebook.cells[35:36])
+        @test noerror(notebook.cells[35])
+        @test noerror(notebook.cells[36])
+        @test notebook.cells[37].output.body == "\"x\""
+
+        set_bond_value(:ts2465, 2, false)
+        @test noerror(notebook.cells[35])
+        @test noerror(notebook.cells[36])
+        @test notebook.cells[37].output.body == "\"xx\""
+
         WorkspaceManager.unmake_workspace((🍭, notebook))
         🍭.options.evaluation.workspace_use_distributed = false
         


### PR DESCRIPTION
This moves bond element de-registration from when defining cell is run to the start of the re-defining reactive run. This prevents a bond element from being de-registered based on cell running order as occurs in #2465.

Fixes #2465.