### PR TITLE
Logging: move `maxlog` handling to PlutoRunner

### DIFF
--- a/src/evaluation/WorkspaceManager.jl
+++ b/src/evaluation/WorkspaceManager.jl
@@ -229,24 +229,6 @@ function start_relaying_logs((session, notebook)::SN, log_channel::Distributed.R
 
             @assert !isnothing(display_cell)
 
-            maybe_max_log = findfirst(((key, _),) -> key == "maxlog", next_log["kwargs"])
-            if maybe_max_log !== nothing
-                n_logs = count(log -> log["id"] == next_log["id"], display_cell.logs)
-                try
-                    max_log = parse(Int, next_log["kwargs"][maybe_max_log][2] |> first)
-
-                    # Don't include maxlog in the log-message, in line
-                    # with how Julia handles it.
-                    deleteat!(next_log["kwargs"], maybe_max_log)
-
-                    # Don't show message with id more than max_log times
-                    if max_log isa Int && n_logs >= max_log
-                        continue
-                    end
-                catch
-                end
-            end
-
             push!(display_cell.logs, next_log)
             Pluto.@asynclog update_throttled()
         catch e

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -2295,10 +2295,14 @@ struct PlutoCellLogger <: Logging.AbstractLogger
     log_channel::Channel{Any}
     cell_id::UUID
     workspace_count::Int # Used to invalidate previous logs
+    message_limits::Dict{Any,Int}
 end
 function PlutoCellLogger(notebook_id, cell_id)
     notebook_log_channel = pluto_log_channels[notebook_id]
-    PlutoCellLogger(nothing, notebook_log_channel, cell_id, moduleworkspace_count[])
+    PlutoCellLogger(nothing,
+                    notebook_log_channel, cell_id,
+                    moduleworkspace_count[],
+                    Dict{Any,Int}())
 end
 
 struct CaptureLogger <: Logging.AbstractLogger
@@ -2308,10 +2312,10 @@ struct CaptureLogger <: Logging.AbstractLogger
 end
 
 Logging.shouldlog(cl::CaptureLogger, args...) = Logging.shouldlog(cl.logger, args...)
-Logging.min_enabled_level(::CaptureLogger) = min(Logging.Debug, stdout_log_level)
-Logging.catch_exceptions(::CaptureLogger) = Logging.catch_exceptions(cl.logger)
-function Logging.handle_message(pl::CaptureLogger, level, msg, _module, group, id, file, line; kwargs...)
-    push!(pl.logs, (level, msg, _module, group, id, file, line, kwargs))
+Logging.min_enabled_level(cl::CaptureLogger) = Logging.min_enabled_level(cl.logger)
+Logging.catch_exceptions(cl::CaptureLogger) = Logging.catch_exceptions(cl.logger)
+function Logging.handle_message(cl::CaptureLogger, level, msg, _module, group, id, file, line; kwargs...)
+    push!(cl.logs, (level, msg, _module, group, id, file, line, kwargs))
 end
 
 
@@ -2342,6 +2346,16 @@ function Logging.handle_message(pl::PlutoCellLogger, level, msg, _module, group,
     # println("receiving msg from ", _module, " ", group, " ", id, " ", msg, " ", level, " ", line, " ", file)
     # println("with types: ", "_module: ", typeof(_module), ", ", "msg: ", typeof(msg), ", ", "group: ", typeof(group), ", ", "id: ", typeof(id), ", ", "file: ", typeof(file), ", ", "line: ", typeof(line), ", ", "kwargs: ", typeof(kwargs)) # thanks Copilot
 
+    # https://github.com/JuliaLang/julia/blob/eb2e9687d0ac694d0aa25434b30396ee2cfa5cd3/stdlib/Logging/src/ConsoleLogger.jl#L110-L115
+    if get(kwargs, :maxlog, nothing) isa Core.BuiltinInts
+        maxlog = kwargs[:maxlog]
+        remaining = get!(pl.message_limits, id, Int(maxlog)::Int)
+        pl.message_limits[id] = remaining - 1
+        if remaining <= 0
+            return
+        end
+    end
+
     try
 
         yield()
@@ -2354,7 +2368,7 @@ function Logging.handle_message(pl::PlutoCellLogger, level, msg, _module, group,
             "file" => string(file),
             "cell_id" => pl.cell_id,
             "line" => line isa Union{Int32,Int64} ? line : nothing,
-            "kwargs" => Tuple{String,Any}[(string(k), format_log_value(v)) for (k, v) in kwargs],
+            "kwargs" => Tuple{String,Any}[(string(k), format_log_value(v)) for (k, v) in kwargs if k != :maxlog],
         ))
 
         yield()


### PR DESCRIPTION
Running the formatter for the logging message is rather costly.

Adding a method such as:

```julia
PlutoRunner.use_tree_viewer_for_struct(::Text) = false
```
could also speed things up.

Fixes #2490.