### PR TITLE
Fix: #2567 by echoing the secret from the request URL

### DIFF
--- a/src/webserver/Router.jl
+++ b/src/webserver/Router.jl
@@ -13,13 +13,14 @@ function http_router_for(session::ServerSession)
     HTTP.register!(router, "GET", "/ping", r -> HTTP.Response(200, "OK!"))
     HTTP.register!(router, "GET", "/possible_binder_token_please", r -> session.binder_token === nothing ? HTTP.Response(200,"") : HTTP.Response(200, session.binder_token))
     
-    function try_launch_notebook_response(action::Function, path_or_url::AbstractString; title="", advice="", home_url="./", as_redirect=true, action_kwargs...)
+    function try_launch_notebook_response(action::Function, path_or_url::AbstractString; title="", advice="", home_url="./", as_redirect=true, secret=nothing, action_kwargs...)
         try
             nb = action(session, path_or_url; action_kwargs...)
-            notebook_response(nb; home_url, as_redirect)
+            @info "secret" secret
+            notebook_response(nb; home_url, as_redirect, secret)
         catch e
             if e isa SessionActions.NotebookIsRunningException
-                notebook_response(e.notebook; home_url, as_redirect)
+                notebook_response(e.notebook; home_url, as_redirect, secret)
             else
                 error_response(500, title, advice, sprint(showerror, e, stacktrace(catch_backtrace())))
             end
@@ -39,13 +40,15 @@ function http_router_for(session::ServerSession)
             uri = HTTP.URI(request.target)
             query = HTTP.queryparams(uri)
             as_sample = haskey(query, "as_sample")
+            secret = get(query, "secret", nothing)
             if haskey(query, "path")
                 path = tamepath(maybe_convert_path_to_wsl(query["path"]))
                 if isfile(path)
                     return try_launch_notebook_response(
                         SessionActions.open, path; 
                         as_redirect=(request.method == "GET"), 
-                        as_sample, 
+                        as_sample,
+                        secret,
                         title="Failed to load notebook", 
                         advice="The file <code>$(htmlesc(path))</code> could not be loaded. Please <a href='https://github.com/fonsp/Pluto.jl/issues'>report this error</a>!",
                     )
@@ -57,7 +60,8 @@ function http_router_for(session::ServerSession)
                 return try_launch_notebook_response(
                     SessionActions.open_url, url;
                     as_redirect=(request.method == "GET"), 
-                    as_sample, 
+                    as_sample,
+                    secret,
                     title="Failed to load notebook", 
                     advice="The notebook from <code>$(htmlesc(url))</code> could not be loaded. Please <a href='https://github.com/fonsp/Pluto.jl/issues'>report this error</a>!"
                 )

--- a/src/webserver/Static.jl
+++ b/src/webserver/Static.jl
@@ -62,10 +62,14 @@ function error_response(
     response
 end
 
-function notebook_response(notebook; home_url="./", as_redirect=true)
+function notebook_response(notebook; home_url="./", as_redirect=true, secret=nothing)
     if as_redirect
         response = HTTP.Response(302, "")
-        HTTP.setheader(response, "Location" => home_url * "edit?id=" * string(notebook.notebook_id))
+        HTTP.setheader(response,
+            "Location" => home_url * "edit?$(
+                isnothing(secret) ? "" : "secret=$secret&"
+            )id=" * string(notebook.notebook_id)
+        )
         return response
     else
         HTTP.Response(200, string(notebook.notebook_id))


### PR DESCRIPTION
The secret is not taken from the session settings; rather we paste whatever existed in the initial request. So this should be as secure as the initial one.