### PR TITLE
PlutoRunner.jl use take!(::IOBuffer) instead of resize!

### DIFF
--- a/src/runner/PlutoRunner/src/PlutoRunner.jl
+++ b/src/runner/PlutoRunner/src/PlutoRunner.jl
@@ -1350,7 +1350,7 @@ end
 function show_richest_withreturned(context::IOContext, @nospecialize(args))
     buffer = IOBuffer(; sizehint=0)
     val = show_richest(IOContext(buffer, context), args)
-    return (resize!(buffer.data, buffer.size), val)
+    return (take!(buffer), val)
 end
 
 "Super important thing don't change."


### PR DESCRIPTION
Has the same allocations but using public API. Should fix a Julia 1.11 issue

<img width="577" alt="image" src="https://github.com/fonsp/Pluto.jl/assets/6933510/fcb0bb66-257b-4221-8d24-a7e21b37e846">
