### PR TITLE
fix: cryptic error on some sysimage builds on Julia 1.8.5

### DIFF
--- a/src/webserver/Dynamic.jl
+++ b/src/webserver/Dynamic.jl
@@ -186,7 +186,7 @@ function send_notebook_changes!(🙋::ClientRequest; commentary::Any=nothing, sk
             if client.connected_notebook !== nothing && client.connected_notebook.notebook_id == 🙋.notebook.notebook_id
                 current_dict = get(current_state_for_clients, client, :empty)
                 patches = Firebasey.diff(current_dict, notebook_dict)
-                patches_as_dicts::Array{Dict} = Firebasey._convert(Array{Dict}, patches)
+                patches_as_dicts = Firebasey._convert(Vector{Dict}, patches)
                 current_state_for_clients[client] = deep_enough_copy(notebook_dict)
 
                 # Make sure we do send a confirmation to the client who made the request, even without changes


### PR DESCRIPTION
This type assert, while perfectly legal, is breaking some sysimage builds with an error that starts with

```
signal (11): Segmentation fault
in expression starting at REPL[3]:1
ijl_subtype_env at /cache/build/default-amdci4-2/julialang/julia-release-1-dot-8/src/subtype.c:1854
#387 at /home/jrun/.julia/packages/Pluto/YRKRh/src/webserver/Dynamic.jl:189
```

This is possibly related to https://github.com/JuliaLang/julia/pull/44527, but in any case doesn't appear in higher versions of Julia (tested with 1.9.1+)
