### PR TITLE
feat: avoid adding packages that exist in the sysimage

### DIFF
--- a/src/packages/Packages.jl
+++ b/src/packages/Packages.jl
@@ -106,7 +106,7 @@ function sync_nbpkg_core(
         new_packages = String.(external_package_names(new_topology)) # search all cells for imports and usings
         
         removed = setdiff(old_packages, new_packages)
-        added = setdiff(new_packages, old_packages)
+        added = setdiff(new_packages, old_packages, PkgCompat.sysimage_module_names())  # Avoid adding the modules of the sysimage
         can_skip = isempty(removed) && isempty(added) && notebook.nbpkg_ctx_instantiated
 
         iolistener = let

--- a/src/packages/PkgCompat.jl
+++ b/src/packages/PkgCompat.jl
@@ -401,6 +401,14 @@ function project(ctx::PkgContext)
 	end
 end
 
+function sysimage_module_names()
+	@static if isdefined(Base, Symbol("_sysimage_modules"))
+		getproperty.(Base._sysimage_modules, :name)
+	else
+		String[]
+	end
+end
+
 # 🐸 "Public API", but using PkgContext
 "Find a package in the manifest. Return `nothing` if not found."
 _get_manifest_entry(ctx::PkgContext, package_name::AbstractString) = 


### PR DESCRIPTION
Experimental. When someone is using a sysimage, `using SysImageModule` triggers a `Pkg.add`. This avoids that. I'm still testing if this is exactly what I have in mind; we probably need to do a special treatment that is similar to stdlibs too.