### PR TITLE
Improve print view styling

### DIFF
--- a/frontend/hide-ui.css
+++ b/frontend/hide-ui.css
@@ -22,15 +22,9 @@ pluto-runarea,
     pkg-status-mark {
         display: none !important;
     }
-    [data-pluto-variable] {
-        text-decoration-color: transparent;
-    }
     pluto-input .cm-editor {
         border-left: 1px solid var(--normal-cell-color);
         border-radius: 4px !important;
-    }
-    .cm-gutterElement {
-        display: none;
     }
 }
 

--- a/frontend/hide-ui.css
+++ b/frontend/hide-ui.css
@@ -28,8 +28,3 @@ pluto-runarea,
         border-radius: 4px !important;
     }
 }
-
-@page {
-    size: auto;
-    margin: 2cm auto; /* suppress browser header/footers */
-}

--- a/frontend/hide-ui.css
+++ b/frontend/hide-ui.css
@@ -22,4 +22,19 @@ pluto-runarea,
     pkg-status-mark {
         display: none !important;
     }
+    [data-pluto-variable] {
+        text-decoration-color: transparent;
+    }
+    pluto-input .cm-editor {
+        border-left: 1px solid var(--normal-cell-color);
+        border-radius: 4px !important;
+    }
+    .cm-gutterElement {
+        display: none;
+    }
+}
+
+@page {
+    size: auto;
+    margin: 2cm auto; /* suppress browser header/footers */
 }


### PR DESCRIPTION
Here are a few small tweaks that I think improve the print style.

- Remove (useless) symbol definition underlines. These could be linked in the PDF (as in HTML), but they aren't, and so they end up being visual noise.
- Re-add the left cell border, in case the browser is hiding background colors, otherwise cells can look a bit funky.
- Hide the gutter element, it serves no purpose here.
- Hide the automatic page/url/date annotations

### Before (Firefox default print settings)

![image](https://user-images.githubusercontent.com/20903656/217277452-e21c9cfb-347c-41d1-8503-85551bfa8804.png)

### After (Firefox default print settings)

![image](https://user-images.githubusercontent.com/20903656/217277484-7ed410ec-1ace-4388-80c3-968ad3b6a7aa.png)
