### PR TITLE
Bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Pluto"
 uuid = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
 license = "MIT"
 authors = ["Fons van der Plas <fons@plutojl.org>"]
-version = "0.19.34"
+version = "0.19.35"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"


### PR DESCRIPTION
This will retrigger a bundler build which failed for 0.19.34.

The bundler succeeded when retriggered in https://github.com/fonsp/Pluto.jl/commit/60baec9da45fdbe57336e965be1ae1aca7728847.