### PR TITLE
◐ Spin Pkg terminal spinners with CSS for performance

### DIFF
--- a/frontend/components/PkgTerminalView.js
+++ b/frontend/components/PkgTerminalView.js
@@ -1,12 +1,14 @@
 import AnsiUp from "../imports/AnsiUp.js"
 import { html, Component, useState, useEffect, useRef, useLayoutEffect } from "../imports/Preact.js"
 
+const make_spinner_spin = (original_html) => original_html.replaceAll("◐", `<span class="make-me-spin">◐</span>`)
+
 const TerminalViewAnsiUp = ({ value }) => {
     const node_ref = useRef(/** @type {HTMLElement?} */ (null))
 
     useEffect(() => {
         if (!node_ref.current) return
-        node_ref.current.innerHTML = new AnsiUp().ansi_to_html(value)
+        node_ref.current.innerHTML = make_spinner_spin(new AnsiUp().ansi_to_html(value))
         const parent = node_ref.current.parentElement
         if (parent) parent.scrollTop = 1e5
     }, [node_ref.current, value])

--- a/frontend/components/PkgTerminalView.js
+++ b/frontend/components/PkgTerminalView.js
@@ -6,8 +6,11 @@ const make_spinner_spin = (original_html) => original_html.replaceAll("◐", `<s
 const TerminalViewAnsiUp = ({ value }) => {
     const node_ref = useRef(/** @type {HTMLElement?} */ (null))
 
+    const start_time = useRef(Date.now())
+
     useEffect(() => {
         if (!node_ref.current) return
+        node_ref.current.style.cssText = `--animation-delay: -${(Date.now() - start_time.current) % 1000}ms`
         node_ref.current.innerHTML = make_spinner_spin(new AnsiUp().ansi_to_html(value))
         const parent = node_ref.current.parentElement
         if (parent) parent.scrollTop = 1e5

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -2006,6 +2006,12 @@ pkg-terminal pre {
     margin: 0;
 }
 
+pkg-terminal .make-me-spin {
+    display: inline-block;
+    animation: identifier-spin 1s linear infinite;
+    transform-origin: 50% 59%;
+}
+
 pkg-popup pkg-terminal {
     display: none;
 }

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -2010,6 +2010,7 @@ pkg-terminal .make-me-spin {
     display: inline-block;
     animation: identifier-spin 1s linear infinite;
     transform-origin: 50% 59%;
+    animation-delay: var(--animation-delay);
 }
 
 pkg-popup pkg-terminal {

--- a/src/packages/IOListener.jl
+++ b/src/packages/IOListener.jl
@@ -47,3 +47,8 @@ function stoplistening(listener::IOListener)
         trigger(listener)
     end
 end
+
+freeze_loading_spinners(s::AbstractString) = _replaceall(s, '◑' => '◐', '◒' => '◐', '◓' => '◐')
+
+_replaceall(s, p) = replace(s, p)
+_replaceall(s, p, ps...) = @static VERSION >= v"1.7" ? replace(s, p, ps...) : _replaceall(replace(s, p), ps...)

--- a/src/packages/Packages.jl
+++ b/src/packages/Packages.jl
@@ -112,7 +112,7 @@ function sync_nbpkg_core(
         iolistener = let
             busy_packages = notebook.nbpkg_ctx_instantiated ? added : new_packages
             report_to = ["nbpkg_sync", busy_packages...]
-            IOListener(callback=(s -> on_terminal_output(report_to, s)))
+            IOListener(callback=(s -> on_terminal_output(report_to, freeze_loading_spinners(s))))
         end
         cleanup[] = () -> stoplistening(iolistener)
 
@@ -553,7 +553,7 @@ function update_nbpkg_core(
         iolistener = let
             # we don't know which packages will be updated, so we send terminal output to all installed packages
             report_to = ["nbpkg_update", old_packages...]
-            IOListener(callback=(s -> on_terminal_output(report_to, s)))
+            IOListener(callback=(s -> on_terminal_output(report_to, freeze_loading_spinners(s))))
         end
         cleanup[] = () -> stoplistening(iolistener)
         


### PR DESCRIPTION
#2500 introduced two performance issues:
1. High network pressure and latency #2739
2. The terminal outputs are stored in the state, and are included in every codemirror as a compartment value (because the terminal text is displayed in the Pkg popup). This was causing lots of expensive re-renders. According the the profile, most time was spent in the CM6 compartment/extension state management.

The solution in this PR is to replace all 4 progress characters with `◐` on the server side (before diffing). This fixes both issues because the updates are now much less frequent.

To still get a spinning animation, we search for the `◐` character, give it a class and make it spin with a CSS animation. The result is almost identical!

# Before
https://github.com/fonsp/Pluto.jl/assets/6933510/55d2052b-fd74-455d-be66-47065a714130


<img width="704" alt="Scherm­afbeelding 2024-01-22 om 11 07 29" src="https://github.com/fonsp/Pluto.jl/assets/6933510/5107b799-d0d9-4ece-9251-3baffd5494ad">


# After

https://github.com/fonsp/Pluto.jl/assets/6933510/c8ab4466-4c95-46f1-a5d2-3c9c769b9f3e


<img width="703" alt="Scherm­afbeelding 2024-01-22 om 11 04 15" src="https://github.com/fonsp/Pluto.jl/assets/6933510/2918080f-7882-4052-bcf1-e437625a7b74">


<details>
<summary>You can see that there are much fewer messages from the server:
</summary>


https://github.com/fonsp/Pluto.jl/assets/6933510/05df3724-833c-46c1-b4d5-0ed3038dd6dc


</details>




fix #2739