### PR TITLE
Multiple authors in feature card

### DIFF
--- a/frontend/components/welcome/FeaturedCard.js
+++ b/frontend/components/welcome/FeaturedCard.js
@@ -59,8 +59,11 @@ export const FeaturedCard = ({ entry, source_manifest, direct_html_links, disabl
                 ? null
                 : html`
                       <div class="author">
-                          <a href=${author.url}> <img src=${author.image ?? transparent_svg} /><span>${author.name}</span></a>
-                          ${author.has_coauthors ? html`<span>...</span>` : null}
+                          <img src=${author.image ?? transparent_svg} />
+                          <span>
+                              <a href=${author.url}>${author.name}</a>
+                              ${author.has_coauthors ? html` and others` : null}
+                          </span>
                       </div>
                   `}
             <h3><a href=${href} title=${entry?.frontmatter?.title}>${entry?.frontmatter?.title ?? entry.id}</a></h3>

--- a/frontend/components/welcome/FeaturedCard.js
+++ b/frontend/components/welcome/FeaturedCard.js
@@ -60,6 +60,7 @@ export const FeaturedCard = ({ entry, source_manifest, direct_html_links, disabl
                 : html`
                       <div class="author">
                           <a href=${author.url}> <img src=${author.image ?? transparent_svg} /><span>${author.name}</span></a>
+                          ${author.has_coauthors ? html`<span>...</span>` : null}
                       </div>
                   `}
             <h3><a href=${href} title=${entry?.frontmatter?.title}>${entry?.frontmatter?.title ?? entry.id}</a></h3>
@@ -74,9 +75,13 @@ export const FeaturedCard = ({ entry, source_manifest, direct_html_links, disabl
  * name: string?,
  * url: string?,
  * image: string?,
+ * has_coauthors?: boolean,
  * }}
  */
 
+/**
+ * @returns {AuthorInfo?}
+ */
 const author_info = (frontmatter) =>
     author_info_item(frontmatter.author) ??
     author_info_item({
@@ -90,9 +95,11 @@ const author_info = (frontmatter) =>
  */
 const author_info_item = (x) => {
     if (x instanceof Array) {
-        return author_info_item(x[0])
-    } else if (x == null) {
-        return null
+        const first = author_info_item(x[0])
+        if (first?.name) {
+            const has_coauthors = x.length > 1
+            return { ...first, has_coauthors }
+        }
     } else if (typeof x === "string") {
         return {
             name: x,
@@ -111,7 +118,6 @@ const author_info_item = (x) => {
             url,
             image,
         }
-    } else {
-        return null
     }
+    return null
 }

--- a/frontend/featured-card.css
+++ b/frontend/featured-card.css
@@ -55,12 +55,14 @@ featured-card .author {
     background: var(--welcome-card-author-backdrop);
     /* background: hsl(var(--card-color-hue) 34% 46% / 59%); */
     backdrop-filter: blur(15px);
-    color: black;
+    color: var(--index-text-color);
     border-radius: 117px;
     /* height: 2.5em; */
     padding: 0.3em;
     padding-right: 0.8em;
     display: flex;
+    align-items: center;
+    gap: 0.4ch;
 }
 
 featured-card .author img {

--- a/frontend/featured-card.css
+++ b/frontend/featured-card.css
@@ -63,6 +63,7 @@ featured-card .author {
     display: flex;
     align-items: center;
     gap: 0.4ch;
+    margin-left: 0.3rem;
 }
 
 featured-card .author img {
@@ -76,13 +77,6 @@ featured-card .author img {
     background: #b6b6b6;
     display: inline-block;
     overflow: hidden;
-}
-
-featured-card .author a {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    gap: 0.4ch;
 }
 
 featured-card h3 a {


### PR DESCRIPTION
Show "and others" in the featured notebook card when it has more than one author listed (close https://github.com/fonsp/Pluto.jl/issues/2719)

For instance, if the first notebook would have more authors, it would look like this:

![screenshot showing preview of "getting started" notebook, with authors listed as "pluto.jl and others"](https://github.com/fonsp/Pluto.jl/assets/43678097/2613f94a-2cd5-4953-a973-3b5ce8fd140a)
