### PR TITLE
ExpressionExplorer: Handle more complex struct constructors

### DIFF
--- a/src/analysis/ExpressionExplorer.jl
+++ b/src/analysis/ExpressionExplorer.jl
@@ -929,6 +929,12 @@ function explore_funcdef!(ex::Expr, scopestate::ScopeState)::Tuple{FunctionName,
         # and explore the function arguments
         return umapfoldl(a -> explore_funcdef!(a, scopestate), params_to_explore; init=(name, symstate))
     elseif ex.head == :(::) || ex.head == :kw || ex.head == :(=)
+        # Treat custom struct constructors as a local scope function
+        if ex.head == :(=) && is_function_assignment(ex)
+            symstate = explore!(ex, scopestate)
+            return Symbol[], symstate
+        end
+
         # account for unnamed params, like in f(::Example) = 1
         if ex.head == :(::) && length(ex.args) == 1
             symstate = explore!(ex.args[1], scopestate)

--- a/test/ExpressionExplorer.jl
+++ b/test/ExpressionExplorer.jl
@@ -133,7 +133,10 @@ Some of these @test_broken lines are commented out to prevent printing to the te
         @test testee(:(struct a{A,B<:C{A}}; i::A; j::B end), [], [:a], [], [:a => ([:C], [], [], [])])
         @test testee(:(struct a{A,B<:C{<:A}} <: D{A,B}; i::A; j::B end), [], [:a], [], [:a => ([:C, :D], [], [], [])])
         @test testee(:(struct a{A,DD<:B.C{D.E{A}}} <: K.A{A} i::A; j::DD; k::C end), [], [:a], [], [:a => ([:B, :C, :D, :K], [], [], [])])
-        
+        @test testee(:(struct a; x; a(t::T) where {T} = new(t); end), [], [:a], [], [:a => ([], [], [[:new]], [])])
+        @test testee(:(struct a; x; y; a(t::T) where {T} = new(t, T); end), [], [:a], [], [:a => ([], [], [[:new]], [])])
+        @test testee(:(struct a; f() = a() end), [], [:a], [], [:a => ([], [], [], [])])
+
         @test testee(:(abstract type a <: b end), [], [:a], [], [:a => ([:b], [], [], [])])
         @test testee(:(abstract type a{T,S} end), [], [:a], [], [:a => ([], [], [], [])])
         @test testee(:(abstract type a{T} <: b end), [], [:a], [], [:a => ([:b], [], [], [])])


### PR DESCRIPTION
Failing case:

```julia
# cell 1
struct A{T}
  x::T
  A(t::T) where {T} = new{T}(t)
end
# cell 2
t = A() # cycle
```
