### PR TITLE
Trigger updating from file upon changes to folded state

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Pluto"
 uuid = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
 license = "MIT"
 authors = ["Fons van der Plas <fons@plutojl.org>"]
-version = "0.19.26"
+version = "0.19.27"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Pluto"
 uuid = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
 license = "MIT"
 authors = ["Fons van der Plas <fons@plutojl.org>"]
-version = "0.19.27"
+version = "0.19.26"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/evaluation/Run.jl
+++ b/src/evaluation/Run.jl
@@ -520,7 +520,7 @@ function notebook_differences(from::Notebook, to::Notebook)
 		changed = let
 			remained = keys(from_cells) ∩ keys(to_cells)
 			filter(remained) do id
-				from_cells[id].code != to_cells[id].code || from_cells[id].metadata != to_cells[id].metadata
+				from_cells[id].code != to_cells[id].code || from_cells[id].metadata != to_cells[id].metadata || from_cells[id].code_folded != to_cells[id].code_folded
 			end
 		end,
 		


### PR DESCRIPTION
Currently, changing the folded state of a cell in the underlying file does not trigger an update in the notebook. This is because the folded state is not currently checked for changes.

This PR makes it so we also check for changes in the folded state:)