### PR TITLE
fix: activate a temp environment when a sysimage is enabled

### DIFF
--- a/src/webserver/SessionActions.jl
+++ b/src/webserver/SessionActions.jl
@@ -221,7 +221,7 @@ function new(session::ServerSession; run_async=true, notebook_id::UUID=uuid1())
     notebook = if session.options.compiler.sysimage === nothing
         emptynotebook()
     else
-        Notebook([Cell("import Pkg"), Cell("# This cell disables Pluto's package manager and activates the global environment. Click on ? inside the bubble next to Pkg.activate to learn more.\n# (added automatically because a sysimage is used)\nPkg.activate()"), Cell()])
+        Notebook([Cell("import Pkg"), Cell("# This cell disables Pluto's package manager and activates the global environment. Click on ? inside the bubble next to Pkg.activate to learn more.\n# (added automatically because a sysimage is used)\nPkg.activate(;temp=true)"), Cell()])
     end
 
     # Run NewNotebookEvent handler before assigning ID


### PR DESCRIPTION
Starting with Julia 1.8, the sysimage internal manifest (here on `Ⅿ₀`) is included in every Pkg resolution. So, a new, fresh manifest is equivalent to `Ⅿ₀` ∪ `∅`. This is strictly better than the "default" manifest that can be inconsistent with the `Ⅿ₀`, or may include packages that will interfere with the new packages we want to add (e.g. an old version of a package that the package you're adding is depending on).

To address that, the proposal is to instantiate a fresh manifest (`temp=true`) instead of the default. 