### PR TITLE
Add Compiler flag to specify --code-coverage

### DIFF
--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -188,6 +188,8 @@ const MATH_MODE_DEFAULT = nothing
 const STARTUP_FILE_DEFAULT = "no"
 const HISTORY_FILE_DEFAULT = "no"
 const HEAP_SIZE_HINT_DEFAULT = nothing
+const CODE_COVERAGE_MODE_DEFAULT = nothing
+const CODE_COVERAGE_FILE_DEFAULT = nothing
 
 function roughly_the_number_of_physical_cpu_cores()
     # https://gist.github.com/fonsp/738fe244719cae820245aa479e7b4a8d
@@ -256,6 +258,9 @@ These options will be passed as command line argument to newly launched processe
     check_bounds::Union{Nothing,String} = CHECK_BOUNDS_DEFAULT
     math_mode::Union{Nothing,String} = MATH_MODE_DEFAULT
     heap_size_hint::Union{Nothing,String} = HEAP_SIZE_HINT_DEFAULT
+
+    code_coverage_mode::Union{String, Nothing} = CODE_COVERAGE_MODE_DEFAULT
+    code_coverage_file::Union{String, Nothing} = CODE_COVERAGE_FILE_DEFAULT
 
     # notebook specified options
     # the followings are different from
@@ -326,6 +331,8 @@ function from_flat_kwargs(;
         startup_file::Union{Nothing,String} = STARTUP_FILE_DEFAULT,
         history_file::Union{Nothing,String} = HISTORY_FILE_DEFAULT,
         threads::Union{Nothing,String,Int} = default_number_of_threads(),
+        code_coverage_mode::Union{String, Nothing} = CODE_COVERAGE_MODE_DEFAULT,
+        code_coverage_file::Union{String, Nothing} = CODE_COVERAGE_FILE_DEFAULT,
     )
     server = ServerOptions(;
         root_url,
@@ -378,6 +385,8 @@ function from_flat_kwargs(;
         startup_file,
         history_file,
         threads,
+        code_coverage_mode,
+        code_coverage_file,
     )
     return Options(; server, security, evaluation, compiler)
 end
@@ -410,6 +419,7 @@ function _convert_to_flags(options::CompilerOptions)::Vector{String}
 
     for name in fieldnames(CompilerOptions)
         flagname = string("--", replace(String(name), "_" => "-"))
+        flagname = startwith(flagname, "--code-coverage") : "--code-coverage" : flagname
         value = getfield(options, name)
         if value !== nothing && flagname ∉ exclude_list
             push!(option_list, string(flagname, "=", value))

--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -188,7 +188,7 @@ const MATH_MODE_DEFAULT = nothing
 const STARTUP_FILE_DEFAULT = "no"
 const HISTORY_FILE_DEFAULT = "no"
 const HEAP_SIZE_HINT_DEFAULT = nothing
-const CODE_COVERAGE_MODE_DEFAULT = nothing
+const CODE_COVERAGE_TRACK_DEFAULT = nothing
 const CODE_COVERAGE_FILE_DEFAULT = nothing
 
 function roughly_the_number_of_physical_cpu_cores()
@@ -236,6 +236,8 @@ These options will be passed as command line argument to newly launched processe
 - `inline::Union{Nothing,String} = $INLINE_DEFAULT`
 - `check_bounds::Union{Nothing,String} = $CHECK_BOUNDS_DEFAULT`
 - `math_mode::Union{Nothing,String} = $MATH_MODE_DEFAULT`
+- `code_coverage_track::Union{Nothing,String} = "$CODE_COVERAGE_TRACK_DEFAULT"`. This specifies for which files code coverage is tracked. It corresponds to the `--code-coverage[={none*|user|all}]` or `--code-coverage=@<path>` command line option.
+- `code_coverage_file::Union{Nothing,String} = "$CODE_COVERAGE_FILE_DEFAULT"`. This specifies the file where code coverage is recorded if provided. It corresponds to the `--code-coverage=filename` command line option.
 - `heap_size_hint::Union{Nothing,String} = $HEAP_SIZE_HINT_DEFAULT`
 - `startup_file::Union{Nothing,String} = "$STARTUP_FILE_DEFAULT"` By default, the startup file isn't loaded in notebooks.
 - `history_file::Union{Nothing,String} = "$HISTORY_FILE_DEFAULT"` By default, the history isn't loaded in notebooks.
@@ -259,7 +261,7 @@ These options will be passed as command line argument to newly launched processe
     math_mode::Union{Nothing,String} = MATH_MODE_DEFAULT
     heap_size_hint::Union{Nothing,String} = HEAP_SIZE_HINT_DEFAULT
 
-    code_coverage_mode::Union{String, Nothing} = CODE_COVERAGE_MODE_DEFAULT
+    code_coverage_track::Union{String, Nothing} = CODE_COVERAGE_TRACK_DEFAULT
     code_coverage_file::Union{String, Nothing} = CODE_COVERAGE_FILE_DEFAULT
 
     # notebook specified options
@@ -331,7 +333,7 @@ function from_flat_kwargs(;
         startup_file::Union{Nothing,String} = STARTUP_FILE_DEFAULT,
         history_file::Union{Nothing,String} = HISTORY_FILE_DEFAULT,
         threads::Union{Nothing,String,Int} = default_number_of_threads(),
-        code_coverage_mode::Union{String, Nothing} = CODE_COVERAGE_MODE_DEFAULT,
+        code_coverage_track::Union{String, Nothing} = CODE_COVERAGE_TRACK_DEFAULT,
         code_coverage_file::Union{String, Nothing} = CODE_COVERAGE_FILE_DEFAULT,
     )
     server = ServerOptions(;
@@ -385,7 +387,7 @@ function from_flat_kwargs(;
         startup_file,
         history_file,
         threads,
-        code_coverage_mode,
+        code_coverage_track,
         code_coverage_file,
     )
     return Options(; server, security, evaluation, compiler)

--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -421,7 +421,7 @@ function _convert_to_flags(options::CompilerOptions)::Vector{String}
 
     for name in fieldnames(CompilerOptions)
         flagname = string("--", replace(String(name), "_" => "-"))
-        flagname = startwith(flagname, "--code-coverage") : "--code-coverage" : flagname
+        flagname = startswith(flagname, "--code-coverage") ? "--code-coverage" : flagname
         value = getfield(options, name)
         if value !== nothing && flagname ∉ exclude_list
             push!(option_list, string(flagname, "=", value))


### PR DESCRIPTION
This PR adds two compiler flags to specify how to track code coverage in the notebook session.

I created two distinct flags as the command line option `--code-coverage` can be provided 2 times:
- One for specifying a file where to store the coverage data.
  - By default, if coverage is tracked, a separate coverage file per source file is generated. Specifying a file explicitly saves everything in a single file.
- Another for specifying what to track, it can be `none`, `user`, `all` or `@<path>` for a specific path.

Fixes #2818 