### PR TITLE
Page parameter `pluto_server_url` overrides default WebSocket address

### DIFF
--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -1301,11 +1301,7 @@ patch: ${JSON.stringify(
                 count_stat(`article-view`)
             }
         } else {
-            if (this.props.launch_params.pluto_server_url) {
-                this.connect(ws_address_from_base(this.props.launch_params.pluto_server_url))
-            } else {
-                this.connect()
-            }
+            this.connect(this.props.launch_params.pluto_server_url ? ws_address_from_base(this.props.launch_params.pluto_server_url) : undefined)
         }
     }
 

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -4,7 +4,7 @@ import immer, { applyPatches, produceWithPatches } from "../imports/immer.js"
 import _ from "../imports/lodash.js"
 
 import { empty_notebook_state, set_disable_ui_css } from "../editor.js"
-import { create_pluto_connection } from "../common/PlutoConnection.js"
+import { create_pluto_connection, ws_address_from_base } from "../common/PlutoConnection.js"
 import { init_feedback } from "../common/Feedback.js"
 import { serialize_cells, deserialize_cells, detect_deserializer } from "../common/Serialization.js"
 
@@ -207,7 +207,6 @@ const first_true_key = (obj) => {
  *  preamble_html: string?,
  *  isolated_cell_ids: string[]?,
  *  binder_url: string?,
- *  ws_url: string?,
  *  pluto_server_url: string?,
  *  slider_server_url: string?,
  *  recording_url: string?,
@@ -1302,7 +1301,11 @@ patch: ${JSON.stringify(
                 count_stat(`article-view`)
             }
         } else {
-            this.connect(this.props.launch_params.ws_url ?? undefined)
+            if (this.props.launch_params.pluto_server_url) {
+                this.connect(ws_address_from_base(this.props.launch_params.pluto_server_url))
+            } else {
+                this.connect()
+            }
         }
     }
 

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -207,6 +207,7 @@ const first_true_key = (obj) => {
  *  preamble_html: string?,
  *  isolated_cell_ids: string[]?,
  *  binder_url: string?,
+ *  ws_url: string?,
  *  pluto_server_url: string?,
  *  slider_server_url: string?,
  *  recording_url: string?,
@@ -851,7 +852,7 @@ patch: ${JSON.stringify(
         /** @type {import('../common/PlutoConnection').PlutoConnection} */
         this.client = /** @type {import('../common/PlutoConnection').PlutoConnection} */ ({})
 
-        this.connect = (ws_address = undefined) =>
+        this.connect = (/** @type {string | undefined} */ ws_address = undefined) =>
             create_pluto_connection({
                 ws_address: ws_address,
                 on_unrequested_update: on_update,
@@ -1301,7 +1302,7 @@ patch: ${JSON.stringify(
                 count_stat(`article-view`)
             }
         } else {
-            this.connect()
+            this.connect(this.props.launch_params.ws_url ?? undefined)
         }
     }
 

--- a/frontend/components/welcome/Welcome.js
+++ b/frontend/components/welcome/Welcome.js
@@ -2,7 +2,7 @@ import _ from "../../imports/lodash.js"
 import { html, useEffect, useState, useRef } from "../../imports/Preact.js"
 import * as preact from "../../imports/Preact.js"
 
-import { create_pluto_connection } from "../../common/PlutoConnection.js"
+import { create_pluto_connection, ws_address_from_base } from "../../common/PlutoConnection.js"
 import { new_update_message } from "../../common/NewUpdateMessage.js"
 import { Open } from "./Open.js"
 import { Recent } from "./Recent.js"
@@ -26,7 +26,7 @@ import default_featured_sources from "../../featured_sources.js"
 /**
  * @typedef LaunchParameters
  * @type {{
- * ws_url: string?,
+ * pluto_server_url: string?,
  * featured_direct_html_links: boolean,
  * featured_sources: import("./Featured.js").FeaturedSource[]?,
  * featured_source_url?: string,
@@ -68,7 +68,7 @@ export const Welcome = ({ launch_params }) => {
             on_unrequested_update: on_update,
             on_connection_status: on_connection_status,
             on_reconnect: () => true,
-            ws_address: launch_params.ws_url ?? undefined,
+            ws_address: ws_address_from_base(launch_params.pluto_server_url) ?? undefined,
         })
         client_promise.then(async (client) => {
             Object.assign(client_ref.current, client)

--- a/frontend/components/welcome/Welcome.js
+++ b/frontend/components/welcome/Welcome.js
@@ -68,7 +68,7 @@ export const Welcome = ({ launch_params }) => {
             on_unrequested_update: on_update,
             on_connection_status: on_connection_status,
             on_reconnect: () => true,
-            ws_address: ws_address_from_base(launch_params.pluto_server_url) ?? undefined,
+            ws_address: launch_params.pluto_server_url ? ws_address_from_base(launch_params.pluto_server_url) : undefined,
         })
         client_promise.then(async (client) => {
             Object.assign(client_ref.current, client)

--- a/frontend/components/welcome/Welcome.js
+++ b/frontend/components/welcome/Welcome.js
@@ -26,6 +26,7 @@ import default_featured_sources from "../../featured_sources.js"
 /**
  * @typedef LaunchParameters
  * @type {{
+ * ws_url: string?,
  * featured_direct_html_links: boolean,
  * featured_sources: import("./Featured.js").FeaturedSource[]?,
  * featured_source_url?: string,
@@ -67,6 +68,7 @@ export const Welcome = ({ launch_params }) => {
             on_unrequested_update: on_update,
             on_connection_status: on_connection_status,
             on_reconnect: () => true,
+            ws_address: launch_params.ws_url ?? undefined,
         })
         client_promise.then(async (client) => {
             Object.assign(client_ref.current, client)

--- a/frontend/editor.js
+++ b/frontend/editor.js
@@ -48,8 +48,6 @@ const launch_params = {
     //@ts-ignore
     binder_url: url_params.get("binder_url") ?? window.pluto_binder_url,
     //@ts-ignore
-    ws_url: url_params.get("ws_url") ?? window.pluto_ws_url,
-    //@ts-ignore
     pluto_server_url: url_params.get("pluto_server_url") ?? window.pluto_pluto_server_url,
     //@ts-ignore
     slider_server_url: url_params.get("slider_server_url") ?? window.pluto_slider_server_url,

--- a/frontend/editor.js
+++ b/frontend/editor.js
@@ -48,6 +48,8 @@ const launch_params = {
     //@ts-ignore
     binder_url: url_params.get("binder_url") ?? window.pluto_binder_url,
     //@ts-ignore
+    ws_url: url_params.get("ws_url") ?? window.pluto_ws_url,
+    //@ts-ignore
     pluto_server_url: url_params.get("pluto_server_url") ?? window.pluto_pluto_server_url,
     //@ts-ignore
     slider_server_url: url_params.get("slider_server_url") ?? window.pluto_slider_server_url,

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -24,7 +24,7 @@ const launch_params = {
     featured_source_integrity: url_params.get("featured_source_integrity") ?? window.pluto_featured_source_integrity,
 
     //@ts-ignore
-    ws_url: url_params.get("ws_url") ?? window.pluto_ws_url,
+    pluto_server_url: url_params.get("pluto_server_url") ?? window.pluto_server_url,
 }
 
 console.log("Launch parameters: ", launch_params)

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -22,6 +22,9 @@ const launch_params = {
     featured_source_url: url_params.get("featured_source_url") ?? window.pluto_featured_source_url,
     //@ts-ignore
     featured_source_integrity: url_params.get("featured_source_integrity") ?? window.pluto_featured_source_integrity,
+
+    //@ts-ignore
+    ws_url: url_params.get("ws_url") ?? window.pluto_ws_url,
 }
 
 console.log("Launch parameters: ", launch_params)


### PR DESCRIPTION
The Pluto.jl desktop app needs a way to tell Pluto explicitly where to find a Pluto.jl WebSocket server running, since frontend assets are served directly from the filesystem (a `file://` url). As far as I can tell, there was no way to do this already built into Pluto.jl, so this PR adds a page parameter to the editor and welcome screen which overrides the default websocket url behavior.