### PR TITLE
Make global progress bar hidden from screen readers

### DIFF
--- a/frontend/components/ProgressBar.js
+++ b/frontend/components/ProgressBar.js
@@ -80,10 +80,7 @@ export const ProgressBar = ({ notebook, backend_launch_phase, status }) => {
                 }
             }
         }}
-        aria-valuenow=${100 * progress}
-        aria-valuemin="0"
-        aria-valuemax="100"
-        aria-valuetext=${title}
+        aria-hidden="true"
         title=${title}
     ></loading-bar>`
 }


### PR DESCRIPTION
This is about the progress bar at the top of the notebook UI.

It should either be live, or totally hidden. Let's make it hidden for now, since it's a "visual bonus".