### PR TITLE
Fix horizontal overflow in tables on Firefox

### DIFF
--- a/frontend/components/TreeView.js
+++ b/frontend/components/TreeView.js
@@ -188,7 +188,7 @@ export const TableView = ({ mime, body, cell_id, persist_js_state }) => {
                           ${row === "more"
                               ? html`<td class="pluto-tree-more-td" colspan=${maxcolspan}>${more(1)}</td>`
                               : html`<th>${row[0]}</th>
-                                    ${row[1].map((x) => html`<td>${x === "more" ? null : mimepair_output(x)}</td>`)}`}
+                                    ${row[1].map((x) => html`<td><div>${x === "more" ? null : mimepair_output(x)}</div></td>`)}`}
                       </tr>`
               )
             : html`<${EmptyRows} colspan=${maxcolspan} />`}

--- a/frontend/treeview.css
+++ b/frontend/treeview.css
@@ -281,6 +281,18 @@ table.pluto-table td {
     overflow: auto;
 }
 
+@supports (-moz-appearance: none) {
+    table.pluto-table td {
+        max-width: unset;
+        overflow: visible;
+    }
+
+    table.pluto-table td > div {
+        max-width: 300px;
+        overflow: auto;
+    }
+}
+
 table.pluto-table .schema-types {
     color: var(--pluto-schema-types-color);
     font-family: var(--julia-mono-font-stack);


### PR DESCRIPTION
Fix https://github.com/fonsp/Pluto.jl/issues/2190#issuecomment-1925008098

The solution (from https://stackoverflow.com/questions/16328233/overflow-auto-does-not-work-in-firefox) made the scrollbar overlap with content on Chrome (because the `td` has padding, not the `div`), so I decided to apply the solution to firefox only.