### PR TITLE
Use <dialog> for the export menu for better keyboard accessibility

### DIFF
--- a/frontend/components/ExportBanner.js
+++ b/frontend/components/ExportBanner.js
@@ -87,7 +87,14 @@ export const ExportBanner = ({ notebook_id, print_title, open, onClose, notebook
         }
     }, [open, element_ref.current])
 
-    useEventListener(element_ref.current, "close", onClose)
+    useEventListener(
+        element_ref.current,
+        "focusout",
+        () => {
+            if (!element_ref.current?.matches(":focus-within")) onClose()
+        },
+        [onClose]
+    )
 
     return html`
         <dialog id="export" inert=${!open} ref=${element_ref}>

--- a/frontend/components/ExportBanner.js
+++ b/frontend/components/ExportBanner.js
@@ -1,4 +1,4 @@
-import { html, useEffect, useRef } from "../imports/Preact.js"
+import { html, useEffect, useLayoutEffect, useRef } from "../imports/Preact.js"
 
 const Circle = ({ fill }) => html`
     <svg
@@ -74,8 +74,18 @@ export const ExportBanner = ({ notebook_id, print_title, open, onClose, notebook
         }
     }, [print_title])
 
+    const element_ref = useRef(null)
+
+    useLayoutEffect(() => {
+        if (open) {
+            element_ref.current?.show()
+        } else {
+            element_ref.current?.close()
+        }
+    })
+
     return html`
-        <aside id="export" inert=${!open}>
+        <dialog id="export" inert=${!open} ref=${element_ref}>
             <div id="container">
                 <div class="export_title">export</div>
                 <!-- no "download" attribute here: we want the jl contents to be shown in a new tab -->
@@ -143,6 +153,6 @@ export const ExportBanner = ({ notebook_id, print_title, open, onClose, notebook
                     </button>
                 </div>
             </div>
-        </aside>
+        </dialog>
     `
 }

--- a/frontend/components/ExportBanner.js
+++ b/frontend/components/ExportBanner.js
@@ -1,3 +1,4 @@
+import { useEventListener } from "../common/useEventListener.js"
 import { html, useEffect, useLayoutEffect, useRef } from "../imports/Preact.js"
 
 const Circle = ({ fill }) => html`
@@ -74,7 +75,7 @@ export const ExportBanner = ({ notebook_id, print_title, open, onClose, notebook
         }
     }, [print_title])
 
-    const element_ref = useRef(null)
+    const element_ref = useRef(/** @type {HTMLDialogElement?} */ (null))
 
     useLayoutEffect(() => {
         if (open) {
@@ -82,7 +83,9 @@ export const ExportBanner = ({ notebook_id, print_title, open, onClose, notebook
         } else {
             element_ref.current?.close()
         }
-    })
+    }, [open, element_ref.current])
+
+    useEventListener(element_ref.current, "close", onClose)
 
     return html`
         <dialog id="export" inert=${!open} ref=${element_ref}>
