### PR TITLE
Call Pkg.upgrade_manifest() when updating packages

### DIFF
--- a/src/packages/Packages.jl
+++ b/src/packages/Packages.jl
@@ -573,6 +573,12 @@ function update_nbpkg_core(
                 with_io_setup(notebook, iolistener) do
                     # We temporarily clear the "semver-compatible" [deps] entries, because it is difficult to update them after the update 🙈. TODO
                     PkgCompat.clear_auto_compat_entries!(notebook.nbpkg_ctx)
+		
+		    @static isdefined(Pkg, :upgrade_manifest) && try
+                        Pkg.upgrade_manifest()
+                    catch
+                    end
+
 
                     try
                         ###


### PR DESCRIPTION
A bit annoying that `Pkg.upgrade_manifest()` throws an error when the manifest is already up to date... so i just put it in an empty try catch

untested