### PR TITLE
suppress output of xdg-open

### DIFF
--- a/src/webserver/WebServer.jl
+++ b/src/webserver/WebServer.jl
@@ -13,7 +13,7 @@ function open_in_default_browser(url::AbstractString)::Bool
             Base.run(`powershell.exe Start "'$url'"`)
             true
         elseif Sys.islinux()
-            Base.run(`xdg-open $url`)
+            Base.run(`xdg-open $url`, devnull, devnull, devnull)
             true
         else
             false


### PR DESCRIPTION
GTK warnings can be confusing, let's redirect the output of xdg-open to devnull.