### PR TITLE
FunctionNameSignaturePair: store hash of canonalized head

### DIFF
--- a/src/notebook/Notebook.jl
+++ b/src/notebook/Notebook.jl
@@ -1,5 +1,4 @@
 import UUIDs: UUID, uuid1
-import .ExpressionExplorer: SymbolsState, FunctionNameSignaturePair, FunctionName
 import .Configuration
 import .PkgCompat: PkgCompat, PkgContext
 import Pkg

--- a/test/MethodSignatures.jl
+++ b/test/MethodSignatures.jl
@@ -1,6 +1,6 @@
 using Test
 
-import Pluto.ExpressionExplorer: SymbolsState, compute_symbolreferences, FunctionNameSignaturePair
+import Pluto.ExpressionExplorer: compute_symbolreferences
 
 @testset "Method signatures" begin
 

--- a/test/helpers.jl
+++ b/test/helpers.jl
@@ -83,7 +83,7 @@ function testee(expr::Any, expected_references, expected_definitions, expected_f
     result.funcdefs = let
         newfuncdefs = Dict{FunctionNameSignaturePair,SymbolsState}()
         for (k, v) in result.funcdefs
-            union!(newfuncdefs, Dict(FunctionNameSignaturePair(new_name.(k.name), "hello") => v))
+            union!(newfuncdefs, Dict(FunctionNameSignaturePair(new_name.(k.name), hash("hello")) => v))
         end
         newfuncdefs
     end
@@ -120,7 +120,7 @@ function easy_symstate(expected_references, expected_definitions, expected_funcc
     new_expected_funcdefs = map(expected_funcdefs) do (k, v)
         new_k = k isa Symbol ? [k] : k
         new_v = v isa SymbolsState ? v : easy_symstate(v...)
-        return FunctionNameSignaturePair(new_k, "hello") => new_v
+        return FunctionNameSignaturePair(new_k, hash("hello")) => new_v
     end |> Dict
 
     new_expected_macrocalls = array_to_set(expected_macrocalls)


### PR DESCRIPTION
@Pangoraw this cleans that up a bit. Should we do something with `const FunctionName = Vector{Symbol}`? Should that be a Tuple or SVector? `Expr.args` is a `Vector{Any}`.