### PR TITLE
Fix invisible button issues on touch displays

### DIFF
--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -1573,10 +1573,13 @@ pluto-input > button > span {
     button.toggle_export,
     button.start_stop_recording,
     pluto-cell:hover > button,
+    pluto-cell:focus-within > button,
     pluto-cell:hover > pluto-input > button,
+    pluto-cell:focus-within > pluto-input > button,
     pluto-cell > pluto-runarea > button,
-    pluto-cell:hover > pluto-shoulder > button {
-        opacity: 0.4;
+    pluto-cell:hover > pluto-shoulder > button,
+    pluto-cell:focus-within > pluto-shoulder > button {
+        opacity: 0.6;
         transition: opacity 0.25s ease-in-out;
     }
     .export_small_btns button:hover,
@@ -1595,22 +1598,25 @@ pluto-input > button > span {
 }
 
 @media screen and (pointer: coarse) {
-    pluto-cell > button,
-    pluto-cell > pluto-runarea {
-        opacity: 0;
-        /* to make it feel smooth: */
-        transition: opacity 0.25s ease-in-out;
-    }
+    pluto-cell > button.add_cell,
     pluto-input > button,
     pluto-shoulder > button {
         opacity: 0.25;
         transition: opacity 0.25s ease-in-out;
     }
-    pluto-cell:focus-within > button,
+    pluto-cell:not(:first-of-type, :last-of-type) > button.add_cell {
+        /* because there are two overlapping buttons */
+        opacity: 0.125;
+    }
+    /* pluto-cell:first-of-type > button.add_cell.before,
+    pluto-cell:last-of-type > button.add_cell.after {
+        opacity: 0.25;
+    } */
+    pluto-cell:focus-within > button.add_cell,
     pluto-cell:focus-within > pluto-input > button,
     pluto-cell:focus-within > pluto-runarea,
     pluto-cell:focus-within > pluto-shoulder > button {
-        opacity: 0.25;
+        opacity: 0.6;
         transition: opacity 0.25s ease-in-out;
     }
     pluto-cell > pluto-input > button:focus-within,


### PR DESCRIPTION
# Before

The "add cell" buttons (+) only show around the focused cell. 

<img width="638" alt="image" src="https://github.com/fonsp/Pluto.jl/assets/6933510/9a4d7670-5d66-4dd0-86a2-8188e008903a">

# After

The "add cell" buttons (+) always show, and have higher contrast when the cell is in focus.

<img width="635" alt="image" src="https://github.com/fonsp/Pluto.jl/assets/6933510/6e85ec33-a878-4f11-bd77-4e1227c11e27">

