### PR TITLE
Fix #2474

### DIFF
--- a/frontend/hide-ui.css
+++ b/frontend/hide-ui.css
@@ -19,7 +19,8 @@ pluto-runarea,
 /* These next rules only apply to @media print, i.e. the PDF export. We want to hide these items in the PDF, but not in a static HTML. */
 @media print {
     .edit_or_run,
-    pkg-status-mark {
+    pkg-status-mark,
+    nav#undo_delete {
         display: none !important;
     }
 }


### PR DESCRIPTION
<ul>
<li>Undo button is hidden in pdf export</li>
</ul>

Before:
 
![before-1](https://user-images.githubusercontent.com/26440593/219977131-f760855a-cb32-489d-8b25-e0426109a914.png)

After:

![after-1](https://user-images.githubusercontent.com/26440593/219977136-226caf06-4931-47a2-9188-123740d358d4.png)
