### PR TITLE
Experimental JS API for getting/setting cell metadata

### DIFF
--- a/frontend/components/CellOutput.js
+++ b/frontend/components/CellOutput.js
@@ -382,6 +382,21 @@ const execute_scripttags = async ({ root_node, script_nodes, previous_results_ma
                                         delete notebook.metadata[key]
                                     }),
 
+                                ...(cell == null
+                                    ? {}
+                                    : {
+                                          getCellMetadataExperimental: (key, { cell_id = null } = {}) =>
+                                              pluto_actions.get_notebook()?.cell_inputs?.[cell_id ?? cell.id]?.metadata[key],
+                                          setCellMetadataExperimental: (key, value, { cell_id = null } = {}) =>
+                                              pluto_actions.update_notebook((notebook) => {
+                                                  notebook.cell_inputs[cell_id ?? cell.id].metadata[key] = value
+                                              }),
+                                          deleteCellMetadataExperimental: (key, { cell_id = null } = {}) =>
+                                              pluto_actions.update_notebook((notebook) => {
+                                                  delete notebook.cell_inputs[cell_id ?? cell.id].metadata[key]
+                                              }),
+                                      }),
+
                                 ...observablehq_for_cells,
                             },
                             code,


### PR DESCRIPTION
We already had epxeirmental JS API for notebook metadata, but now also for cells!

Example notebook:

```julia
### A Pluto.jl notebook ###
# v0.19.27

using Markdown
using InteractiveUtils

# ╔═╡ 339c3ba2-95e1-44a2-9601-8382e0cfb9cf
# ╠═╡ number = 0.13315567181932053
html"""
<script>
console.log("before", getCellMetadataExperimental("number"))
await setCellMetadataExperimental("number", Math.random())
	
console.log("after", getCellMetadataExperimental("number"))

// await deleteCellMetadataExperimental("number")
</script>
"""

# ╔═╡ 9f26c140-24b0-11ee-1332-c3ced47002e2
# ╠═╡ aa = 1232
html"""
<script>
await setCellMetadataExperimental("aa", 777, {cell_id: "f8fc0eb8-0ef6-4096-a54f-c04c741f8258"})
console.log(getCellMetadataExperimental("aa", {cell_id: "f8fc0eb8-0ef6-4096-a54f-c04c741f8258"}))
await deleteCellMetadataExperimental("aa", {cell_id: "f8fc0eb8-0ef6-4096-a54f-c04c741f8258"})
</script>
"""

# ╔═╡ f8fc0eb8-0ef6-4096-a54f-c04c741f8258


# ╔═╡ Cell order:
# ╠═339c3ba2-95e1-44a2-9601-8382e0cfb9cf
# ╠═9f26c140-24b0-11ee-1332-c3ced47002e2
# ╠═f8fc0eb8-0ef6-4096-a54f-c04c741f8258
```

cc @lucaferranti