### PR TITLE
Fix safe preview in ExperimentalLayout and embed_display

### DIFF
--- a/frontend/components/FrontmatterInput.js
+++ b/frontend/components/FrontmatterInput.js
@@ -147,7 +147,7 @@ export const FrontMatterInput = ({ filename, remote_frontmatter, set_remote_fron
                     /** @type {import("./welcome/Featured.js").SourceManifestNotebookEntry} */ ({
                         id: filename.replace(/\.jl$/, ""),
                         hash: "xx",
-                        frontmatter,
+                        frontmatter: clean_data(frontmatter) ?? {},
                     })
                 }
                 disable_links=${true}

--- a/frontend/components/TreeView.js
+++ b/frontend/components/TreeView.js
@@ -199,8 +199,9 @@ export const TableView = ({ mime, body, cell_id, persist_js_state }) => {
     </table>`
 }
 
-export let DivElement = ({ cell_id, style, classname, children, persist_js_state = false }) => {
-    const mimepair_output = (pair) => html`<${SimpleOutputBody} cell_id=${cell_id} mime=${pair[1]} body=${pair[0]} persist_js_state=${persist_js_state} />`
+export let DivElement = ({ cell_id, style, classname, children, persist_js_state = false, sanitize_html = true }) => {
+    const mimepair_output = (pair) =>
+        html`<${SimpleOutputBody} cell_id=${cell_id} mime=${pair[1]} body=${pair[0]} persist_js_state=${persist_js_state} sanitize_html=${sanitize_html} />`
 
     return html`<div style=${style} class=${classname}>${children.map(mimepair_output)}</div>`
 }

--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -2401,6 +2401,7 @@ function Base.show(io::IO, m::MIME"text/html", e::EmbeddableDisplay)
         const display = create_new ? currentScript.previousElementSibling : this;
         
         display.persist_js_state = true;
+        display.sanitize_html = false;
         display.body = body;
         if(create_new) {
             // only set the mime if necessary, it triggers a second preact update


### PR DESCRIPTION
The "Safe preview" was always enabled for content embedded using ExperimentalLayout. This fixes it