### PR TITLE
Change 🔺🔴🟥 button to share icon

### DIFF
--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -704,7 +704,7 @@ nav#at_the_top button.start_stop_recording.stop span {
     background-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/stop-circle-outline.svg");
 }
 nav#at_the_top button.toggle_export span {
-    background-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/download-outline.svg");
+    background-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/share-outline.svg");
     filter: var(--image-filters);
 }
 aside#export button.toggle_export span {

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -704,7 +704,7 @@ nav#at_the_top button.start_stop_recording.stop span {
     background-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/stop-circle-outline.svg");
 }
 nav#at_the_top button.toggle_export span {
-    background-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/shapes-outline.svg");
+    background-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/download-outline.svg");
     filter: var(--image-filters);
 }
 aside#export button.toggle_export span {


### PR DESCRIPTION
# Before

<img width="750" alt="image" src="https://user-images.githubusercontent.com/6933510/234683808-8a278f69-fb11-4a58-b0a1-da7bd071570a.png">

# After

<img width="740" alt="image" src="https://user-images.githubusercontent.com/6933510/234683764-bdc81f23-91b2-44b7-ac62-e58eb0c52991.png">


I think that the <img height="20" alt="image" src="https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/shapes-outline.svg"> button was cute and cool, but <img height="20" alt="image" src="https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/share-outline.svg"> is more intuitive.  😅

I updated the Getting Started featured notebook