### PR TITLE
fix: ensure recent browser without eval

### DIFF
--- a/frontend/warn_old_browsers.js
+++ b/frontend/warn_old_browsers.js
@@ -3,9 +3,12 @@ function ismodern() {
         // See: https://kangax.github.io/compat-table/es2016plus/
 
         // 2020 check:
-        return eval("let {a, ...r} = {a:1,b:1}; r?.a != r.b; 1 ?? 2")
+        // return eval("let {a, ...r} = {a:1,b:1}; r?.a != r.b; 1 ?? 2")
         // 2021 check:
         // return eval("let {a, ...r} = {a:1,b:1}; r?.a != r.b; 1 ?? 2; a ||= false")
+        // 2021 check (Chrome 85+, Firefox 77+, Safari 13.1+)
+        // Please check with macs
+        return Boolean(String.prototype.replaceAll)
     } catch (ex) {
         return false
     }


### PR DESCRIPTION
This eval renders Pluto unable to run with a CSP policy. The  `Boolean(String.prototype.replaceAll)` check should be equivalent chronologically.

Pluto also does CSP-infringing magic on `execute_dynamic_function` but I'm happy to disallow that.