### PR TITLE
Hide bottom row of pixels from export background when minimized

### DIFF
--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -540,7 +540,7 @@ dialog#export {
     height: 130px;
     background: var(--export-bg-color);
     color: var(--export-color);
-    transform: translateY(-100%);
+    transform: translateY(calc(-100% - 1px));
     /* overlay: none !important; */
     overflow: visible;
     margin: 0;


### PR DESCRIPTION
This PR fixes a subtle visual bug only noticeable with light browser themes on Google Chrome. The bottom row of pixels from the export background is visible even when collapsed.

**Main**:
![image](https://github.com/fonsp/Pluto.jl/assets/22894011/088f5e77-933d-4eed-94f3-50d748a41b28)

**This PR**:
![image](https://github.com/fonsp/Pluto.jl/assets/22894011/4fa4dcbe-f76f-4b84-ac5a-0705a157ddcc)

