### PR TITLE
Add `project` kwarg to Pluto.run() defaulting to `nothing`

### DIFF
--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -143,6 +143,7 @@ const WORKSPACE_USE_DISTRIBUTED_DEFAULT = true
 const LAZY_WORKSPACE_CREATION_DEFAULT = false
 const CAPTURE_STDOUT_DEFAULT = true
 const WORKSPACE_CUSTOM_STARTUP_EXPR_DEFAULT = nothing
+const PROJECT_DEFAULT = nothing
 
 """
     EvaluationOptions([; kwargs...])
@@ -155,6 +156,7 @@ These options are not intended to be changed during normal use.
 - `lazy_workspace_creation::Bool = $LAZY_WORKSPACE_CREATION_DEFAULT`
 - `capture_stdout::Bool = $CAPTURE_STDOUT_DEFAULT`
 - `workspace_custom_startup_expr::Union{Nothing,Expr} = $WORKSPACE_CUSTOM_STARTUP_EXPR_DEFAULT` An expression to be evaluated in the workspace process before running notebook code.
+- `project::Union{Nothing, String} = $PROJECT_DEFAULT` Optionally supply project environment for Pluto notebooks. Disables Pluto's built-in package manager. Useful e.g. for batch runs during continuous integration.
 """
 @option mutable struct EvaluationOptions
     run_notebook_on_load::Bool = RUN_NOTEBOOK_ON_LOAD_DEFAULT
@@ -162,6 +164,7 @@ These options are not intended to be changed during normal use.
     lazy_workspace_creation::Bool = LAZY_WORKSPACE_CREATION_DEFAULT
     capture_stdout::Bool = CAPTURE_STDOUT_DEFAULT
     workspace_custom_startup_expr::Union{Nothing,Expr} = WORKSPACE_CUSTOM_STARTUP_EXPR_DEFAULT
+    project::Union{Nothing, String} = PROJECT_DEFAULT
 end
 
 const COMPILE_DEFAULT = nothing
@@ -311,6 +314,8 @@ function from_flat_kwargs(;
         startup_file::Union{Nothing,String} = STARTUP_FILE_DEFAULT,
         history_file::Union{Nothing,String} = HISTORY_FILE_DEFAULT,
         threads::Union{Nothing,String,Int} = default_number_of_threads(),
+                          
+        project::Union{Nothing,String} = nothing,
     )
     server = ServerOptions(;
         root_url,
@@ -343,6 +348,7 @@ function from_flat_kwargs(;
         lazy_workspace_creation,
         capture_stdout,
         workspace_custom_startup_expr,
+        project,
     )
     compiler = CompilerOptions(;
         compile,

--- a/src/packages/Packages.jl
+++ b/src/packages/Packages.jl
@@ -323,6 +323,12 @@ In addition to the steps performed by [`sync_nbpkg_core`](@ref):
 - `try` `catch` and reset the package environment on failure.
 """
 function sync_nbpkg(session, notebook, old_topology::NotebookTopology, new_topology::NotebookTopology; save::Bool=true, take_token::Bool=true)
+    if session.options.evaluation.project!=nothing
+        Pkg.activate(session.options.evaluation.project)
+        notebook.nbpkg_ctx=nothing
+        return true
+    end
+
     cleanup = Ref{Function}(_default_cleanup)
 	try
         Status.report_business_started!(notebook.status_tree, :pkg)


### PR DESCRIPTION
Optionally, this
* provides an environment activated at notebook start
* disables Pluto's package management

Useful e.g. for running CI tests where Pluto notebooks are used to provide examples

Known issues to be resolved:
* Status is not properly updated (seems like waiting for one last cell to be finished)
* No CI test yet