### PR TITLE
🦆 Fix #2416 maybe by avoiding race condition

### DIFF
--- a/src/evaluation/Run.jl
+++ b/src/evaluation/Run.jl
@@ -177,7 +177,7 @@ function run_reactive_core!(
         cell.running = true
         # Important to not use empty! here because AppendonlyMarker requires a new array identity.
         # Eventually we could even make AppendonlyArray to enforce this but idk if it's worth it. yadiyadi.
-        cell.logs = []
+        cell.logs = Vector{Dict{String,Any}}()
         send_notebook_changes_throttled()
 
         if any_interrupted || notebook.wants_to_interrupt || !will_run_code(notebook)

--- a/src/webserver/Dynamic.jl
+++ b/src/webserver/Dynamic.jl
@@ -173,30 +173,39 @@ end
 For each connected client, we keep a copy of their current state. This way we know exactly which updates to send when the server-side state changes.
 """
 const current_state_for_clients = WeakKeyDict{ClientSession,Any}()
+const current_state_for_clients_lock = ReentrantLock()
 
 """
 Update the local state of all clients connected to this notebook.
 """
 function send_notebook_changes!(🙋::ClientRequest; commentary::Any=nothing, skip_send::Bool=false)
-    notebook_dict = notebook_to_js(🙋.notebook)
-    for (_, client) in 🙋.session.connected_clients
-        if client.connected_notebook !== nothing && client.connected_notebook.notebook_id == 🙋.notebook.notebook_id
-            current_dict = get(current_state_for_clients, client, :empty)
-            patches = Firebasey.diff(current_dict, notebook_dict)
-            patches_as_dicts::Array{Dict} = Firebasey._convert(Array{Dict}, patches)
-            current_state_for_clients[client] = deep_enough_copy(notebook_dict)
+    const outbox = Set{Tuple{ClientSession,UpdateMessage}}()
+    
+    lock(current_state_for_clients_lock) do
+        notebook_dict = notebook_to_js(🙋.notebook)
+        for (_, client) in 🙋.session.connected_clients
+            if client.connected_notebook !== nothing && client.connected_notebook.notebook_id == 🙋.notebook.notebook_id
+                current_dict = get(current_state_for_clients, client, :empty)
+                patches = Firebasey.diff(current_dict, notebook_dict)
+                patches_as_dicts::Array{Dict} = Firebasey._convert(Array{Dict}, patches)
+                current_state_for_clients[client] = deep_enough_copy(notebook_dict)
 
-            # Make sure we do send a confirmation to the client who made the request, even without changes
-            is_response = 🙋.initiator !== nothing && client == 🙋.initiator.client
+                # Make sure we do send a confirmation to the client who made the request, even without changes
+                is_response = 🙋.initiator !== nothing && client == 🙋.initiator.client
 
-            if !skip_send && (!isempty(patches) || is_response)
-                response = Dict(
-                    :patches => patches_as_dicts,
-                    :response => is_response ? commentary : nothing
-                )
-                putclientupdates!(client, UpdateMessage(:notebook_diff, response, 🙋.notebook, nothing, 🙋.initiator))
+                if !skip_send && (!isempty(patches) || is_response)
+                    response = Dict(
+                        :patches => patches_as_dicts,
+                        :response => is_response ? commentary : nothing
+                    )
+                    push!(outbox, (client, UpdateMessage(:notebook_diff, response, 🙋.notebook, nothing, 🙋.initiator)))
+                end
             end
         end
+    end
+    
+    for (client, msg) in outbox
+        putclientupdates!(client, msg)
     end
     try_event_call(🙋.session, FileEditEvent(🙋.notebook))
 end

--- a/src/webserver/Dynamic.jl
+++ b/src/webserver/Dynamic.jl
@@ -179,7 +179,7 @@ const current_state_for_clients_lock = ReentrantLock()
 Update the local state of all clients connected to this notebook.
 """
 function send_notebook_changes!(🙋::ClientRequest; commentary::Any=nothing, skip_send::Bool=false)
-    const outbox = Set{Tuple{ClientSession,UpdateMessage}}()
+    outbox = Set{Tuple{ClientSession,UpdateMessage}}()
     
     lock(current_state_for_clients_lock) do
         notebook_dict = notebook_to_js(🙋.notebook)


### PR DESCRIPTION
Be sure to read this PR with whitespace changes disabled.

Fix #2416 which looks like it was a race condition: multiple updates were happening at the same time, and there was a race condition around updating `current_state_for_clients`. Our code is not multithreaded, but it does run in many async `Task`s.

Since I can't reproduce #2416, this is some guesswork. "Fixed" it by:
- adding a lock around the logic that updates `current_state_for_clients`. 
- instead of doing the blocking websocket IO during the update loop (inside the lock), I first compute all updates, (then release the lock), and then send them in a single batch afterwards.

Questions:
- I used `ReentrantLock` but I don't know what it is. 
	- Is this the right choice? what about `Threads.SpinLock`? If we want to multithread in the future, will this also lock among threads?
	- Is there a performance cost?
	- Is there a risk of deadlock?