### PR TITLE
Add binder progress and logs to status tab

### DIFF
--- a/frontend/common/Binder.js
+++ b/frontend/common/Binder.js
@@ -6,6 +6,7 @@ export const BackendLaunchPhase = {
     wait_for_user: 0,
     requesting: 0.4,
     created: 0.6,
+    responded: 0.7,
     notebook_running: 0.9,
     ready: 1.0,
 }
@@ -128,8 +129,14 @@ export const start_binder = async ({ setStatePromise, connect, launch_params }) 
             })
         )
 
-        // fetch index to say hello
+        // fetch index to say hello to the pluto server. this ensures that the pluto server is running and it triggers JIT compiling some of the HTTP code.
         await fetch(with_token(binder_session_url))
+
+        await setStatePromise(
+            immer((/** @type {import("../components/Editor.js").EditorState} */ state) => {
+                state.backend_launch_phase = BackendLaunchPhase.responded
+            })
+        )
 
         /// PART 2: Using Pluto's REST API to open the notebook file. We either upload the notebook with a POST request, or we let the server open by giving it the filename/URL.
 

--- a/frontend/common/RunLocal.js
+++ b/frontend/common/RunLocal.js
@@ -19,7 +19,7 @@ export const start_local = async ({ setStatePromise, connect, launch_params }) =
 
         await setStatePromise(
             immer((/** @type {import("../components/Editor.js").EditorState} */ state) => {
-                state.backend_launch_phase = BackendLaunchPhase.created
+                state.backend_launch_phase = BackendLaunchPhase.responded
                 state.disable_ui = false
                 // Clear the Status of the process that generated the HTML
                 state.notebook.status_tree = null

--- a/frontend/common/RunLocal.js
+++ b/frontend/common/RunLocal.js
@@ -18,9 +18,11 @@ export const start_local = async ({ setStatePromise, connect, launch_params }) =
         if (launch_params.pluto_server_url == null || launch_params.notebookfile == null) throw Error("Invalid launch parameters for starting locally.")
 
         await setStatePromise(
-            immer((state) => {
+            immer((/** @type {import("../components/Editor.js").EditorState} */ state) => {
                 state.backend_launch_phase = BackendLaunchPhase.created
                 state.disable_ui = false
+                // Clear the Status of the process that generated the HTML
+                state.notebook.status_tree = null
             })
         )
 
@@ -60,7 +62,7 @@ export const start_local = async ({ setStatePromise, connect, launch_params }) =
         window.history.replaceState({}, "", edit_url)
 
         await setStatePromise(
-            immer((state) => {
+            immer((/** @type {import("../components/Editor.js").EditorState} */ state) => {
                 state.notebook.notebook_id = new_notebook_id
                 state.backend_launch_phase = BackendLaunchPhase.notebook_running
             })

--- a/frontend/components/BottomRightPanel.js
+++ b/frontend/components/BottomRightPanel.js
@@ -180,7 +180,7 @@ const useBackendStatus = (/** @type {number | null} */ backend_launch_phase) => 
     let x = backend_launch_phase ?? -1
 
     const subtasks = Object.fromEntries(
-        ["requesting", "created", "notebook_running"].map((key) => {
+        ["requesting", "created", "responded", "notebook_running"].map((key) => {
             let val = BackendLaunchPhase[key]
             let name = `backend_${key}`
             return [name, useStatusItem(name, x >= val, x > val)]

--- a/frontend/components/BottomRightPanel.js
+++ b/frontend/components/BottomRightPanel.js
@@ -47,8 +47,6 @@ export let BottomRightPanel = ({ desired_doc_query, on_update_doc_query, noteboo
 
     const status = useWithBackendStatus(notebook, backend_launch_phase)
 
-    console.log({ status })
-
     const [status_total, status_done] = useMemo(
         () =>
             status == null
@@ -165,21 +163,17 @@ const useDelayedTruth = (/** @type {boolean} */ x, /** @type {number} */ timeout
 const useWithBackendStatus = (notebook, backend_launch_phase) => {
     const backend_launch = useBackendStatus(backend_launch_phase)
 
-    return useMemo(
-        () =>
-            backend_launch_phase == null
-                ? notebook.status_tree
-                : {
-                      name: "notebook",
-                      started_at: 0,
-                      finished_at: null,
-                      subtasks: {
-                          ...notebook.status_tree?.subtasks,
-                          backend_launch,
-                      },
-                  },
-        [notebook.status_tree, backend_launch, backend_launch_phase]
-    )
+    return backend_launch_phase == null
+        ? notebook.status_tree
+        : {
+              name: "notebook",
+              started_at: 0,
+              finished_at: null,
+              subtasks: {
+                  ...notebook.status_tree?.subtasks,
+                  backend_launch,
+              },
+          }
 }
 
 const useBackendStatus = (/** @type {number | null} */ backend_launch_phase) => {

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -142,6 +142,7 @@ const first_true_key = (obj) => {
  *   name: string,
  *   started_at: number?,
  *   finished_at: number?,
+ *   type?: "remote" | "local",
  *   subtasks: Record<string,StatusEntryData>,
  * }}
  */
@@ -269,6 +270,7 @@ const url_logo_small = document.head.querySelector("link[rel='pluto-logo-small']
  * disable_ui: boolean,
  * static_preview: boolean,
  * backend_launch_phase: ?number,
+ * backend_launch_logs: ?string,
  * binder_session_url: ?string,
  * binder_session_token: ?string,
  * refresh_target: ?string,
@@ -311,6 +313,7 @@ export class Editor extends Component {
                 launch_params.notebookfile != null && (launch_params.binder_url != null || launch_params.pluto_server_url != null)
                     ? BackendLaunchPhase.wait_for_user
                     : null,
+            backend_launch_logs: null,
             binder_session_url: null,
             binder_session_token: null,
             refresh_target: null,
@@ -1557,6 +1560,8 @@ patch: ${JSON.stringify(
                         desired_doc_query=${this.state.desired_doc_query}
                         on_update_doc_query=${this.actions.set_doc_query}
                         connected=${this.state.connected}
+                        backend_launch_phase=${this.state.backend_launch_phase}
+                        backend_launch_logs=${this.state.backend_launch_logs}
                         notebook=${this.state.notebook}
                     />
                     <${Popup} 

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -142,7 +142,7 @@ const first_true_key = (obj) => {
  *   name: string,
  *   started_at: number?,
  *   finished_at: number?,
- *   type?: "remote" | "local",
+ *   timing?: "remote" | "local",
  *   subtasks: Record<string,StatusEntryData>,
  * }}
  */

--- a/frontend/components/ProcessTab.js
+++ b/frontend/components/ProcessTab.js
@@ -1,20 +1,29 @@
-import { html, useEffect, useRef, useState } from "../imports/Preact.js"
+import { html, useEffect, useMemo, useRef, useState } from "../imports/Preact.js"
 
 import { cl } from "../common/ClassTable.js"
 import { prettytime, useMillisSinceTruthy } from "./RunArea.js"
 import { DiscreteProgressBar } from "./DiscreteProgressBar.js"
 import { PkgTerminalView } from "./PkgTerminalView.js"
+import { BackendLaunchPhase } from "../common/Binder.js"
 
 /**
  * @param {{
+ * status: import("./Editor.js").StatusEntryData,
  * notebook: import("./Editor.js").NotebookData,
+ * backend_launch_logs: string?,
  * my_clock_is_ahead_by: number,
  * }} props
  */
-export let ProcessTab = ({ notebook, my_clock_is_ahead_by }) => {
+export let ProcessTab = ({ status, notebook, backend_launch_logs, my_clock_is_ahead_by }) => {
     return html`
         <section>
-            <${StatusItem} status_tree=${notebook.status_tree} path=${[]} my_clock_is_ahead_by=${my_clock_is_ahead_by} nbpkg=${notebook.nbpkg} />
+            <${StatusItem}
+                status_tree=${status}
+                path=${[]}
+                my_clock_is_ahead_by=${my_clock_is_ahead_by}
+                nbpkg=${notebook.nbpkg}
+                backend_launch_logs=${backend_launch_logs}
+            />
         </section>
     `
 }
@@ -62,6 +71,11 @@ const descriptions = {
     evaluate: "Running code",
     registry_update: "Updating package registry",
     waiting_for_others: "Waiting for other notebooks to finish package operations",
+
+    backend_launch: "Connecting to backend",
+    backend_requesting: "Requesting a worker",
+    backend_created: "Starting Pluto & opening notebook file",
+    backend_notebook_running: "Switching to live editing",
 }
 
 export const friendly_name = (/** @type {string} */ task_name) => {
@@ -78,10 +92,12 @@ const to_ns = (x) => x * 1e9
  * path: string[],
  * my_clock_is_ahead_by: number,
  * nbpkg: import("./Editor.js").NotebookPkgData?,
+ * backend_launch_logs: string?,
  * }} props
  */
-const StatusItem = ({ status_tree, path, my_clock_is_ahead_by, nbpkg }) => {
+const StatusItem = ({ status_tree, path, my_clock_is_ahead_by, nbpkg, backend_launch_logs }) => {
     if (status_tree == null) return null
+
     const mystatus = path.reduce((entry, key) => entry.subtasks[key], status_tree)
     if (!mystatus) return null
 
@@ -97,7 +113,7 @@ const StatusItem = ({ status_tree, path, my_clock_is_ahead_by, nbpkg }) => {
     const local_busy_time = (useMillisSinceTruthy(busy) ?? 0) / 1000
     const mytime = Date.now() / 1000
 
-    const busy_time = Math.max(local_busy_time, mytime - my_clock_is_ahead_by - start)
+    const busy_time = Math.max(local_busy_time, mytime - start - (mystatus.type === "local" ? 0 : my_clock_is_ahead_by))
 
     useEffect(() => {
         if (busy) {
@@ -137,6 +153,7 @@ const StatusItem = ({ status_tree, path, my_clock_is_ahead_by, nbpkg }) => {
                           my_clock_is_ahead_by=${my_clock_is_ahead_by}
                           path=${[...path, key]}
                           nbpkg=${nbpkg}
+                          backend_launch_logs=${backend_launch_logs}
                       />`
             )
 
@@ -187,7 +204,10 @@ const StatusItem = ({ status_tree, path, my_clock_is_ahead_by, nbpkg }) => {
                   <span class="status-name">${friendly_name(mystatus.name)}${inner_progress}</span>
                   <span class="status-time">${finished ? prettytime(to_ns(end - start)) : busy ? prettytime(to_ns(busy_time)) : null}</span>
               </div>
-              ${inner}${is_open && mystatus.name === "pkg" ? html`<${PkgTerminalView} value=${nbpkg?.terminal_outputs?.nbpkg_sync} />` : undefined}
+              ${inner}${is_open && mystatus.name === "pkg" ? html`<${PkgTerminalView} value=${nbpkg?.terminal_outputs?.nbpkg_sync} />` : undefined}${is_open &&
+              mystatus.name === "backend_launch"
+                  ? html`<${PkgTerminalView} value=${backend_launch_logs} />`
+                  : undefined}
           </pl-status>`
 }
 
@@ -253,6 +273,15 @@ export const path_to_first_busy_business = (status) => {
     }
     return []
 }
+
+/** @returns {import("./Editor.js").StatusEntryData} */
+export const useStatusItem = (/** @type {string} */ name, /** @type {boolean} */ started, /** @type {boolean} */ finished, subtasks = {}) => ({
+    name,
+    subtasks,
+    type: "local",
+    started_at: useMemo(() => (started || finished ? Date.now() / 1000 : null), [started || finished]),
+    finished_at: useMemo(() => (finished ? Date.now() / 1000 : null), [finished]),
+})
 
 /** Like `useEffect`, but the handler function gets the previous deps value as argument. */
 const useEffectWithPrevious = (fn, deps) => {

--- a/frontend/editor.js
+++ b/frontend/editor.js
@@ -94,7 +94,7 @@ export const empty_notebook_state = ({ notebook_id }) => ({
     published_objects: {},
     bonds: {},
     nbpkg: null,
-    status_tree: { name: "notebook", started_at: null, finished_at: null, subtasks: {} },
+    status_tree: null,
 })
 
 /**


### PR DESCRIPTION
![Screenshot (1)](https://user-images.githubusercontent.com/6933510/230774369-4948fbec-9948-4bd4-8ae9-bebd9a506c06.png)

I used the `backend_launch_phase` for the subtasks of the backend launch, and I capture the JSON logs from the streaming mybinder.org API as logs in the little terminal, similar to #2498 