### PR TITLE
add `pretty_stackcall(::Base.StackFrame, ::Module)`

### DIFF
--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -1096,6 +1096,10 @@ function pretty_stackcall(frame::Base.StackFrame, linfo::Core.MethodInstance)
     end
 end
 
+function pretty_stackcall(frame::Base.StackFrame, linfo::Module)
+    sprint(Base.show, linfo)
+end
+
 "Return a `(String, Any)` tuple containing function output as the second entry."
 function show_richest_withreturned(context::IOContext, @nospecialize(args))
     buffer = IOBuffer(; sizehint=0)


### PR DESCRIPTION
Patch https://github.com/fonsp/Pluto.jl/issues/2554

tested on 

```
Version 1.10.0-DEV.1293 (2023-05-14)
Commit 344f1f5a9cd (0 days old master)
```

Would be nice to understand what changed in julia before merging
