### PR TITLE
🧾 Stack traces: code preview, URL, truncated, design

### DIFF
--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -936,7 +936,6 @@ const InputContextMenu = ({ on_delete, cell_id, run_cell, skip_as_script, runnin
 
     const prevously_focused_element_ref = useRef(/** @type {Element?} */ (null))
     const setOpen = (val) => {
-        console.error("setOpen", val)
         if (val) {
             prevously_focused_element_ref.current = document.activeElement
         }

--- a/frontend/components/ErrorMessage.js
+++ b/frontend/components/ErrorMessage.js
@@ -55,7 +55,7 @@ const Funccall = ({ frame }) => {
     }
 }
 
-const LinePreview = ({ frame }) => {
+const LinePreview = ({ frame, num_context_lines = 2 }) => {
     let pluto_actions = useContext(PlutoActionsContext)
     let cell_id = extract_cell_id(frame.file)
     if (cell_id) {
@@ -75,8 +75,12 @@ const LinePreview = ({ frame }) => {
                 ><div>
                     <pre>
 ${lines.map((line, i) =>
-                            frame.line - 3 <= i && i <= frame.line + 1
-                                ? html`<${JuliaHighlightedLine} code=${line} frameLine=${i === frame.line - 1 && lines.length > 1} />`
+                            frame.line - 1 - num_context_lines <= i && i <= frame.line - 1 + num_context_lines
+                                ? html`<${JuliaHighlightedLine}
+                                      code=${line}
+                                      i=${i}
+                                      frameLine=${i === frame.line - 1 && num_context_lines > 0 && lines.length > 1}
+                                  />`
                                 : null
                         )}</pre
                     >
@@ -86,7 +90,7 @@ ${lines.map((line, i) =>
     }
 }
 
-const JuliaHighlightedLine = ({ code, frameLine }) => {
+const JuliaHighlightedLine = ({ code, frameLine, i }) => {
     const code_ref = useRef(/** @type {HTMLPreElement?} */ (null))
     useLayoutEffect(() => {
         if (code_ref.current) {
@@ -97,6 +101,7 @@ const JuliaHighlightedLine = ({ code, frameLine }) => {
 
     return html`<code
         ref=${code_ref}
+        style=${`--before-content: "${i + 1}";`}
         class=${cl({
             "language-julia": true,
             "frame-line": frameLine,
@@ -319,7 +324,7 @@ export const ErrorMessage = ({ msg, stacktrace, cell_id }) => {
                                   <span>@</span>
                                   <${StackFrameFilename} frame=${frame} cell_id=${cell_id} />
                               </div>
-                              ${from_this_notebook ? html`<${LinePreview} frame=${frame} />` : null}
+                              ${from_this_notebook ? html`<${LinePreview} frame=${frame} num_context_lines=${from_this_cell ? 1 : 2} />` : null}
                           </li>`
                       })}
                       ${limited

--- a/frontend/components/ErrorMessage.js
+++ b/frontend/components/ErrorMessage.js
@@ -222,7 +222,6 @@ export const ErrorMessage = ({ msg, stacktrace, cell_id }) => {
 
     const matched_rewriter = rewriters.find(({ pattern }) => pattern.test(msg)) ?? default_rewriter
 
-    console.log(stacktrace)
     return html`<jlerror>
         <header>${matched_rewriter.display(msg)}</header>
         ${stacktrace.length == 0 || !(matched_rewriter.show_stacktrace?.() ?? true)

--- a/frontend/components/ErrorMessage.js
+++ b/frontend/components/ErrorMessage.js
@@ -9,6 +9,7 @@ const StackFrameFilename = ({ frame, cell_id }) => {
     if (sep_index != -1) {
         const frame_cell_id = frame.file.substr(sep_index + 4, 36)
         const a = html`<a
+            internal-file=${frame.file}
             href="#"
             onclick=${(e) => {
                 window.dispatchEvent(
@@ -58,24 +59,24 @@ export const ParseError = ({ cell_id, diagnostics }) => {
         <jlerror>
             <header><p>Syntax error</p></header>
             <section>
-              <ol>
-                  ${diagnostics.map(
-                    ({ message, from, to, line }) =>
-                        html`<li onmouseenter=${() => // NOTE: this could be moved move to `StackFrameFilename`
-                                window.dispatchEvent(new CustomEvent("cell_highlight_range", { detail: { cell_id, from, to }}))
-                        }
-                        onmouseleave=${() =>
-                                window.dispatchEvent(new CustomEvent("cell_highlight_range", { detail: { cell_id, from: null, to: null }}))
-                        }
-                      >
-                            ${message}<span>@</span>
-                            <${StackFrameFilename} frame=${{file: "#==#" + cell_id, line}} cell_id=${cell_id} />
-                        </li>`)
-                    }
-              </ol>
+                <ol>
+                    ${diagnostics.map(
+                        ({ message, from, to, line }) =>
+                            html`<li
+                                onmouseenter=${() =>
+                                    // NOTE: this could be moved move to `StackFrameFilename`
+                                    window.dispatchEvent(new CustomEvent("cell_highlight_range", { detail: { cell_id, from, to } }))}
+                                onmouseleave=${() =>
+                                    window.dispatchEvent(new CustomEvent("cell_highlight_range", { detail: { cell_id, from: null, to: null } }))}
+                            >
+                                ${message}<span>@</span>
+                                <${StackFrameFilename} frame=${{ file: "#==#" + cell_id, line }} cell_id=${cell_id} />
+                            </li>`
+                    )}
+                </ol>
             </section>
         </jlerror>
-    `;
+    `
 }
 
 export const ErrorMessage = ({ msg, stacktrace, cell_id }) => {
@@ -102,9 +103,9 @@ export const ErrorMessage = ({ msg, stacktrace, cell_id }) => {
                         <a
                             href="#"
                             onClick=${(e) => {
-                            e.preventDefault()
-                            pluto_actions.split_remote_cell(cell_id, boundaries, true)
-                        }}
+                                e.preventDefault()
+                                pluto_actions.split_remote_cell(cell_id, boundaries, true)
+                            }}
                             >Split this cell into ${boundaries.length} cells</a
                         >, or
                     </p>`
@@ -221,6 +222,7 @@ export const ErrorMessage = ({ msg, stacktrace, cell_id }) => {
 
     const matched_rewriter = rewriters.find(({ pattern }) => pattern.test(msg)) ?? default_rewriter
 
+    console.log(stacktrace)
     return html`<jlerror>
         <header>${matched_rewriter.display(msg)}</header>
         ${stacktrace.length == 0 || !(matched_rewriter.show_stacktrace?.() ?? true)
@@ -228,14 +230,13 @@ export const ErrorMessage = ({ msg, stacktrace, cell_id }) => {
             : html`<section>
                   <ol>
                       ${stacktrace.map(
-                (frame) =>
-                    html`<li>
+                          (frame) =>
+                              html`<li>
                                   <${Funccall} frame=${frame} />
                                   <span>@</span>
                                   <${StackFrameFilename} frame=${frame} cell_id=${cell_id} />
-                                  ${frame.inlined ? html`<span>[inlined]</span>` : null}
                               </li>`
-            )}
+                      )}
                   </ol>
               </section>`}
     </jlerror>`

--- a/frontend/components/Notebook.js
+++ b/frontend/components/Notebook.js
@@ -213,7 +213,7 @@ export const Notebook = ({
                     />`
                 )}
             ${cell_outputs_delayed && notebook.cell_order.length >= render_cell_outputs_minimum
-                ? html`<div style="font-family: system-ui; font-style: italic; text-align: center; padding: 5rem 1rem;">Loading...</div>`
+                ? html`<div style="font-family: system-ui; font-style: italic; text-align: center; padding: 5rem 1rem;">Loading more cells...</div>`
                 : null}
         </pluto-notebook>
     `

--- a/frontend/dark_color.css
+++ b/frontend/dark_color.css
@@ -183,6 +183,7 @@
         --cm-line-numbers-color: #8d86875e;
         --cm-selection-background: hsl(215deg 64% 59% / 48%);
         --cm-selection-background-blurred: hsl(215deg 0% 59% / 48%);
+        --cm-highlighted: #cbceb629;
 
         /* code highlighting */
         --cm-editor-text-color: #ffe9fc;
@@ -206,6 +207,7 @@
         --cm-matchingBracket-color: white;
         --cm-matchingBracket-bg-color: #c58c237a;
         --cm-placeholder-text-color: rgb(255 255 255 / 20%);
+        --cm-clickable-underline: #5d5f70;
 
         /*autocomplete menu*/
         --autocomplete-menu-bg-color: var(--input-context-menu-bg-color);

--- a/frontend/dark_color.css
+++ b/frontend/dark_color.css
@@ -138,7 +138,7 @@
         /* jlerror */
         --jlerror-header-color: #d9baba;
         --jlerror-mark-bg-color: rgb(0 0 0 / 18%);
-        --jlerror-a-bg-color: rgba(82, 58, 58, 0.5);
+        --jlerror-a-bg-color: rgba(82, 58, 58, 1);
         --jlerror-a-border-left-color: #704141;
         --jlerror-mark-color: #b1a9a9;
 

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -1328,7 +1328,7 @@ pluto-input .cm-editor .cm-line {
 
 pluto-input .cm-editor span.cm-highlighted-range,
 pluto-input .cm-editor .cm-line.cm-highlighted-line {
-    background-color: #bdbdbd68;
+    background-color: var(--cm-highlighted);
     border-radius: 3px;
 }
 
@@ -3280,7 +3280,7 @@ Based on "Paraíso (Light)" by Jan T. Sott:
 .cm-editor .cm-tooltip.cm-tooltip-autocomplete li.c_from_notebook .cm-completionLabel {
     font-weight: bold;
     text-decoration: underline;
-    text-decoration-color: #ced2ef;
+    text-decoration-color: var(--cm-clickable-underline);
     text-decoration-thickness: 3px;
     text-decoration-skip-ink: none;
 }

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -3399,7 +3399,15 @@ pluto-cell.code_differs .cm-editor .cm-gutters {
 }
 pluto-input:focus-within .cm-editor .cm-lineNumbers .cm-gutterElement::after {
     color: transparent;
-} */
+}
+ */
+
+pluto-cell.errored .cm-editor .cm-lineNumbers .cm-gutterElement {
+    color: var(--cm-line-numbers-color);
+}
+pluto-cell.errored .cm-editor .cm-lineNumbers .cm-gutterElement::after {
+    color: transparent;
+}
 /* Case 2: Print */
 @media print {
     .cm-editor .cm-lineNumbers .cm-gutterElement {

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -3285,13 +3285,6 @@ Based on "Paraíso (Light)" by Jan T. Sott:
     text-decoration-skip-ink: none;
 }
 
-@media (prefers-color-scheme: dark) {
-    [data-pluto-variable],
-    [data-pluto-variable]:hover {
-        text-decoration-color: #5d5f70;
-    }
-}
-
 body.disable_ui [data-pluto-variable],
 body.disable_ui [data-cell-variable] {
     cursor: pointer;

--- a/frontend/light_color.css
+++ b/frontend/light_color.css
@@ -186,6 +186,7 @@
         --cm-line-numbers-color: #8d86875e;
         --cm-selection-background: hsl(214deg 100% 73% / 48%);
         --cm-selection-background-blurred: hsl(214deg 0% 73% / 48%);
+        --cm-highlighted: #cbceb668;
 
         /* code highlighting */
         --cm-editor-text-color: #41323f;
@@ -209,6 +210,7 @@
         --cm-matchingBracket-color: black;
         --cm-matchingBracket-bg-color: #1b4bbb21;
         --cm-placeholder-text-color: rgba(0, 0, 0, 0.2);
+        --cm-clickable-underline: #ced2ef;
 
         /*autocomplete menu*/
         --autocomplete-menu-bg-color: white;

--- a/frontend/treeview.css
+++ b/frontend/treeview.css
@@ -253,23 +253,77 @@ jlerror > header > p {
 jlerror > header > p:first-child {
     font-weight: bold;
 }
-jlerror > section > ol > li > mark {
+jlerror .stacktrace-header {
+    font-family: var(--system-ui-font-stack);
+    font-size: 1.9rem;
+    font-weight: 700;
+}
+jlerror > section {
+    padding: 1em;
+    background-color: var(--code-section-bg-color);
+    border: 3px solid var(--pkg-terminal-border-color);
+    border-radius: 0.6em;
+    margin: 1em 0;
+}
+jlerror > section > ol {
+    line-height: 1.6;
+}
+jlerror > section > ol > li.from_this_notebook {
+    --bg: #e1efff;
+    background: var(--bg);
+    outline: 3px solid var(--bg);
+    padding: 0.4em 0.2em;
+    border-radius: 0.6em;
+}
+jlerror > section .classical-frame > mark {
     background: var(--jlerror-mark-bg-color);
     border-radius: 6px;
     color: var(--jlerror-mark-color);
     font-family: var(--julia-mono-font-stack);
     font-variant-ligatures: none;
 }
-jlerror > section > ol > li > em > a {
+jlerror > section .classical-frame > em > a {
     background: var(--jlerror-a-bg-color);
     border-radius: 4px;
     padding: 1px 7px;
     text-decoration: none;
     border-left: 3px solid var(--jlerror-a-border-left-color);
 }
-jlerror > section > ol > li > span {
+jlerror > section .classical-frame > span {
     opacity: 0.8;
     padding: 0px 1em;
+}
+
+jlerror li::marker {
+    background: red;
+    border: 3px solid red;
+    /* font-size: 0.7rem; */
+    font-weight: 900;
+    color: var(--pluto-logs-key-color);
+}
+
+jlerror li.from_this_notebook .classical-frame {
+    opacity: 0.4;
+}
+
+jlerror li a.frame-line-preview {
+    display: block;
+    text-decoration: none;
+    border: 3px solid var(--cm-clickable-underline);
+    --br: 0.6em;
+    border-radius: var(--br);
+}
+jlerror li .frame-line-preview pre:not(.asdfdsaf) {
+    background-color: var(--code-background);
+    padding: 0 1em;
+    border-radius: var(--br);
+}
+
+jlerror li .frame-line-preview pre > code.frame-line {
+    background: var(--cm-highlighted);
+}
+jlerror li .frame-line-preview pre > code:not(.frame-line) {
+    opacity: 0.7;
 }
 
 table.pluto-table {

--- a/frontend/treeview.css
+++ b/frontend/treeview.css
@@ -267,9 +267,12 @@ jlerror > section {
 }
 jlerror > section > ol {
     line-height: 1.6;
+    /* transform: perspective(29rem) rotateX(-12.7deg); */
+    /* transform-origin: top; */
+    /* perspective-origin: top; */
 }
 jlerror > section > ol > li.from_this_notebook {
-    --bg: #e1efff;
+    --bg: var(--jl-info-acccolor);
     background: var(--bg);
     outline: 3px solid var(--bg);
     padding: 0.4em 0.2em;
@@ -282,12 +285,15 @@ jlerror > section .classical-frame > mark {
     font-family: var(--julia-mono-font-stack);
     font-variant-ligatures: none;
 }
-jlerror > section .classical-frame > em > a {
+jlerror > section .classical-frame > em > a[href] {
     background: var(--jlerror-a-bg-color);
     border-radius: 4px;
     padding: 1px 7px;
     text-decoration: none;
     border-left: 3px solid var(--jlerror-a-border-left-color);
+}
+jlerror > section .classical-frame > em > a[href].remote-url {
+    filter: hue-rotate(160deg);
 }
 jlerror > section .classical-frame > span {
     opacity: 0.8;
@@ -303,7 +309,7 @@ jlerror li::marker {
 }
 
 jlerror li.from_this_notebook .classical-frame {
-    opacity: 0.4;
+    /* opacity: 0.4; */
 }
 
 jlerror li a.frame-line-preview {

--- a/frontend/treeview.css
+++ b/frontend/treeview.css
@@ -243,9 +243,19 @@ jlerror {
     font-size: 0.75rem;
     font-family: "Roboto Mono", monospace;
 }
+jlerror {
+    display: block;
+    padding: 1em;
+    background-color: var(--code-section-bg-color);
+    border: 3px solid var(--pkg-terminal-border-color);
+    border-radius: 0.6em;
+    margin: 1em 0;
+}
 
 jlerror > header {
     color: var(--jlerror-header-color);
+    border-left: 3px solid var(--jlerror-header-color);
+    padding: 0.7rem;
 }
 jlerror > header > p {
     margin-block-end: 0.2em;
@@ -255,15 +265,15 @@ jlerror > header > p:first-child {
 }
 jlerror .stacktrace-header {
     font-family: var(--system-ui-font-stack);
+}
+jlerror .stacktrace-header > secret-h1 {
     font-size: 1.9rem;
     font-weight: 700;
 }
 jlerror > section {
-    padding: 1em;
-    background-color: var(--code-section-bg-color);
-    border: 3px solid var(--pkg-terminal-border-color);
-    border-radius: 0.6em;
-    margin: 1em 0;
+    border-block-start: 3px dashed var(--pkg-terminal-border-color);
+    margin-block-start: 1rem;
+    padding-block-start: 1rem;
 }
 jlerror > section > ol {
     line-height: 1.6;
@@ -291,12 +301,16 @@ jlerror > section .classical-frame > em > a[href] {
     padding: 1px 7px;
     text-decoration: none;
     border-left: 3px solid var(--jlerror-a-border-left-color);
+    /* font-family: var(--system-ui-font-stack); */
 }
 jlerror > section .classical-frame > em > a[href].remote-url {
     filter: hue-rotate(160deg);
 }
+jlerror > section li.from_this_notebook:not(.from_this_cell) .classical-frame > em > a[href] {
+    filter: hue-rotate(50deg);
+}
 jlerror > section .classical-frame > span {
-    opacity: 0.8;
+    opacity: 0.4;
     padding: 0px 1em;
 }
 
@@ -318,14 +332,27 @@ jlerror li a.frame-line-preview {
     border: 3px solid var(--cm-clickable-underline);
     --br: 0.6em;
     border-radius: var(--br);
+    --crop: -0.5em;
 }
 jlerror li .frame-line-preview pre:not(.asdfdsaf) {
     background-color: var(--code-background);
-    padding: 0 1em;
+    padding: 0;
     border-radius: var(--br);
+    overflow: hidden;
+    position: relative;
 }
 
-jlerror li .frame-line-preview pre > code.frame-line {
+jlerror li:not(.from_this_cell) .frame-line-preview pre::after {
+    content: "cell preview";
+    display: block;
+    position: absolute;
+    bottom: 0;
+    right: 1ch;
+    font-weight: 900;
+    opacity: 0.6;
+}
+
+jlerror li .frame-line-preview pre > code:not(:only-child).frame-line {
     background: var(--cm-highlighted);
 }
 jlerror li .frame-line-preview pre > code:not(.frame-line) {
@@ -334,6 +361,17 @@ jlerror li .frame-line-preview pre > code:not(.frame-line) {
 jlerror li .frame-line-preview pre > code::before {
     content: var(--before-content);
     color: var(--cm-line-numbers-color);
+    margin-right: 0.7em;
+    width: 2ch;
+    display: inline-block;
+    text-align: right;
+}
+
+jlerror li .frame-line-preview pre > code:first-of-type:not(.frame-line) {
+    margin-top: var(--crop);
+}
+jlerror li .frame-line-preview pre > code:last-of-type:not(.frame-line) {
+    margin-bottom: var(--crop);
 }
 
 table.pluto-table {

--- a/frontend/treeview.css
+++ b/frontend/treeview.css
@@ -271,9 +271,6 @@ jlerror > section > ol > li > span {
     opacity: 0.8;
     padding: 0px 1em;
 }
-jlerror .frame-inlined {
-    opacity: 0.4;
-}
 
 table.pluto-table {
     table-layout: fixed;

--- a/frontend/treeview.css
+++ b/frontend/treeview.css
@@ -331,6 +331,10 @@ jlerror li .frame-line-preview pre > code.frame-line {
 jlerror li .frame-line-preview pre > code:not(.frame-line) {
     opacity: 0.7;
 }
+jlerror li .frame-line-preview pre > code::before {
+    content: var(--before-content);
+    color: var(--cm-line-numbers-color);
+}
 
 table.pluto-table {
     table-layout: fixed;

--- a/frontend/treeview.css
+++ b/frontend/treeview.css
@@ -271,6 +271,9 @@ jlerror > section > ol > li > span {
     opacity: 0.8;
     padding: 0px 1em;
 }
+jlerror .frame-inlined {
+    opacity: 0.4;
+}
 
 table.pluto-table {
     table-layout: fixed;

--- a/src/runner/PlutoRunner/src/PlutoRunner.jl
+++ b/src/runner/PlutoRunner/src/PlutoRunner.jl
@@ -1271,6 +1271,7 @@ function format_output(val::CapturedException; context=default_iocontext)
                 :path => String(s.file),
                 :line => s.line,
                 :url => frame_url(s),
+                :linfo_type => string(typeof(s.linfo)),
             )
         end
     else

--- a/src/runner/PlutoRunner/src/PlutoRunner.jl
+++ b/src/runner/PlutoRunner/src/PlutoRunner.jl
@@ -1228,6 +1228,16 @@ end
 
 frame_is_from_usercode(frame::Base.StackTraces.StackFrame) = occursin("#==#", String(frame.file))
 
+function frame_url(frame::Base.StackTraces.StackFrame)
+    if frame.linfo isa Core.MethodInstance
+        Base.url(frame.linfo.def)
+    elseif frame.linfo isa Method
+        Base.url(frame.linfo)
+    else
+        nothing
+    end
+end
+
 function format_output(val::CapturedException; context=default_iocontext)
     if has_julia_syntax && val.ex isa Base.Meta.ParseError && val.ex.detail isa Base.JuliaSyntax.ParseError
         dict = convert_parse_error_to_dict(val.ex.detail)
@@ -1260,6 +1270,7 @@ function format_output(val::CapturedException; context=default_iocontext)
                 :file => basename(String(s.file)),
                 :path => String(s.file),
                 :line => s.line,
+                :url => frame_url(s),
             )
         end
     else


### PR DESCRIPTION
<img width="723" alt="image" src="https://github.com/fonsp/Pluto.jl/assets/6933510/fa396024-a27a-4820-b447-211623f323db">


In the REPL:

<img width="748" alt="image" src="https://github.com/fonsp/Pluto.jl/assets/6933510/82a83e9d-050a-45d3-aab4-dcdc2c6ba6b4">


# New design
New design makes the stack trace look more inviting! It also adds more visual variety. There is also a title and some text to explain what it is.

# Code previews
The most relevant frames are (often) those from your own code. In this PR, you get a small preview of the code from your notebook that made the call. You can click to jump to the line.

This is implemented without CodeMirror, but just with a `<pre>` and highlight.js to keep things simple :)

# URLs
You can now click on file locations from Julia Base, and it will send you to the source code on github :) Adding this functionality for stdlibs and remote packages would be nice! Working on this with @adrhill

# Truncated stack trace
We search for the first frame that comes from this notebook, and all frames that came before it are hidden behind a *More...* button. This makes the stack trace less intimidating, and it is hopefully a good heuristic for "which frames are more useful?". It would be nice to add more heuristics. 

# Remove "top-level-scope"
Pretty technical, just removed the whole phrase, showing only the file:line.

# TODO
- [x] Dark mode tweaks
- [ ] More experimentation!
- [x] Make the error message stand out more, especially when it is a single line.

# More pictures

<img width="731" alt="image" src="https://github.com/fonsp/Pluto.jl/assets/6933510/450f7d76-5f21-4f48-a823-3bf8f1382edd">

<img width="720" alt="image" src="https://github.com/fonsp/Pluto.jl/assets/6933510/a3445102-ac50-4ed3-979a-d5869122f570">

<img width="721" alt="image" src="https://github.com/fonsp/Pluto.jl/assets/6933510/2a221898-9ec7-455f-bc4a-17018040c321">

