### PR TITLE
Frontmatter GUI: multiple authors

### DIFF
--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -3445,6 +3445,10 @@ pluto-cell.hooked_up pluto-output {
     margin-top: 0.5em;
 }
 
+.pluto-frontmatter fieldset {
+    grid-column: 1/4;
+}
+
 .pluto-frontmatter .final {
     display: flex;
     margin-top: 2rem;


### PR DESCRIPTION
We already supported multiple authors in frontmatter metadata and in the featured notebook viewer, and now there is also a GUI for inputting this information!

<img width="552" alt="image" src="https://github.com/fonsp/Pluto.jl/assets/6933510/b01db3d0-fc9b-4150-90e4-ea1118db848c">

You can even add custom fields to authors!

<img width="502" alt="image" src="https://github.com/fonsp/Pluto.jl/assets/6933510/908185cc-3cd5-4fb3-a712-14df028c3c92">