@@ -126,32 +129,32 @@ export const ExportBanner = ({ notebook_id, print_title, open, onClose, notebook
                         <section>Capture the entire notebook, and any changes you make.</section>
                     </a>
                 `}
-                <div class="export_small_btns">
-                    <button
-                        title="Edit frontmatter"
-                        class="toggle_frontmatter_edit"
-                        onClick=${() => {
-                            onClose()
-                            window.dispatchEvent(new CustomEvent("open pluto frontmatter"))
-                        }}
-                    >
-                        <span></span>
-                    </button>
-                    <button
-                        title="Start presentation"
-                        class="toggle_presentation"
-                        onClick=${() => {
-                            onClose()
-                            // @ts-ignore
-                            window.present()
-                        }}
-                    >
-                        <span></span>
-                    </button>
-                    <button title="Close" class="toggle_export" onClick=${() => onClose()}>
-                        <span></span>
-                    </button>
-                </div>
+            </div>
+            <div class="export_small_btns">
+                <button
+                    title="Edit frontmatter"
+                    class="toggle_frontmatter_edit"
+                    onClick=${() => {
+                        onClose()
+                        window.dispatchEvent(new CustomEvent("open pluto frontmatter"))
+                    }}
+                >
+                    <span></span>
+                </button>
+                <button
+                    title="Start presentation"
+                    class="toggle_presentation"
+                    onClick=${() => {
+                        onClose()
+                        // @ts-ignore
+                        window.present()
+                    }}
+                >
+                    <span></span>
+                </button>
+                <button title="Close" class="toggle_export" onClick=${() => onClose()}>
+                    <span></span>
+                </button>
             </div>
         </dialog>
     `

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -491,7 +491,7 @@ header#pluto-nav.show_export {
 
 dialog#export {
     position: absolute;
-    display: flex;
+    display: block;
     top: 0;
     width: 100%;
     height: 130px;
@@ -499,7 +499,7 @@ dialog#export {
     color: var(--export-color);
     transform: translateY(-100%);
     /* overlay: none !important; */
-    /* overflow: auto; */
+    overflow: visible;
     margin: 0;
     padding: 0;
     max-width: none;

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -489,16 +489,24 @@ header#pluto-nav.show_export {
     transform: translateY(130px);
 }
 
-aside#export {
+dialog#export {
     position: absolute;
+    display: flex;
     top: 0;
     width: 100%;
     height: 130px;
     background: var(--export-bg-color);
     color: var(--export-color);
     transform: translateY(-100%);
+    /* overlay: none !important; */
+    /* overflow: auto; */
+    margin: 0;
+    padding: 0;
+    max-width: none;
+    max-height: none;
+    border: none;
 }
-aside#export::before {
+dialog#export::before {
     content: "";
     position: absolute;
     bottom: 100%;
@@ -507,7 +515,7 @@ aside#export::before {
     height: 100px;
     background: inherit;
 }
-aside#export div#container {
+dialog#export div#container {
     flex-direction: row;
     display: flex;
     max-width: 1000px;
@@ -515,11 +523,11 @@ aside#export div#container {
     margin: 0 auto;
     position: relative;
 }
-header aside#export div#container {
+header dialog#export div#container {
     /* to prevent the div from taking up horizontal page when the export pane is closed. On small screen this causes overscroll on the right. */
     overflow-x: hidden;
 }
-header.show_export aside#export div#container {
+header.show_export dialog#export div#container {
     overflow-x: auto;
 }
 a.export_card {
@@ -562,7 +570,7 @@ a.export_card section {
     /* font-size: 14px; */
     padding: 3px;
 }
-aside#export .export_small_btns {
+dialog#export .export_small_btns {
     display: flex;
     flex-direction: row;
     padding: 0.9em;
@@ -727,15 +735,15 @@ nav#at_the_top button.toggle_export span {
     background-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/share-outline.svg");
     filter: var(--image-filters);
 }
-aside#export button.toggle_export span {
+dialog#export button.toggle_export span {
     background-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/close-outline.svg");
     filter: invert(1);
 }
-aside#export button.toggle_frontmatter_edit span {
+dialog#export button.toggle_frontmatter_edit span {
     background-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/newspaper-outline.svg");
     filter: invert(1);
 }
-aside#export button.toggle_presentation span {
+dialog#export button.toggle_presentation span {
     background-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/easel-outline.svg");
     filter: invert(1);
 }


### PR DESCRIPTION
The export menu used to be an `<aside>`, using `inert` and styling when the menu is toggled. This PR changes it to `<dialog>` with `open` (not modal), which is better semantics that will also make sure that the correct tabbing behaviour is achieved. The menu is also closed when focus is lost.

This matches the expected behaviour, like in https://webaim.org/resources/htmlcheatsheet/ or https://webaim.org/techniques/keyboard/

In the video below, I use the Tab, Enter and Escape keys:

https://github.com/fonsp/Pluto.jl/assets/6933510/8627ac01-771c-4475-8299-39b64f5662c2

