### PR TITLE
Make the pkg popup tab-friendly

### DIFF
--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -868,6 +868,7 @@ patch: ${JSON.stringify(
                             }}
                             >Stay here</a
                         >`,
+                    should_focus: true,
                 })
             }
         }

--- a/frontend/components/PkgStatusMark.js
+++ b/frontend/components/PkgStatusMark.js
@@ -139,6 +139,7 @@ export const PkgStatusMark = ({ package_name, pluto_actions, notebook_id, nbpkg 
                         source_element: event.currentTarget.parentElement,
                         package_name: package_name,
                         is_disable_pkg: false,
+                        should_focus: true,
                     })
                 }}
             >
@@ -165,6 +166,7 @@ export const PkgActivateMark = ({ package_name }) => {
                         source_element: event.currentTarget.parentElement,
                         package_name: package_name,
                         is_disable_pkg: true,
+                        should_focus: true,
                     })
                 }}
             >

--- a/frontend/components/PkgTerminalView.js
+++ b/frontend/components/PkgTerminalView.js
@@ -13,7 +13,7 @@ const TerminalViewAnsiUp = ({ value }) => {
 
     return !!value
         ? html`<pkg-terminal
-              ><div class="scroller"><pre ref=${node_ref} class="pkg-terminal"></pre></div
+              ><div class="scroller" tabindex="0"><pre ref=${node_ref} class="pkg-terminal"></pre></div
           ></pkg-terminal>`
         : null
 }

--- a/frontend/components/SafePreviewUI.js
+++ b/frontend/components/SafePreviewUI.js
@@ -15,6 +15,7 @@ export const SafePreviewUI = ({ process_waiting_for_permission, risky_file_sourc
                                   open_pluto_popup({
                                       type: "info",
                                       big: true,
+                                      should_focus: true,
                                       body: html`
                                           <h1>Safe preview</h1>
                                           <p>You are reading and editing this file without running Julia code.</p>


### PR DESCRIPTION
This makes the pluto-popup tab-friendly.

Some "spontaneous" popups, like the message "another cell was disabled because it also defines xyz" or #2746 are unchanged: they should not interfere with keyboard focus.

But popups like the Pkg popup (clicking the checkmark next to `using Plots`) should behave like a non-modal dialog: when opened, the first interactive item should be focused, and when focus leaves the popup, the popup should close and focus should return to the button that opened it.

https://github.com/fonsp/Pluto.jl/assets/6933510/b8dd5f25-e156-4bca-99d6-3f13cc7e91b8

