### PR TITLE
Show help when stuck in tab index trap

### DIFF
--- a/frontend/common/Bond.js
+++ b/frontend/common/Bond.js
@@ -1,7 +1,7 @@
 // import Generators_input from "https://unpkg.com/@observablehq/stdlib@3.3.1/src/generators/input.js"
 // import Generators_input from "https://unpkg.com/@observablehq/stdlib@3.3.1/src/generators/input.js"
 
-import { open_pluto_popup } from "../components/Popup.js"
+import { open_pluto_popup } from "../common/open_pluto_popup.js"
 import _ from "../imports/lodash.js"
 import { html } from "../imports/Preact.js"
 import observablehq from "./SetupCellEnvironment.js"

--- a/frontend/common/open_pluto_popup.js
+++ b/frontend/common/open_pluto_popup.js
@@ -1,0 +1,7 @@
+export const open_pluto_popup = (/** @type{import("../components/Popup").PkgPopupDetails | import("../components/Popup").MiscPopupDetails} */ detail) => {
+    window.dispatchEvent(
+        new CustomEvent("open pluto popup", {
+            detail,
+        })
+    )
+}

--- a/frontend/components/Cell.js
+++ b/frontend/components/Cell.js
@@ -7,7 +7,7 @@ import { Logs } from "./Logs.js"
 import { RunArea, useDebouncedTruth } from "./RunArea.js"
 import { cl } from "../common/ClassTable.js"
 import { PlutoActionsContext } from "../common/PlutoContext.js"
