### PR TITLE
No IOContext for `stdout` and `stderr` globals

### DIFF
--- a/src/runner/PlutoRunner.jl
+++ b/src/runner/PlutoRunner.jl
@@ -2627,8 +2627,8 @@ function with_io_to_logs(f::Function; enabled::Bool=true, loglevel::Logging.LogL
     # Redirect both the `stdout` and `stderr` streams to a single `Pipe` object.
     pipe = Pipe()
     Base.link_pipe!(pipe; reader_supports_async = true, writer_supports_async = true)
-    pe_stdout = IOContext(pipe.in, default_stdout_iocontext)
-    pe_stderr = IOContext(pipe.in, default_stdout_iocontext)
+    pe_stdout = pipe.in
+    pe_stderr = pipe.in
     redirect_stdout(pe_stdout)
     redirect_stderr(pe_stderr)
 
@@ -2661,7 +2661,7 @@ function with_io_to_logs(f::Function; enabled::Bool=true, loglevel::Logging.LogL
     end
 
     # To make the `display` function work.
-    redirect_display = TextDisplay(pe_stdout)
+    redirect_display = TextDisplay(IOContext(pe_stdout, default_stdout_iocontext))
     pushdisplay(redirect_display)
 
     # Run the function `f`, capturing all output that it might have generated.


### PR DESCRIPTION
In particular, this means that the `size` and `limit` context properties are not set, which means that `println(rand(1000))` and `show(rand(1000))` will show all 1000 elements. `display(rand(1000))` will still only show a summary. (And obvs `@info(rand(1000))` will still use Pluto's tree viewer.)

This seems like bad UX, but it matches what the REPL does:

```
julia> show(rand(1000))
[0.12299314771000547, 0.34481837861238196, 0.1412851103310082, 0.341192658866322, 0.4771573774466965, 0.7286849486802406, 0.35442839476258836, 0.49616617094335125, 0.9335479398640664, 0.5364511086226855, 0.9929904521012239, 0.8314686759998279, 0.7298980063043572, 0.8617306443450735, 0.37664232713035906, 0.3318862761876735, 0.7473904847036247, 0.7918504407018792, 0.054745059968528076, 0.015044635937407791, 0.859486105415115, 0.7934766508079504, 0.5119828918730756, 0.32428349059782047, 0.756175465285966, 0.24141251977124378, 0.9537129008763774, 0.5074258231916178, 0.6521823979577855, 0.12178021062312916, 0.6155530113180632, 0.06014062595785519, 0.2565760855216096, 0.9400240063081378, 0.8686618401354126, 0.7896392260224593, 0.5751160603362497, 0.01271347661215616, 0.2571469766147547, 0.7684866249541698, 0.8451645118347535, 0.1361998455870692, 0.752427542128302, 0.08386050664147593, 0.2785632156153358, 0.2737807744002383, 0.14896579627304207, 0.5195003163294613, 0.02708863359041591, 0.7426053727927592, 0.49280298668856615, 0.18165789886455475, 0.6597655482107889, 0.6188361252798483, 0.6141356986509118, 0.8896604394780323, 0.09047334067372037, 0.149823096144719, 0.7622071145976002, 0.6132541750769761, 0.7242025305527855, 0.772254058625823, 0.9210455942859939, 0.6719599412268669, 0.9844640596156032, 0.19771538569541813, 0.9684850223773421, 0.97179842779803, 0.5609477833365853, 0.5224375468116627, 0.7704271662681313, 0.3984791652783807, 0.148953923805895, 0.29059359399512175, 0.4708947773151656, 0.6865854882231424, 0.7346523166961143, 0.7606257817569155, 0.55770839909113, 0.952657292358489, 0.7271737695524088, 0.104108984785095, 0.8453513619375655, 0.5170538913842834, 0 AND SO ON
```

Users might expect to be able to see all elements of an array by calling `show` or `print` on it. Without this, it's difficult to see all entries.

# Before
![localhost_1234_edit_id=2633ce8c-886e-11ee-08f4-79051ff0d21d](https://github.com/fonsp/Pluto.jl/assets/6933510/b4cd232a-1042-4a9c-8ba8-d08a05513948)

# After
![localhost_1234_edit_id=cab264ec-886d-11ee-34cf-8b6e992c022d](https://github.com/fonsp/Pluto.jl/assets/6933510/31274f1b-f2b8-4f4d-8e08-0023af07a574)


