### PR TITLE
Render diagnostics only for actual syntax error

### DIFF
--- a/src/analysis/Parse.jl
+++ b/src/analysis/Parse.jl
@@ -107,7 +107,7 @@ function preprocess_expr(expr::Expr)
         Expr(:toplevel, expr)
     elseif expr.head === :(=) && (expr.args[1] isa Expr && expr.args[1].head == :curly)
         Expr(:const, expr)
-    elseif expr.head === :incomplete
+    elseif expr.head === :incomplete || expr.head === :error
         Expr(:call, :(PlutoRunner.throw_syntax_error), expr.args...)
     else
         expr

--- a/src/analysis/Parse.jl
+++ b/src/analysis/Parse.jl
@@ -99,6 +99,7 @@ Make some small adjustments to the `expr` to make it work nicely inside a timed,
 1. If `expr` is a `:toplevel` expression (this is the case iff the expression is a combination of expressions using semicolons, like `a = 1; b` or `123;`), then it gets turned into a `:block` expression. The reason for this transformation is that `:toplevel` does not return/relay the output of its last argument, unlike `begin`, `let`, `if`, etc. (But we want it!)
 2. If `expr` is a `:module` expression, wrap it in a `:toplevel` block - module creation needs to be at toplevel. Rule 1. is not applied.
 3. If `expr` is a `:(=)` expression with a curly assignment, wrap it in a `:const` to allow execution - see https://github.com/fonsp/Pluto.jl/issues/517
+4. If `expr` failed to parse, it has head in (:incomplete, :error) and is replaced with a call to PlutoRunner.throw_syntax_error which will render diagnostics in a frontend compatible manner (Pluto.jl#2526).
 """
 function preprocess_expr(expr::Expr)
     if expr.head === :toplevel

--- a/test/React.jl
+++ b/test/React.jl
@@ -1024,16 +1024,26 @@ import Pluto.Configuration: Options, EvaluationOptions
         notebook = Notebook(Cell.([
             "begin",
             "\n\nend",
+            "throw(Meta.parse(\"begin\"; raise=false).args[end])",
         ]))
         update_run!(🍭, notebook, notebook.cells)
         @test Pluto.is_just_text(notebook.topology, notebook.cells[1])
         @test Pluto.is_just_text(notebook.topology, notebook.cells[2])
         @static if VERSION >= v"1.10.0-DEV.1548" # ~JuliaSyntax PR Pluto.jl#2526 julia#46372
+            @test notebook.cells[1].errored
+            @test notebook.cells[2].errored
+            @test notebook.cells[3].errored
+
             @test haskey(notebook.cells[1].output.body, :source)
             @test haskey(notebook.cells[1].output.body, :diagnostics)
 
             @test haskey(notebook.cells[2].output.body, :source)
             @test haskey(notebook.cells[2].output.body, :diagnostics)
+
+            # not literal syntax error
+            @test haskey(notebook.cells[3].output.body, :msg)
+            @test !haskey(notebook.cells[3].output.body, :source)
+            @test !haskey(notebook.cells[3].output.body, :diagnostics)
         else
             @test !occursinerror("(incomplete ", notebook.cells[1])
             @test !occursinerror("(incomplete ", notebook.cells[2])


### PR DESCRIPTION
![image](https://github.com/fonsp/Pluto.jl/assets/9824244/1bd0e00a-b8a7-4bb0-aff1-8a6708290cdc)

Fixes #2819.

---
ps: i really like the new error display. 