### PR TITLE
fix: make sure mathjax will be bundled

### DIFF
--- a/frontend-bundler/package.json
+++ b/frontend-bundler/package.json
@@ -8,6 +8,7 @@
     "scripts": {
         "start": "cd ../frontend && parcel --dist-dir ../frontend-dist --config ../frontend-bundler/.parcelrc editor.html index.html error.jl.html",
         "build": "cd ../frontend && parcel build --no-source-maps --public-url . --dist-dir ../frontend-dist --config ../frontend-bundler/.parcelrc editor.html index.html error.jl.html && node ../frontend-bundler/add_sri.js ../frontend-dist/editor.html",
+        "clean": "rm -rf ../frontend/.parcel-cache/",
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "author": "",

--- a/frontend/common/SetupMathJax.js
+++ b/frontend/common/SetupMathJax.js
@@ -76,6 +76,7 @@ export const setup_mathjax = () => {
         () => {
             console.log("Loading mathjax!!")
             const src = new URL("https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/tex-svg-full.js", import.meta.url)
+            const integrity = "sha384-4kE/rQ11E8xT9QgrCBTyvenkuPfQo8rXYQvJZuMgxyPOoUfpatjQPlgdv6V5yhUK"
             const script = document.head.querySelector("#MathJax-script")
             if (!script) return
             script.addEventListener("load", () => {
@@ -85,6 +86,7 @@ export const setup_mathjax = () => {
                 }
             })
             script.setAttribute("crossorigin", "anonymous")
+            if (!import.meta.url.startsWith("file:///")) script.setAttribute("integrity", integrity)
             script.setAttribute("src", src.toString())
         },
         { timeout: 2000 }

--- a/frontend/common/SetupMathJax.js
+++ b/frontend/common/SetupMathJax.js
@@ -76,7 +76,6 @@ export const setup_mathjax = () => {
         () => {
             console.log("Loading mathjax!!")
             const src = new URL("https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/tex-svg-full.js", import.meta.url)
-            const integrity = "sha384-4kE/rQ11E8xT9QgrCBTyvenkuPfQo8rXYQvJZuMgxyPOoUfpatjQPlgdv6V5yhUK"
             const script = document.head.querySelector("#MathJax-script")
             if (!script) return
             script.addEventListener("load", () => {
@@ -86,7 +85,6 @@ export const setup_mathjax = () => {
                 }
             })
             script.setAttribute("crossorigin", "anonymous")
-            script.setAttribute("integrity", integrity)
             script.setAttribute("src", src.toString())
         },
         { timeout: 2000 }

--- a/frontend/common/SetupMathJax.js
+++ b/frontend/common/SetupMathJax.js
@@ -75,14 +75,19 @@ export const setup_mathjax = () => {
     requestIdleCallback(
         () => {
             console.log("Loading mathjax!!")
+            const src = new URL("https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/tex-svg-full.js", import.meta.url)
+            const integrity = "sha384-4kE/rQ11E8xT9QgrCBTyvenkuPfQo8rXYQvJZuMgxyPOoUfpatjQPlgdv6V5yhUK"
             const script = document.head.querySelector("#MathJax-script")
-            script?.addEventListener("load", () => {
+            if (!script) return
+            script.addEventListener("load", () => {
                 console.log("MathJax loaded!")
                 if (window["MathJax"]?.version !== "3.2.2") {
                     twowasloaded()
                 }
             })
-            script.setAttribute("src", script.getAttribute("not-the-src-yet"))
+            script.setAttribute("crossorigin", "anonymous")
+            script.setAttribute("integrity", integrity)
+            script.setAttribute("src", src.toString())
         },
         { timeout: 2000 }
     )

--- a/frontend/editor.html
+++ b/frontend/editor.html
@@ -43,8 +43,8 @@
     <script src="./editor.js" type="module" defer></script>
     <script src="./warn_old_browsers.js"></script>
 
-    <!-- This script will be enabled by JS after the notebook has initialized to prevent taking up bandwidth during the initial load. -->
-    <script type="text/javascript" id="MathJax-script" integrity="sha384-4kE/rQ11E8xT9QgrCBTyvenkuPfQo8rXYQvJZuMgxyPOoUfpatjQPlgdv6V5yhUK" crossorigin="anonymous" not-the-src-yet="https://cdn.jsdelivr.net/npm/mathjax@3.2.2/es5/tex-svg-full.js" async></script>
+    <!-- This script will be enabled by JS after the notebook has initialized to prevent taking up bandwidth during the initial load. Update the version there. -->
+    <script type="text/javascript" id="MathJax-script" async></script>
 </head>
 
 <body class="loading no-MαθJax">


### PR DESCRIPTION
The `not-the-src-yet` attribute was, of course, not being bundled. we use the `new URL()` trick of parcel to make sure this will load, keeping the same flow.