### PR TITLE
Add `run_requested_timestamp` state to delete the `run_multiple_cells` action

### DIFF
--- a/frontend/components/Cell.js
+++ b/frontend/components/Cell.js
@@ -86,6 +86,17 @@ const on_jump = (hasBarrier, pluto_actions, cell_id) => () => {
     }
 }
 
+export const is_queued = (/** @type {import("./Editor.js").CellInputData} */ cell_input, /** @type {import("./Editor.js").CellResultData} */ cell_result) =>
+    cell_input.run_requested_timestamp > (cell_result.output.last_run_timestamp ?? 0) && !cell_result.running
+
+export const is_running = (/** @type {import("./Editor.js").CellInputData} */ cell_input, /** @type {import("./Editor.js").CellResultData} */ cell_result) =>
+    cell_result.running
+
+export const is_queued_or_running = (
+    /** @type {import("./Editor.js").CellInputData} */ cell_input,
+    /** @type {import("./Editor.js").CellResultData} */ cell_result
+) => is_queued(cell_input, cell_result) || is_running(cell_input, cell_result)
+
 /**
  * @param {{
  *  cell_result: import("./Editor.js").CellResultData,
@@ -100,8 +111,8 @@ const on_jump = (hasBarrier, pluto_actions, cell_id) => () => {
  * }} props
  * */
 export const Cell = ({
-    cell_input: { cell_id, code, code_folded, metadata },
-    cell_result: { queued, running, runtime, errored, output, logs, published_object_keys, depends_on_disabled_cells, depends_on_skipped_cells },
+    cell_input,
+    cell_result,
     cell_dependencies,
     cell_input_local,
     notebook_id,
@@ -113,6 +124,11 @@ export const Cell = ({
     nbpkg,
     global_definition_locations,
 }) => {
+    const { cell_id, code, code_folded, metadata, run_requested_timestamp } = cell_input
+    const { running, runtime, errored, output, logs, published_object_keys, depends_on_disabled_cells, depends_on_skipped_cells } = cell_result
+
+    const queued = is_queued(cell_input, cell_result)
+
     const { show_logs, disabled: running_disabled, skip_as_script } = metadata
     let pluto_actions = useContext(PlutoActionsContext)
     // useCallback because pluto_actions.set_doc_query can change value when you go from viewing a static document to connecting (to binder)

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -869,7 +869,7 @@ const InputContextMenu = ({ on_delete, cell_id, run_cell, skip_as_script, runnin
     const is_copy_output_supported = () => {
         let notebook = /** @type{import("./Editor.js").NotebookData?} */ (pluto_actions.get_notebook())
         let cell_result = notebook?.cell_results?.[cell_id]
-        return !!cell_result && !cell_result.errored && !cell_result.queued && cell_result.output.mime === "text/plain" && cell_result.output.body
+        return cell_result != null && !cell_result.errored && cell_result.output.mime === "text/plain" && cell_result.output.body
     }
 
     const copy_output = () => {

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -559,7 +559,6 @@ export class Editor extends Component {
                             }
                             notebook.cell_order = notebook.cell_order.filter((cell_id) => !cell_ids.includes(cell_id))
                         })
-                        await this.client.send("run_multiple_cells", { cells: [] }, { notebook_id: this.state.notebook.notebook_id })
                     }
                 }
             },
@@ -587,31 +586,12 @@ export class Editor extends Component {
                 if (cell_ids.length > 0) {
                     await update_notebook((notebook) => {
                         for (let cell_id of cell_ids) {
-                            if (this.state.cell_inputs_local[cell_id]) {
+                            if (this.state.cell_inputs_local[cell_id] != null) {
                                 notebook.cell_inputs[cell_id].code = this.state.cell_inputs_local[cell_id].code
+                                notebook.cell_inputs[cell_id].run_requested_timestamp = Date.now() / 1000
                             }
                         }
                     })
-                    // This is a "dirty" trick, as this should actually be stored in some shared request_status => status state
-                    // But for now... this is fine 😼
-                    await this.setStatePromise(
-                        immer((/** @type {EditorState} */ state) => {
-                            for (let cell_id of cell_ids) {
-                                if (state.notebook.cell_results[cell_id] != null) {
-                                    state.notebook.cell_results[cell_id].queued = this.is_process_ready()
-                                } else {
-                                    // nothing
-                                }
-                            }
-                        })
-                    )
-                    const result = await this.client.send("run_multiple_cells", { cells: cell_ids }, { notebook_id: this.state.notebook.notebook_id })
-                    const { disabled_cells } = result.message
-                    if (Object.entries(disabled_cells).length > 0) {
-                        await this.setStatePromise({
-                            recently_auto_disabled_cells: disabled_cells,
-                        })
-                    }
                 }
             },
             /**
@@ -782,6 +762,13 @@ patch: ${JSON.stringify(
                             })
 
                         break
+                    case "run_feedback":
+                        const { disabled_cells } = message
+                        if (Object.entries(disabled_cells).length > 0) {
+                            this.setStatePromise({
+                                recently_auto_disabled_cells: disabled_cells,
+                            })
+                        }
                     default:
                         console.error("Received unknown update type!", update)
                         // alert("Something went wrong 🙈\n Try clearing your browser cache and refreshing the page")

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -28,7 +28,7 @@ import { setup_mathjax } from "../common/SetupMathJax.js"
 import { slider_server_actions, nothing_actions } from "../common/SliderServerClient.js"
 import { ProgressBar } from "./ProgressBar.js"
 import { NonCellOutput } from "./NonCellOutput.js"
-import { IsolatedCell } from "./Cell.js"
+import { IsolatedCell, is_queued_or_running } from "./Cell.js"
 import { RawHTMLContainer } from "./CellOutput.js"
 import { RecordingPlaybackUI, RecordingUI } from "./RecordingUI.js"
 import { HijackExternalLinksToOpenInNewTab } from "./HackySideStuff/HijackExternalLinksToOpenInNewTab.js"
@@ -122,6 +122,7 @@ const first_true_key = (obj) => {
  *  code: string,
  *  code_folded: boolean,
  *  metadata: CellMetaData,
+ *  run_requested_timestamp: number,
  * }}
  */
 
@@ -151,7 +152,6 @@ const first_true_key = (obj) => {
  * @typedef CellResultData
  * @type {{
  *  cell_id: string,
- *  queued: boolean,
  *  running: boolean,
  *  errored: boolean,
  *  runtime: number?,
@@ -301,7 +301,7 @@ export class Editor extends Component {
 
         this.state = {
             notebook: /** @type {NotebookData} */ initial_notebook_state,
-            cell_inputs_local: /** @type {{ [id: string]: CellInputData }} */ ({}),
+            cell_inputs_local: {},
             desired_doc_query: null,
             recently_deleted: /** @type {Array<{ index: number, cell: CellInputData }>} */ ([]),
             recently_auto_disabled_cells: /** @type {Map<string,[string,string]>} */ ({}),
@@ -375,14 +375,10 @@ export class Editor extends Component {
             },
             add_deserialized_cells: async (data, index_or_id, deserializer = deserialize_cells) => {
                 let new_codes = deserializer(data)
-                /** @type {Array<CellInputData>} Create copies of the cells with fresh ids */
+                /** Create copies of the cells with fresh ids */
                 let new_cells = new_codes.map((code) => ({
                     cell_id: uuidv4(),
                     code: code,
-                    code_folded: false,
-                    metadata: {
-                        ...DEFAULT_CELL_METADATA,
-                    },
                 }))
 
                 let index
@@ -406,7 +402,7 @@ export class Editor extends Component {
                  * (the usual flow is keyboard event -> cm -> local_code and not the opposite )
                  * See ** 1 **
                  */
-                this.setState(
+                await this.setStatePromise(
                     immer((/** @type {EditorState} */ state) => {
                         // Deselect everything first, to clean things up
                         state.selected_cells = []
@@ -428,9 +424,11 @@ export class Editor extends Component {
                             ...cell,
                             // Fill the cell with empty code remotely, so it doesn't run unsafe code
                             code: "",
+                            code_folded: false,
                             metadata: {
                                 ...DEFAULT_CELL_METADATA,
                             },
+                            run_requested_timestamp: 0.0,
                         }
                     }
                     notebook.cell_order = [
@@ -464,15 +462,16 @@ export class Editor extends Component {
                 const cells_to_add = parts.map((code) => {
                     return {
                         cell_id: uuidv4(),
-                        code: code,
+                        code: submit ? code : "",
                         code_folded: false,
                         metadata: {
                             ...DEFAULT_CELL_METADATA,
                         },
+                        run_requested_timestamp: submit ? Date.now() / 1000 : 0.0,
                     }
                 })
 
-                this.setState(
+                await this.setStatePromise(
                     immer((/** @type {EditorState} */ state) => {
                         for (let cell of cells_to_add) {
                             state.cell_inputs_local[cell.cell_id] = cell
@@ -527,10 +526,10 @@ export class Editor extends Component {
                         code,
                         code_folded: false,
                         metadata: { ...DEFAULT_CELL_METADATA },
+                        run_requested_timestamp: Date.now() / 1000,
                     }
                     notebook.cell_order = [...notebook.cell_order.slice(0, index), id, ...notebook.cell_order.slice(index, Infinity)]
                 })
-                await this.client.send("run_multiple_cells", { cells: [id] }, { notebook_id: this.state.notebook.notebook_id })
                 return id
             },
             add_remote_cell: async (cell_id, before_or_after, code) => {
@@ -540,7 +539,7 @@ export class Editor extends Component {
             },
             confirm_delete_multiple: async (verb, cell_ids) => {
                 if (cell_ids.length <= 1 || confirm(`${verb} ${cell_ids.length} cells?`)) {
-                    if (cell_ids.some((cell_id) => this.state.notebook.cell_results[cell_id].running || this.state.notebook.cell_results[cell_id].queued)) {
+                    if (cell_ids.some((cell_id) => is_queued_or_running(this.state.notebook.cell_inputs[cell_id], this.state.notebook.cell_results[cell_id]))) {
                         if (confirm("This cell is still running - would you like to interrupt the notebook?")) {
                             this.actions.interrupt_remote(cell_ids[0])
                         }
@@ -930,13 +929,18 @@ patch: ${JSON.stringify(
             // console.info("All scripts finished!")
             this.send_queued_bond_changes()
         })
+        this.any_cells_queued_or_running = () =>
+            this.state.notebook.cell_order.some((cell_id) =>
+                is_queued_or_running(this.state.notebook.cell_inputs[cell_id], this.state.notebook.cell_results[cell_id])
+            )
+
         /** Is the notebook ready to execute code right now? (i.e. are no cells queued or running?) */
         this.notebook_is_idle = () => {
             return !(
                 this.waiting_for_bond_to_trigger_execution ||
                 this.pending_local_updates > 0 ||
                 // a cell is running:
-                Object.values(this.state.notebook.cell_results).some((cell) => cell.running || cell.queued) ||
+                this.any_cells_queued_or_running() ||
                 // a cell is initializing JS:
                 !_.isEmpty(this.js_init_set) ||
                 !this.is_process_ready()
@@ -1159,7 +1163,7 @@ patch: ${JSON.stringify(
             // }
             if (e.key.toLowerCase() === "q" && has_ctrl_or_cmd_pressed(e)) {
                 // This one can't be done as cmd+q on mac, because that closes chrome - Dral
-                if (Object.values(this.state.notebook.cell_results).some((c) => c.running || c.queued)) {
+                if (this.any_cells_queued_or_running()) {
                     this.actions.interrupt_remote()
                 }
                 e.preventDefault()

--- a/frontend/components/Notebook.js
+++ b/frontend/components/Notebook.js
@@ -24,6 +24,19 @@ const useMemoDebug = (fn, args) => {
     }, args)
 }
 
+/**
+ * @param {{
+ *  cell_result: import("./Editor.js").CellResultData,
+ *  cell_input: import("./Editor.js").CellInputData,
+ *  cell_input_local: { code: String },
+ *  cell_dependencies: import("./Editor.js").CellDependencyData
+ *  nbpkg: import("./Editor.js").NotebookPkgData?,
+ *  selected: boolean,
+ *  force_hide_input: boolean,
+ *  focus_after_creation: boolean,
+ *  [key: string]: any,
+ * }} props
+ * */
 let CellMemo = ({
     cell_result,
     cell_input,
@@ -41,8 +54,8 @@ let CellMemo = ({
     global_definition_locations,
 }) => {
     const { body, last_run_timestamp, mime, persist_js_state, rootassignee } = cell_result?.output || {}
-    const { queued, running, runtime, errored, depends_on_disabled_cells, logs, depends_on_skipped_cells } = cell_result || {}
-    const { cell_id, code, code_folded, metadata } = cell_input || {}
+    const { running, runtime, errored, depends_on_disabled_cells, logs, depends_on_skipped_cells } = cell_result || {}
+    const { cell_id, code, code_folded, metadata, run_requested_timestamp } = cell_input || {}
     return useMemo(() => {
         return html`
             <${Cell}
@@ -65,9 +78,9 @@ let CellMemo = ({
         cell_id,
         ...Object.keys(metadata),
         ...Object.values(metadata),
+        run_requested_timestamp,
         depends_on_disabled_cells,
         depends_on_skipped_cells,
-        queued,
         running,
         runtime,
         errored,
@@ -154,7 +167,6 @@ export const Notebook = ({ notebook, cell_inputs_local, last_created_cell, selec
                         key=${cell_id}
                         cell_result=${notebook.cell_results[cell_id] ?? {
                             cell_id: cell_id,
-                            queued: true,
                             running: false,
                             errored: false,
                             runtime: null,

--- a/src/analysis/Errors.jl
+++ b/src/analysis/Errors.jl
@@ -39,13 +39,13 @@ function showerror(io::IO, mde::MultipleDefinitionsError)
 end
 
 "Send `error` to the frontend without backtrace. Runtime errors are handled by `WorkspaceManager.eval_format_fetch_in_workspace` - this function is for Reactivity errors."
-function relay_reactivity_error!(cell::Cell, error::Exception)
+function relay_reactivity_error!(cell::Cell, error::Exception, timestamp::Float64)
 	body, mime = PlutoRunner.format_output(CapturedException(error, []))
 	cell.output = CellOutput(
 		body=body,
 		mime=mime,
 		rootassignee=nothing,
-		last_run_timestamp=time(),
+		last_run_timestamp=timestamp,
 		persist_js_state=false,
 	)
 	cell.published_objects = Dict{String,Any}()

--- a/src/evaluation/Run.jl
+++ b/src/evaluation/Run.jl
@@ -458,7 +458,9 @@ function update_save_run!(
                 # not async because that would be double async
                 run_reactive_core!(session, notebook, old, new, to_run_online; save, kwargs...)
                 # run_reactive_async!(session, notebook, old, new, to_run_online; deletion_hook=deletion_hook, run_async=false, kwargs...)
-            end
+			else
+				# TODO: set the queued statuses to false
+			end
         end
         try_event_call(
             session,

--- a/src/notebook/Cell.jl
+++ b/src/notebook/Cell.jl
@@ -18,7 +18,7 @@ Base.@kwdef struct CellOutput
     rootassignee::Union{Symbol,Nothing}=nothing
 
     "Time that the last output was created, used only on the frontend to rerender the output"
-    last_run_timestamp::Float64=0
+    last_run_timestamp::Float64=0.0
     
     "Whether `this` inside `<script id=something>` should refer to the previously returned object in HTML output. This is used for fancy animations. true iff a cell runs as a reactive consequence."
     persist_js_state::Bool=false
@@ -42,8 +42,8 @@ Base.@kwdef mutable struct Cell
     code_folded::Bool=false
     
     output::CellOutput=CellOutput()
-    queued::Bool=false
     running::Bool=false
+    run_requested_timestamp::Float64=0.0
 
     published_objects::Dict{String,Any}=Dict{String,Any}()
     

--- a/src/webserver/Dynamic.jl
+++ b/src/webserver/Dynamic.jl
@@ -112,6 +112,7 @@ function notebook_to_js(notebook::Notebook)
                 "code" => cell.code,
                 "code_folded" => cell.code_folded,
                 "metadata" => cell.metadata,
+                "run_requested_timestamp" => cell.run_requested_timestamp,
             )
         for (id, cell) in notebook.cells_dict),
         "cell_dependencies" => Dict{UUID,Dict{String,Any}}(
@@ -134,7 +135,6 @@ function notebook_to_js(notebook::Notebook)
                 "depends_on_disabled_cells" => cell.depends_on_disabled_cells,
                 "output" => FirebaseyUtils.ImmutableMarker(cell.output),
                 "published_object_keys" => keys(cell.published_objects),
-                "queued" => cell.queued,
                 "running" => cell.running,
                 "errored" => cell.errored,
                 "runtime" => cell.runtime,
@@ -499,7 +499,7 @@ responses[:reshow_cell] = function response_reshow_cell(🙋::ClientRequest)
         collect(keys(cell.published_objects)),
         (parse(PlutoRunner.ObjectID, 🙋.body["objectid"], base=16), convert(Int64, 🙋.body["dim"])),
     )
-    set_output!(cell, run, ExprAnalysisCache(🙋.notebook, cell); persist_js_state=true)
+    set_output!(cell, run, ExprAnalysisCache(🙋.notebook, cell), cell.output.last_run_timestamp + 1.0; persist_js_state=true)
     # send to all clients, why not
     send_notebook_changes!(🙋 |> without_initiator)
 end

--- a/src/webserver/SessionActions.jl
+++ b/src/webserver/SessionActions.jl
@@ -80,12 +80,16 @@ function open(session::ServerSession, path::AbstractString;
     if session.options.evaluation.run_notebook_on_load
         Status.report_business_planned!(run_status, :resolve_topology)
         cell_status = Status.report_business_planned!(run_status, :evaluate)
-        for (i,c) in enumerate(notebook.cells)
-            c.queued = true
+        for i in eachindex(notebook.cells)
             Status.report_business_planned!(cell_status, Symbol(i))
         end
     end
 
+    let t = time()
+        for c in notebook.cells
+            c.run_requested_timestamp = t
+        end
+    end
     update_save_run!(session, notebook, notebook.cells; run_async, prerender_text=true)
     add(session, notebook; run_async)
     try_event_call(session, OpenNotebookEvent(notebook))


### PR DESCRIPTION
Right now the frontend makes a request to the backend (`run_multiple_cells`) to run cells. So when you Shift+enter, we currently do this:
1. Frontend changes `cell_input[cell_id].code` in the frontend state, and computes patches from that change.
2. Send those patches to the backend
3. Backend sends confirmation back to frontend
4. Frontend sends a `run_multiple_cells` request to backend
5. Backend runs cells async

After this PR, the `cell_input` struct will have one new field: `run_requested_timestamp`. And the `cell_result` already has a field `cell_result.output.last_run_timestamp`. So now, we can say:
- A cell should run if `run_requested_timestamp > last_run_timestamp`. So the frontend doesn't need to explicitly request a run anymore.
- When a cell completes, set `last_run_timestamp = run_requested_timestamp`. 
- A cell is "queued" if `run_requested_timestamp > last_run_timestamp && !running`. So we can remove the `queued` field from our state and make it a computed field.

So after this PR, the process is:
1. Frontend changes `cell_input[cell_id].code` and `cell_input[cell_id].run_requested_timestamp = Date.now() / 1000` in the frontend state, and computes patches from that change.
2. Send those patches to the backend
3. Backend applies those patches locally, and notices that a `run_requested_timestamp` changed. This patch is matched by our wildcard as a side effect.
4. Backend runs cells async
5. Backend sends confirmation back to frontend

This change is mostly internal. Right now I want to mimick the old behaviour with respect to #220, but after this PR, it will be easier to control this behaviour. Instead of having a queue of executions, we could see this as: "this is the set of cells that still needs to be executed". Then we can improve #220, and we could allow you to add new cells while older cells are still queued, and execute that new cell faster, before waiting for all cells to be done.

This also means that Shift+Enter will be slightly faster! Because it avoids the second round trip/

# TODO



search for:

- [ ] relay_reactivity_error!
- [ ] last_run_timestamp
- [ ] CellOutput
- [ ] run_feedback
- [ ] run_multiple_cells
- [ ] is_process_ready
- [ ] disabled_cells


test for

- [ ] disable cells
- [ ] show more items
- [ ] bond timing stuff ughhhhh
- [ ] deleting cells
- [ ] auto disabling cells with message