-import { open_pluto_popup } from "./Popup.js"
+import { open_pluto_popup } from "../common/open_pluto_popup.js"
 import { SafePreviewOutput } from "./SafePreviewUI.js"
 
 const useCellApi = (node_ref, published_object_keys, pluto_actions) => {

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -67,6 +67,7 @@ import { ScopeStateField } from "./CellInput/scopestate_statefield.js"
 import { mod_d_command } from "./CellInput/mod_d_command.js"
 import { open_bottom_right_panel } from "./BottomRightPanel.js"
 import { timeout_promise } from "../common/PlutoConnection.js"
+import { LastFocusWasForcedEffect, tab_help_plugin } from "./CellInput/tab_help_plugin.js"
 
 export const ENABLE_CM_MIXED_PARSER = window.localStorage.getItem("ENABLE_CM_MIXED_PARSER") === "true"
 
@@ -636,6 +637,7 @@ export const CellInput = ({
                     highlightSelectionMatches(),
                     bracketMatching(),
                     docs_updater,
+                    tab_help_plugin,
                     // Remove selection on blur
                     EditorView.domEventHandlers({
                         blur: (event, view) => {

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -865,6 +865,7 @@ export const CellInput = ({
                     EditorView.scrollIntoView(EditorSelection.range(new_selection.anchor, new_selection.head), {
                         yMargin: 80,
                     }),
+                    LastFocusWasForcedEffect.of(true),
                 ],
             })
         }

--- a/frontend/components/CellInput/tab_help_plugin.js
+++ b/frontend/components/CellInput/tab_help_plugin.js
@@ -1,6 +1,6 @@
+import { open_pluto_popup } from "../../common/open_pluto_popup.js"
 import { ViewPlugin, StateEffect, StateField } from "../../imports/CodemirrorPlutoSetup.js"
 import _ from "../../imports/lodash.js"
-import { open_pluto_popup } from "../Popup.js"
 import { html } from "../../imports/Preact.js"
 
 /** @type {any} */

--- a/frontend/components/CellInput/tab_help_plugin.js
+++ b/frontend/components/CellInput/tab_help_plugin.js
@@ -1,14 +1,10 @@
-import { Facet, ViewPlugin, Decoration, EditorView, StateEffect, StateField, ViewUpdate } from "../../imports/CodemirrorPlutoSetup.js"
-import { ctrl_or_cmd_name, has_ctrl_or_cmd_pressed } from "../../common/KeyboardShortcuts.js"
+import { ViewPlugin, StateEffect, StateField } from "../../imports/CodemirrorPlutoSetup.js"
 import _ from "../../imports/lodash.js"
-import { ScopeStateField } from "./scopestate_statefield.js"
 import { open_pluto_popup } from "../Popup.js"
 import { html } from "../../imports/Preact.js"
 
 /** @type {any} */
 const TabHelpEffect = StateEffect.define()
-/** @type {any} */
-export const LastFocusWasForcedEffect = StateEffect.define()
 const TabHelp = StateField.define({
     create() {
         return false
@@ -20,6 +16,9 @@ const TabHelp = StateField.define({
         return value
     },
 })
+
+/** @type {any} */
+export const LastFocusWasForcedEffect = StateEffect.define()
 const LastFocusWasForced = StateField.define({
     create() {
         return false
@@ -32,54 +31,35 @@ const LastFocusWasForced = StateField.define({
     },
 })
 
-export const tab_help_plugin = ViewPlugin.fromClass(
-    class {
-        /**
-         * @param {EditorView} view
-         */
-        constructor(view) {
-            // let global_definitions = view.state.facet(GlobalDefinitionsFacet)
-            this.setready = (x) =>
-                view.dispatch({
-                    effects: [TabHelpEffect.of(x)],
-                })
-        }
-
-        /**
-         * @param {ViewUpdate} update
-         */
-        update(update) {
-            const selection_changed = update.startState.selection.eq(update.state.selection)
-            const doc_changed = update.docChanged
-
-            console.log("ff", update.view.state.field(LastFocusWasForced))
-            console.log({ selection_changed, doc_changed }, update)
-        }
-    },
+export const tab_help_plugin = ViewPlugin.define(
+    (view) => ({
+        setready: (x) =>
+            view.dispatch({
+                effects: [TabHelpEffect.of(x)],
+            }),
+    }),
     {
         provide: (p) => [TabHelp, LastFocusWasForced],
         eventObservers: {
             focus: function (event, view) {
                 // The next key should trigger the popup
                 this.setready(true)
-                console.warn("focus", event, view)
             },
             blur: function (event, view) {
                 this.setready(false)
                 view.dispatch({
                     effects: [LastFocusWasForcedEffect.of(false)],
                 })
-                console.warn("blur", event, view)
             },
             click: function (event, view) {
                 // This means you are not doing keyboard navigation :)
                 this.setready(false)
-                console.warn("click", event, view)
             },
             keydown: function (event, view) {
-                console.warn("keydown", event, view)
+                console.error(event.key, view.state.field(TabHelp), view.state.field(LastFocusWasForced))
                 if (event.key == "Tab") {
                     if (view.state.field(TabHelp) && !view.state.field(LastFocusWasForced) && !view.state.readOnly) {
+                        console.log(123)
                         open_pluto_popup({
                             type: "info",
                             source_element: view.dom,

--- a/frontend/components/CellInput/tab_help_plugin.js
+++ b/frontend/components/CellInput/tab_help_plugin.js
@@ -1,0 +1,96 @@
+import { Facet, ViewPlugin, Decoration, EditorView, StateEffect, StateField, ViewUpdate } from "../../imports/CodemirrorPlutoSetup.js"
+import { ctrl_or_cmd_name, has_ctrl_or_cmd_pressed } from "../../common/KeyboardShortcuts.js"
+import _ from "../../imports/lodash.js"
+import { ScopeStateField } from "./scopestate_statefield.js"
+import { open_pluto_popup } from "../Popup.js"
+import { html } from "../../imports/Preact.js"
+
+/** @type {any} */
+const TabHelpEffect = StateEffect.define()
+/** @type {any} */
+export const LastFocusWasForcedEffect = StateEffect.define()
+const TabHelp = StateField.define({
+    create() {
+        return false
+    },
+    update(value, tr) {
+        for (let effect of tr.effects) {
+            if (effect.is(TabHelpEffect)) return effect.value
+        }
+        return value
+    },
+})
+const LastFocusWasForced = StateField.define({
+    create() {
+        return false
+    },
+    update(value, tr) {
+        for (let effect of tr.effects) {
+            if (effect.is(LastFocusWasForcedEffect)) return effect.value
+        }
+        return value
+    },
+})
+
+export const tab_help_plugin = ViewPlugin.fromClass(
+    class {
+        /**
+         * @param {EditorView} view
+         */
+        constructor(view) {
+            // let global_definitions = view.state.facet(GlobalDefinitionsFacet)
+            this.setready = (x) =>
+                view.dispatch({
+                    effects: [TabHelpEffect.of(x)],
+                })
+        }
+
+        /**
+         * @param {ViewUpdate} update
+         */
+        update(update) {
+            const selection_changed = update.startState.selection.eq(update.state.selection)
+            const doc_changed = update.docChanged
+
+            console.log("ff", update.view.state.field(LastFocusWasForced))
+            console.log({ selection_changed, doc_changed }, update)
+        }
+    },
+    {
+        provide: (p) => [TabHelp, LastFocusWasForced],
+        eventObservers: {
+            focus: function (event, view) {
+                // The next key should trigger the popup
+                this.setready(true)
+                console.warn("focus", event, view)
+            },
+            blur: function (event, view) {
+                this.setready(false)
+                view.dispatch({
+                    effects: [LastFocusWasForcedEffect.of(false)],
+                })
+                console.warn("blur", event, view)
+            },
+            click: function (event, view) {
+                // This means you are not doing keyboard navigation :)
+                this.setready(false)
+                console.warn("click", event, view)
+            },
+            keydown: function (event, view) {
+                console.warn("keydown", event, view)
+                if (event.key == "Tab") {
+                    if (view.state.field(TabHelp) && !view.state.field(LastFocusWasForced) && !view.state.readOnly) {
+                        open_pluto_popup({
+                            type: "info",
+                            source_element: view.dom,
+                            body: html`Press <kbd>Esc</kbd> and then <kbd>Tab</kbd> to continue navigation.`,
+                        })
+                        this.setready(false)
+                    }
+                } else {
+                    this.setready(false)
+                }
+            },
+        },
+    }
+)

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -18,7 +18,7 @@ import { RecentlyDisabledInfo, UndoDelete } from "./UndoDelete.js"
 import { SlideControls } from "./SlideControls.js"
 import { Scroller } from "./Scroller.js"
 import { ExportBanner } from "./ExportBanner.js"
-import { open_pluto_popup, Popup } from "./Popup.js"
+import { Popup } from "./Popup.js"
 
 import { slice_utf8, length_utf8 } from "../common/UnicodeTools.js"
 import { has_ctrl_or_cmd_pressed, ctrl_or_cmd_name, is_mac_keyboard, in_textarea_or_input } from "../common/KeyboardShortcuts.js"
@@ -36,6 +36,7 @@ import { EditorLaunchBackendButton } from "./Editor/LaunchBackendButton.js"
 import { get_environment } from "../common/Environment.js"
 import { ProcessStatus } from "../common/ProcessStatus.js"
 import { SafePreviewUI } from "./SafePreviewUI.js"
+import { open_pluto_popup } from "../common/open_pluto_popup.js"
 
 // This is imported asynchronously - uncomment for development
 // import environment from "../common/Environment.js"

--- a/frontend/components/FilePicker.js
+++ b/frontend/components/FilePicker.js
@@ -16,6 +16,7 @@ import {
     StateEffect,
 } from "../imports/CodemirrorPlutoSetup.js"
 import { guess_notebook_location } from "../common/NotebookLocationFromURL.js"
+import { tab_help_plugin } from "./CellInput/tab_help_plugin.js"
 
 let { autocompletion, completionKeymap } = autocomplete
 
@@ -248,6 +249,7 @@ export const FilePicker = ({ value, suggest_new_file, button_label, placeholder,
                     keymap.of(completionKeymap),
 
                     Placeholder(placeholder),
+                    tab_help_plugin,
                 ],
             }),
         })

--- a/frontend/components/Logs.js
+++ b/frontend/components/Logs.js
@@ -2,8 +2,9 @@ import _ from "../imports/lodash.js"
 import { cl } from "../common/ClassTable.js"
 import { html, useState, useEffect, useLayoutEffect, useRef, useMemo } from "../imports/Preact.js"
 import { SimpleOutputBody } from "./TreeView.js"
-import { help_circle_icon, open_pluto_popup } from "./Popup.js"
+import { help_circle_icon } from "./Popup.js"
 import AnsiUp from "../imports/AnsiUp.js"
+import { open_pluto_popup } from "../common/open_pluto_popup.js"
 
 const LOGS_VISIBLE_START = 60
 const LOGS_VISIBLE_END = 20

--- a/frontend/components/PkgStatusMark.js
+++ b/frontend/components/PkgStatusMark.js
@@ -1,6 +1,6 @@
+import { open_pluto_popup } from "../common/open_pluto_popup.js"
 import _ from "../imports/lodash.js"
 import { html, useEffect, useState } from "../imports/Preact.js"
-import { open_pluto_popup } from "./Popup.js"
 
 export const nbpkg_fingerprint = (nbpkg) => (nbpkg == null ? [null] : Object.entries(nbpkg).flat())
 

--- a/frontend/components/Popup.js
+++ b/frontend/components/Popup.js
@@ -1,13 +1,10 @@
-import { html, useState, useRef, useLayoutEffect, useEffect, useMemo, useContext } from "../imports/Preact.js"
-import immer from "../imports/immer.js"
-import observablehq from "../common/SetupCellEnvironment.js"
+import { html, useState, useRef, useEffect, useContext } from "../imports/Preact.js"
 import { cl } from "../common/ClassTable.js"
 
-import { RawHTMLContainer, highlight } from "./CellOutput.js"
 import { PlutoActionsContext } from "../common/PlutoContext.js"
 import { package_status, nbpkg_fingerprint_without_terminal } from "./PkgStatusMark.js"
 import { PkgTerminalView } from "./PkgTerminalView.js"
-import { prettytime, useDebouncedTruth } from "./RunArea.js"
+import { useDebouncedTruth } from "./RunArea.js"
 import { time_estimate, usePackageTimingData } from "../common/InstallTimeEstimate.js"
 import { pretty_long_time } from "./EditOrRunButton.js"
 

--- a/frontend/components/RunArea.js
+++ b/frontend/components/RunArea.js
@@ -3,7 +3,7 @@ import { html, useContext, useEffect, useMemo, useState } from "../imports/Preac
 
 import { in_textarea_or_input } from "../common/KeyboardShortcuts.js"
 import { PlutoActionsContext } from "../common/PlutoContext.js"
-import { open_pluto_popup } from "./Popup.js"
+import { open_pluto_popup } from "../common/open_pluto_popup.js"
 
 export const RunArea = ({
     runtime,

--- a/frontend/components/SafePreviewUI.js
+++ b/frontend/components/SafePreviewUI.js
@@ -1,6 +1,6 @@
+import { open_pluto_popup } from "../common/open_pluto_popup.js"
 import _ from "../imports/lodash.js"
 import { html } from "../imports/Preact.js"
-import { open_pluto_popup } from "./Popup.js"
 
 export const SafePreviewUI = ({ process_waiting_for_permission, risky_file_source, restart, warn_about_untrusted_code }) => {
     return html`

--- a/frontend/components/SlideControls.js
+++ b/frontend/components/SlideControls.js
@@ -1,5 +1,4 @@
 import { html, useRef, useState, useLayoutEffect, useEffect } from "../imports/Preact.js"
-import { open_pluto_popup } from "./Popup.js"
 
 export const SlideControls = () => {
     const button_prev_ref = useRef(/** @type {HTMLButtonElement?} */ (null))

--- a/frontend/imports/AnsiUp.js
+++ b/frontend/imports/AnsiUp.js
@@ -1,5 +1,6 @@
 // @ts-ignore
 const AnsiUp = window?.AnsiUp ?? {}
 
+// @ts-ignore
 export default AnsiUp
 // export default window.AnsiUp

--- a/frontend/imports/AnsiUp.js
+++ b/frontend/imports/AnsiUp.js
@@ -1,5 +1,12 @@
 // @ts-ignore
-const AnsiUp = window?.AnsiUp ?? class {}
+const AnsiUp =
+    window?.AnsiUp ??
+    class {
+        ansi_to_html(value) {
+            throw new Error("Method not implemented.")
+            return ""
+        }
+    }
 
 // @ts-ignore
 export default AnsiUp

--- a/frontend/imports/AnsiUp.js
+++ b/frontend/imports/AnsiUp.js
@@ -1,3 +1,5 @@
 // @ts-ignore
-export default AnsiUp = window.AnsiUp
+const AnsiUp = window?.AnsiUp ?? {}
+
+export default AnsiUp
 // export default window.AnsiUp

--- a/frontend/imports/AnsiUp.js
+++ b/frontend/imports/AnsiUp.js
@@ -1,5 +1,5 @@
 // @ts-ignore
-const AnsiUp = window?.AnsiUp ?? {}
+const AnsiUp = window?.AnsiUp ?? class {}
 
 // @ts-ignore
 export default AnsiUp

--- a/frontend/imports/AnsiUp.js
+++ b/frontend/imports/AnsiUp.js
@@ -1,13 +1,2 @@
 // @ts-ignore
-const AnsiUp =
-    window?.AnsiUp ??
-    class {
-        ansi_to_html(value) {
-            throw new Error("Method not implemented.")
-            return ""
-        }
-    }
-
-// @ts-ignore
-export default AnsiUp
-// export default window.AnsiUp
+export default AnsiUp = window.AnsiUp


### PR DESCRIPTION
We use tab for autocomplete, which is a usability issue: if you use TAB to navigate a website, a codemirror acts as a "focus trap": it is not possible to focus on the next item.

Codemirror 6 addresses this issue by disabling tab-to-indent by default, but we enabled it anyways because it is the expected behaviour of an IDE. In that case, CM6 lets users focus on the next item using Escape - Tab, but as https://codemirror.net/examples/tab/ suggests, this should be clearly documented.

(FYI this does not happen when viewing a static Pluto document, we disable the Tab key handler in this case.)

I think the best way to document this is to detect the scenario and show documentation on-screen. I tried to use fancy CM6 API to do it :)

The help message will show when: a cell is focused, but not using a click or arrow-movement-across-cells (not implemented in the video below), and the first key that is pressed is Tab.

In this video, I navigate through the page using Tab, and also using my mouse, and you can see when the message shows up or not.

https://github.com/fonsp/Pluto.jl/assets/6933510/7906642e-ebd8-4aed-a972-4ffca248b31a

