### PR TITLE
Restyle frontmatter dialog to match rest of pluto

### DIFF
--- a/frontend/components/FrontmatterInput.js
+++ b/frontend/components/FrontmatterInput.js
@@ -85,11 +85,12 @@ export const FrontMatterInput = ({ remote_frontmatter, set_remote_frontmatter })
                     <${Input} type=${field_type(key)} id=${id} value=${value} on_value=${fm_setter(key)} />
                     <button
                         class="deletefield"
+                        title="Delete field"
                         onClick=${() => {
                             set_frontmatter((fm) => Object.fromEntries(Object.entries(fm).filter(([k]) => k !== key)))
                         }}
                     >
-                        ⨯
+                        ✕
                     </button>
                 `
             })}

--- a/frontend/dark_color.css
+++ b/frontend/dark_color.css
@@ -29,6 +29,12 @@
         --export-card-text-color: rgb(255 255 255 / 70%);
         --export-card-shadow-color: #0000001c;
 
+        /*Frontmatter styling*/
+        --frontmatter-button-bg-color: #554e4e;
+        --frontmatter-outline-color: rgb(255 248 235);
+        --frontmatter-input-bg-color: #2c2c2c;
+        --frontmatter-input-border-color: #757575;
+
         /*Pluto output styling */
         --pluto-schema-types-color: rgba(255, 255, 255, 0.6);
         --pluto-schema-types-border-color: rgba(255, 255, 255, 0.2);

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -3331,7 +3331,6 @@ pluto-cell.hooked_up pluto-output {
     background-color: var(--frontmatter-button-bg-color);
     border-radius: 0.5em;
     border: 2px solid var(--frontmatter-button-bg-color);
-    padding: 0.3em 0.5em;
     font-weight: 500;
 }
 
@@ -3346,8 +3345,8 @@ pluto-cell.hooked_up pluto-output {
     padding: 0.3em 0.5em;
 }
 
-.pluto-frontmatter input:focus {
-    outline: none;
+.pluto-frontmatter rbl-tag-input {
+    color: var(--black);
 }
 
 .pluto-frontmatter label {
@@ -3356,24 +3355,11 @@ pluto-cell.hooked_up pluto-output {
 }
 
 .pluto-frontmatter .deletefield {
-    font-size: 1.1em;
     color: var(--export-color);
-    align-self: baseline;
     background-color: transparent;
     border-width: 0;
-    opacity: 0.6;
+    align-self: stretch;
     margin-left: -1em;
-    margin-top: -0.35em;
-}
-
-.pluto-frontmatter .deletefield:hover {
-    opacity: 1;
-}
-
-.pluto-frontmatter .deletefield:focus {
-    outline: none;
-    opacity: 1;
-    font-weight: bold;
 }
 
 .pluto-frontmatter .addentry {

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -3320,22 +3320,65 @@ pluto-cell.hooked_up pluto-output {
 .pluto-frontmatter {
     font-family: var(--system-ui-font-stack);
     width: min(31rem, 90vw);
-    color: var(--black);
-    background: var(--white);
+    color: var(--export-color);
+    background: var(--export-bg-color);
+    border-radius: 1em;
+    padding: 1em 1.5em;
 }
 
 .pluto-frontmatter button {
     cursor: pointer;
+    background-color: var(--frontmatter-button-bg-color);
+    border-radius: 0.5em;
+    border: 2px solid var(--frontmatter-button-bg-color);
+    padding: 0.3em 0.5em;
+    font-weight: 500;
+}
+
+.pluto-frontmatter button:hover {
+    border-color: var(--frontmatter-input-border-color);
+}
+
+.pluto-frontmatter input {
+    background-color: var(--frontmatter-input-bg-color);
+    border-radius: 0.5em;
+    border: 2px solid var(--frontmatter-input-border-color);
+    padding: 0.3em 0.5em;
+}
+
+.pluto-frontmatter input:focus {
+    outline: none;
+}
+
+.pluto-frontmatter label {
+    text-transform: capitalize;
+    font-weight: 500;
 }
 
 .pluto-frontmatter .deletefield {
+    font-size: 1.1em;
+    color: var(--export-color);
     align-self: baseline;
+    background-color: transparent;
+    border-width: 0;
+    opacity: 0.6;
+    margin-left: -1em;
+    margin-top: -0.35em;
+}
+
+.pluto-frontmatter .deletefield:hover {
+    opacity: 1;
+}
+
+.pluto-frontmatter .deletefield:focus {
+    outline: none;
+    opacity: 1;
+    font-weight: bold;
 }
 
 .pluto-frontmatter .addentry {
     grid-column: 1/3;
     margin-top: 0.5em;
-    background-color: transparent;
 }
 
 .pluto-frontmatter .final {

--- a/frontend/light_color.css
+++ b/frontend/light_color.css
@@ -32,6 +32,12 @@
         --export-card-text-color: rgba(0, 0, 0, 0.5);
         --export-card-shadow-color: #00000029;
 
+        /*Frontmatter styling*/
+        --frontmatter-button-bg-color: white;
+        --frontmatter-outline-color: hsl(230, 14%, 11%);
+        --frontmatter-input-bg-color: #fbfbfb;
+        --frontmatter-input-border-color: hsl(207deg 24% 87%);
+
         /*Pluto output styling */
         --pluto-schema-types-color: rgba(0, 0, 0, 0.4);
         --pluto-schema-types-border-color: rgba(0, 0, 0, 0.2);

--- a/frontend/light_color.css
+++ b/frontend/light_color.css
@@ -26,7 +26,7 @@
 
         /*Export styling*/
         --export-bg-color: rgb(60, 67, 101);
-        --export-color: rgba(255, 255, 255, 0.7);
+        --export-color: rgb(228, 228, 228);
         --export-card-bg-color: rgba(255, 255, 255, 0.8);
         --export-card-title-color: rgba(0, 0, 0, 0.7);
         --export-card-text-color: rgba(0, 0, 0, 0.5);


### PR DESCRIPTION
I recently used the frontmatter dialog, and noticed the styling didn't really fit with the rest of pluto at all. Assuming this is an oversight, I've restyled it.

## Before

![image](https://user-images.githubusercontent.com/20903656/217286496-b1f10402-3a91-4b12-8ab8-dd6fd9f6a920.png)

## After

![image](https://user-images.githubusercontent.com/20903656/217286589-6a61ecab-3cb4-4bff-b67a-9c19fbe6be13.png)
