### PR TITLE
add keyboard shortcuts (LeftArrow and RightArrow) to move slides in presentation mode

### DIFF
--- a/frontend/components/SlideControls.js
+++ b/frontend/components/SlideControls.js
@@ -1,4 +1,4 @@
-import { html, useRef, useEffect, useState, useLayoutEffect } from "../imports/Preact.js"
+import { html, useRef, useState, useLayoutEffect } from "../imports/Preact.js"
 
 export const SlideControls = () => {
     const button_prev_ref = useRef(/** @type {HTMLButtonElement?} */ (null))

--- a/frontend/components/SlideControls.js
+++ b/frontend/components/SlideControls.js
@@ -7,7 +7,7 @@ export const SlideControls = () => {
 
     const [presenting, set_presenting] = useState(false)
 
-    const move_slides_with_arrows = (/** @type {KeyboardEvent} */ e) => {
+    const move_slides_with_keyboard = (/** @type {KeyboardEvent} */ e) => {
         const activeElement = document.activeElement
         if (
             activeElement != null &&
@@ -81,10 +81,10 @@ export const SlideControls = () => {
 
         if (!presenting) return // We do not add listeners if not presenting
 
-        window.addEventListener("keydown", move_slides_with_arrows)
+        window.addEventListener("keydown", move_slides_with_keyboard)
 
         return () => {
-            window.removeEventListener("keydown", move_slides_with_arrows)
+            window.removeEventListener("keydown", move_slides_with_keyboard)
         }
     }, [presenting])
 

--- a/frontend/components/SlideControls.js
+++ b/frontend/components/SlideControls.js
@@ -6,7 +6,6 @@ export const SlideControls = () => {
     const button_next_ref = useRef(/** @type {HTMLButtonElement?} */ (null))
 
     const [presenting, set_presenting] = useState(false)
-    const [fullscreen, set_fullscreen] = useState(false)
 
     const move_slides_with_arrows = (/** @type {KeyboardEvent} */ e) => {
         const activeElement = document.activeElement
@@ -19,10 +18,12 @@ export const SlideControls = () => {
             // We do not move slides with arrow if we have an active element
             return
         }
-        if (e.key === "ArrowLeft") {
+        if (e.key === "ArrowLeft" || e.key === " " || e.key === "PageDown") {
             button_prev_ref.current?.click()
-        } else if (e.key === "ArrowRight") {
+        } else if (e.key === "ArrowRight" || e.key === "PageUp") {
             button_next_ref.current?.click()
+        } else if (e.key === "Escape") {
+            set_presenting(false)
         } else {
             return
         }
@@ -75,25 +76,6 @@ export const SlideControls = () => {
         set_presenting(!presenting_ref.current)
     }
 
-    const fullscreen_ref = useRef(false)
-    fullscreen_ref.current = fullscreen
-    const check_fullscreen_status = (/** @type {UIEvent} */ e) => {
-        // This will detect full screen if the window height becomes equivalent to the screen height
-        // In firefox, screen.height is adapted based on OS DPI settings (at least on windows) and browser zoom, while on chrome the screen is not reflecting the browser zoom level. This means that the current approach will only work on chrome when the browser zoom is 100%.
-        let maxHeight = window.screen.height
-        let curHeight = window.innerHeight
-
-        if (!fullscreen_ref.current && maxHeight === curHeight) {
-            // We just got into FullScreen
-            set_fullscreen(true)
-        } else if (fullscreen_ref.current && maxHeight !== curHeight) {
-            // We just got out of FullScreen
-            set_fullscreen(false)
-        } else {
-            return
-        }
-    }
-
     useLayoutEffect(() => {
         document.body.classList.toggle("presentation", presenting)
 
@@ -105,69 +87,6 @@ export const SlideControls = () => {
             window.removeEventListener("keydown", move_slides_with_arrows)
         }
     }, [presenting])
-
-    useLayoutEffect(() => {
-        console.log("presenting")
-        if (!presenting_ref.current && fullscreen) {
-            open_pluto_popup({
-                type: "info",
-                source_element: null,
-                body: html`It seems you have just entered fullscreen mode.
-                    <p>Would you like to <b>activate</b> Pluto presentation mode?</p>
-                    <a
-                        href="#"
-                        onClick=${(e) => {
-                            e.preventDefault()
-                            set_presenting(true)
-                            window.dispatchEvent(new CustomEvent("close pluto popup"))
-                        }}
-                        >Yes</a
-                    >
-                    <br />
-                    <a
-                        href="#"
-                        onClick=${(e) => {
-                            e.preventDefault()
-                            window.dispatchEvent(new CustomEvent("close pluto popup"))
-                        }}
-                        >No</a
-                    >`,
-            })
-        } else if (presenting_ref.current && !fullscreen) {
-            open_pluto_popup({
-                type: "info",
-                source_element: null,
-                body: html`It seems you have just exited fullscreen mode.
-                    <p>Would you like to <b>deactivate</b> Pluto presentation mode?</p>
-                    <a
-                        href="#"
-                        onClick=${(e) => {
-                            e.preventDefault()
-                            set_presenting(false)
-                            window.dispatchEvent(new CustomEvent("close pluto popup"))
-                        }}
-                        >Yes</a
-                    >
-                    <br />
-                    <a
-                        href="#"
-                        onClick=${(e) => {
-                            e.preventDefault()
-                            window.dispatchEvent(new CustomEvent("close pluto popup"))
-                        }}
-                        >No</a
-                    >`,
-            })
-        }
-    }, [fullscreen])
-
-    useEffect(() => {
-        window.addEventListener("resize", check_fullscreen_status)
-
-        return () => {
-            window.removeEventListener("resize", check_fullscreen_status)
-        }
-    }, [])
 
     return html`
         <nav id="slide_controls">

--- a/frontend/components/SlideControls.js
+++ b/frontend/components/SlideControls.js
@@ -1,10 +1,12 @@
-import { html, useRef, useState, useLayoutEffect } from "../imports/Preact.js"
+import { html, useRef, useState, useLayoutEffect, useEffect } from "../imports/Preact.js"
+import { open_pluto_popup } from "./Popup.js"
 
 export const SlideControls = () => {
     const button_prev_ref = useRef(/** @type {HTMLButtonElement?} */ (null))
     const button_next_ref = useRef(/** @type {HTMLButtonElement?} */ (null))
 
     const [presenting, set_presenting] = useState(false)
+    const [fullscreen, set_fullscreen] = useState(false)
 
     const move_slides_with_arrows = (/** @type {KeyboardEvent} */ e) => {
         const activeElement = document.activeElement
@@ -73,6 +75,25 @@ export const SlideControls = () => {
         set_presenting(!presenting_ref.current)
     }
 
+    const fullscreen_ref = useRef(false)
+    fullscreen_ref.current = fullscreen
+    const check_fullscreen_status = (/** @type {UIEvent} */ e) => {
+        // This will detect full screen if the window height becomes equivalent to the screen height
+        // In firefox, screen.height is adapted based on OS DPI settings (at least on windows) and browser zoom, while on chrome the screen is not reflecting the browser zoom level. This means that the current approach will only work on chrome when the browser zoom is 100%.
+        let maxHeight = window.screen.height
+        let curHeight = window.innerHeight
+
+        if (!fullscreen_ref.current && maxHeight === curHeight) {
+            // We just got into FullScreen
+            set_fullscreen(true)
+        } else if (fullscreen_ref.current && maxHeight !== curHeight) {
+            // We just got out of FullScreen
+            set_fullscreen(false)
+        } else {
+            return
+        }
+    }
+
     useLayoutEffect(() => {
         document.body.classList.toggle("presentation", presenting)
 
@@ -84,6 +105,69 @@ export const SlideControls = () => {
             window.removeEventListener("keydown", move_slides_with_arrows)
         }
     }, [presenting])
+
+    useLayoutEffect(() => {
+        console.log("presenting")
+        if (!presenting_ref.current && fullscreen) {
+            open_pluto_popup({
+                type: "info",
+                source_element: null,
+                body: html`It seems you have just entered fullscreen mode.
+                    <p>Would you like to <b>activate</b> Pluto presentation mode?</p>
+                    <a
+                        href="#"
+                        onClick=${(e) => {
+                            e.preventDefault()
+                            set_presenting(true)
+                            window.dispatchEvent(new CustomEvent("close pluto popup"))
+                        }}
+                        >Yes</a
+                    >
+                    <br />
+                    <a
+                        href="#"
+                        onClick=${(e) => {
+                            e.preventDefault()
+                            window.dispatchEvent(new CustomEvent("close pluto popup"))
+                        }}
+                        >No</a
+                    >`,
+            })
+        } else if (presenting_ref.current && !fullscreen) {
+            open_pluto_popup({
+                type: "info",
+                source_element: null,
+                body: html`It seems you have just exited fullscreen mode.
+                    <p>Would you like to <b>deactivate</b> Pluto presentation mode?</p>
+                    <a
+                        href="#"
+                        onClick=${(e) => {
+                            e.preventDefault()
+                            set_presenting(false)
+                            window.dispatchEvent(new CustomEvent("close pluto popup"))
+                        }}
+                        >Yes</a
+                    >
+                    <br />
+                    <a
+                        href="#"
+                        onClick=${(e) => {
+                            e.preventDefault()
+                            window.dispatchEvent(new CustomEvent("close pluto popup"))
+                        }}
+                        >No</a
+                    >`,
+            })
+        }
+    }, [fullscreen])
+
+    useEffect(() => {
+        window.addEventListener("resize", check_fullscreen_status)
+
+        return () => {
+            window.removeEventListener("resize", check_fullscreen_status)
+        }
+    }, [])
 
     return html`
         <nav id="slide_controls">

--- a/frontend/components/SlideControls.js
+++ b/frontend/components/SlideControls.js
@@ -76,6 +76,8 @@ export const SlideControls = () => {
     useLayoutEffect(() => {
         document.body.classList.toggle("presentation", presenting)
 
+        if (!presenting) return // We do not add listeners if not presenting
+
         window.addEventListener("keydown", move_slides_with_arrows)
 
         return () => {

--- a/frontend/components/SlideControls.js
+++ b/frontend/components/SlideControls.js
@@ -18,9 +18,9 @@ export const SlideControls = () => {
             // We do not move slides with arrow if we have an active element
             return
         }
-        if (e.key === "ArrowLeft" || e.key === " " || e.key === "PageDown") {
+        if (e.key === "ArrowLeft" || e.key === "PageUp") {
             button_prev_ref.current?.click()
-        } else if (e.key === "ArrowRight" || e.key === "PageUp") {
+        } else if (e.key === "ArrowRight" || e.key === " " || e.key === "PageDown") {
             button_next_ref.current?.click()
         } else if (e.key === "Escape") {
             set_presenting(false)


### PR DESCRIPTION
Thanks to @fonsp for showing me the React way

When in presentation mode, using the Left and Right arrow will allow to move slides back and forward.
This functionality is not triggered when the active element is a cell input or any other element within the notebook that you might want to interact with using arrows.

Also added some experimental functionality to detect full screen and prompt for activating (or deactivating) presentation mode:

https://github.com/fonsp/Pluto.jl/assets/12846528/90ecd33d-07fc-4484-91d7-13bf0d4d7826

There are some caveats to the current automatic detection of full screen:
- It does not work on chrome if the browser zoom level is not 100%
  - This is because chrome does not the update the `screen.height` as a function of the zoom and there does not seem to be a nice way to make it work reliably
- The popup does not disappear if clicking outside of it (this is caused by `source_element =  null` in the `open_popup` function.  @fonsp is there a better way/source_element to handle this?

