### PR TITLE
switch any-pointer:coarse to pointer:coarse

### DIFF
--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -1519,7 +1519,7 @@ pluto-input > button > span {
     }
 }
 
-@media screen and (any-pointer: coarse) {
+@media screen and (pointer: coarse) {
     pluto-cell > button,
     pluto-cell > pluto-runarea {
         opacity: 0;


### PR DESCRIPTION
The current CSS keeps the hide cell buttons always on when Pluto is opened on laptops which also have a touchscreen.

Using pointer instead of any-pointer should only make the button always on only on devices that have the touchscreen as primary.

With the proposed change the button will still be always on on devices whose primary pointer is a touchscreen, even if they have a secondary pointer connected with fine accuracy as the media query for pointer:coarse comes after the one with any-pointer:fine