### PR TITLE
Enable Malt on Windows by default

### DIFF
--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -153,7 +153,7 @@ These options are not intended to be changed during normal use.
 
 - `run_notebook_on_load::Bool = $RUN_NOTEBOOK_ON_LOAD_DEFAULT` Whether to evaluate a notebook on load.
 - `workspace_use_distributed::Bool = $WORKSPACE_USE_DISTRIBUTED_DEFAULT` Whether to start notebooks in a separate process.
-- `workspace_use_distributed_stdlib::Bool? = $WORKSPACE_USE_DISTRIBUTED_STDLIB_DEFAULT` Should we use the Distributed stdlib to run processes? Distributed will be replaced by Malt.jl, you can use this option to already get the old behaviour. `nothing` means: determine automatically (which is currently the same as `true`).
+- `workspace_use_distributed_stdlib::Bool? = $WORKSPACE_USE_DISTRIBUTED_STDLIB_DEFAULT` Should we use the Distributed stdlib to run processes? Distributed will be replaced by Malt.jl, you can use this option to already get the old behaviour. `nothing` means: determine automatically (which is currently `false` on Windows, `true` otherwise).
 - `lazy_workspace_creation::Bool = $LAZY_WORKSPACE_CREATION_DEFAULT`
 - `capture_stdout::Bool = $CAPTURE_STDOUT_DEFAULT`
 - `workspace_custom_startup_expr::Union{Nothing,String} = $WORKSPACE_CUSTOM_STARTUP_EXPR_DEFAULT` An expression to be evaluated in the workspace process before running notebook code.

--- a/src/evaluation/WorkspaceManager.jl
+++ b/src/evaluation/WorkspaceManager.jl
@@ -55,8 +55,7 @@ function make_workspace((session, notebook)::SN; is_offline_renderer::Bool=false
         Malt.InProcessWorker
     elseif something(
         session.options.evaluation.workspace_use_distributed_stdlib, 
-        true
-        # VERSION < v"1.8.0-0"
+        Sys.iswindows() ? false : true
     )
         Malt.DistributedStdlibWorker
     else


### PR DESCRIPTION
Oops forgot to make a PR for this branch 🙈

Since Malt has the biggest benefit on Windows (interrupting cells), let's enable it there first as an extended testing period and we can enable it for everyone in the future.