### PR TITLE
Change "Static PDF" export title to just "PDF"

### DIFF
--- a/frontend/components/ExportBanner.js
+++ b/frontend/components/ExportBanner.js
@@ -54,7 +54,7 @@ export const ExportBanner = ({ notebook_id, onClose, notebookfile_url, notebooke
                     <section>An <b>.html</b> file for your web page, or to share online.</section>
                 </a>
                 <a href="#" class="export_card" onClick=${() => window.print()}>
-                    <header><${Square} fill="#619b3d" /> Static PDF</header>
+                    <header><${Square} fill="#619b3d" /> PDF</header>
                     <section>A static <b>.pdf</b> file for print or email.</section>
                 </a>
                 ${


### PR DESCRIPTION
Just a minor tweak with the export banner: PDFs are already a static format, and it's stated in the description, and so this is implicit and redundent 😛.

![image](https://user-images.githubusercontent.com/20903656/217278366-6347e8b7-7a1f-4285-9dff-6f67815308ac.png)
