### PR TITLE
Autocomplete improvements

### DIFF
--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -63,6 +63,7 @@ import { moveLineDown } from "../imports/CodemirrorPlutoSetup.js"
 
 export const ENABLE_CM_MIXED_PARSER = window.localStorage.getItem("ENABLE_CM_MIXED_PARSER") === "true"
 export const ENABLE_CM_SPELLCHECK = window.localStorage.getItem("ENABLE_CM_SPELLCHECK") === "true"
+export const ENABLE_CM_AUTOCOMPLETE_ON_TYPE = window.localStorage.getItem("ENABLE_CM_AUTOCOMPLETE_ON_TYPE") === "true"
 
 if (ENABLE_CM_MIXED_PARSER) {
     console.log(`YOU ENABLED THE CODEMIRROR MIXED LANGUAGE PARSER
@@ -82,6 +83,12 @@ window.PLUTO_TOGGLE_CM_MIXED_PARSER = (val = !ENABLE_CM_MIXED_PARSER) => {
 // @ts-ignore
 window.PLUTO_TOGGLE_CM_SPELLCHECK = (val = !ENABLE_CM_SPELLCHECK) => {
     window.localStorage.setItem("ENABLE_CM_SPELLCHECK", String(val))
+    window.location.reload()
+}
+
+// @ts-ignore
+window.PLUTO_TOGGLE_CM_AUTOCOMPLETE_ON_TYPE = (val = !ENABLE_CM_AUTOCOMPLETE_ON_TYPE) => {
+    window.localStorage.setItem("ENABLE_CM_AUTOCOMPLETE_ON_TYPE", String(val))
     window.location.reload()
 }
 

--- a/frontend/components/CellInput/pluto_autocomplete.js
+++ b/frontend/components/CellInput/pluto_autocomplete.js
@@ -262,7 +262,7 @@ const julia_code_completions_to_cm = (/** @type {PlutoRequestAutocomplete} */ re
         //      If we backspace however, to `Math.a`, `a` does no longer match! So it will re-query this function.
         // span: RegExp(`^${_.escapeRegExp(ctx.state.sliceDoc(start, stop))}[^\\s"'()\\[\\].{}]*`),
         options: [
-            ...results.map(([text, type_description, is_exported, is_from_notebook, completion_type], i) => {
+            ...results.map(([text, value_type, is_exported, is_from_notebook, completion_type], i) => {
                 // (quick) fix for identifiers that need to be escaped
                 // Ideally this is done with Meta.isoperator on the julia side
                 let text_to_apply =
@@ -276,7 +276,7 @@ const julia_code_completions_to_cm = (/** @type {PlutoRequestAutocomplete} */ re
                     type:
                         cl({
                             c_notexported: !is_exported,
-                            [`c_${type_description}`]: type_description != null,
+                            [`c_${value_type}`]: value_type != null,
                             [`completion_${completion_type}`]: completion_type != null,
                             c_from_notebook: is_from_notebook,
                         }) ?? undefined,
@@ -290,13 +290,13 @@ const julia_code_completions_to_cm = (/** @type {PlutoRequestAutocomplete} */ re
             //      `Meta.isoperator` thing mentioned above
             ...results
                 .filter(([text]) => is_field_expression && override_text_to_apply_in_field_expression(text) != null)
-                .map(([text, type_description, is_exported], i) => {
+                .map(([text, value_type, is_exported], i) => {
                     let text_to_apply = override_text_to_apply_in_field_expression(text) ?? ""
 
                     return {
                         label: text_to_apply,
                         apply: text_to_apply,
-                        type: (is_exported ? "" : "c_notexported ") + (type_description == null ? "" : "c_" + type_description),
+                        type: (is_exported ? "" : "c_notexported ") + (value_type == null ? "" : "c_" + value_type),
                         boost: -99 - i / results.length, // Display below all normal results
                         // Non-standard
                         is_not_exported: !is_exported,
@@ -404,8 +404,6 @@ export let pluto_autocomplete = ({ request_autocomplete, on_update_doc_query }) 
             activateOnTyping: false,
             override: [
                 pluto_completion_fetcher(memoize_last_request_autocomplete),
-                // julia_special_completions_to_cm(memoize_last_request_autocomplete),
-                // julia_code_completions_to_cm(memoize_last_request_autocomplete),
                 complete_anyword,
                 // TODO: Disabled because of performance problems, see https://github.com/fonsp/Pluto.jl/pull/1925. Remove `complete_anyword` once fixed. See https://github.com/fonsp/Pluto.jl/pull/2013
                 // local_variables_completion,

--- a/frontend/components/CellInput/pluto_autocomplete.js
+++ b/frontend/components/CellInput/pluto_autocomplete.js
@@ -1,7 +1,5 @@
 import _ from "../../imports/lodash.js"
 
-import { utf8index_to_ut16index } from "../../common/UnicodeTools.js"
-
 import {
     EditorState,
     EditorSelection,

--- a/frontend/components/CellInput/pluto_autocomplete.js
+++ b/frontend/components/CellInput/pluto_autocomplete.js
@@ -167,11 +167,11 @@ let update_docs_from_autocomplete_selection = (on_update_doc_query) => {
 }
 
 /** Are we matching something like `\lambd...`? */
-let match_latex_complete = (ctx) => ctx.matchBefore(/\\[^\s"'.`]*/)
+let match_latex_complete = (/** @type {autocomplete.CompletionContext} */ ctx) => ctx.matchBefore(/\\[^\s"'.`]*/)
 /** Are we matching something like `:writing_a_symbo...`? */
-let match_symbol_complete = (ctx) => ctx.matchBefore(/\.\:[^\s"'`()\[\].]*/)
+let match_symbol_complete = (/** @type {autocomplete.CompletionContext} */ ctx) => ctx.matchBefore(/\.\:[^\s"'`()\[\].]*/)
 /** Are we matching exactly `~/`? */
-let match_expanduser_complete = (ctx) => ctx.matchBefore(/~\//)
+let match_expanduser_complete = (/** @type {autocomplete.CompletionContext} */ ctx) => ctx.matchBefore(/~\//)
 /** Are we matching inside a string */
 function match_string_complete(ctx) {
     const tree = syntaxTree(ctx.state)
@@ -318,7 +318,7 @@ const pluto_completion_fetcher = (request_autocomplete) => {
     const unicode_completions = julia_special_completions_to_cm(request_autocomplete)
     const code_completions = julia_code_completions_to_cm(request_autocomplete)
 
-    return (ctx) => {
+    return (/** @type {autocomplete.CompletionContext} */ ctx) => {
         if (ctx.tokenBefore(["Number"]) != null) return null
         let unicode_match = match_latex_complete(ctx) || match_expanduser_complete(ctx)
         if (unicode_match === null) {
@@ -329,7 +329,7 @@ const pluto_completion_fetcher = (request_autocomplete) => {
     }
 }
 
-const complete_anyword = async (ctx) => {
+const complete_anyword = async (/** @type {autocomplete.CompletionContext} */ ctx) => {
     const results_from_cm = await autocomplete.completeAnyWord(ctx)
     if (results_from_cm === null) return null
 

--- a/frontend/components/CellInput/pluto_autocomplete.js
+++ b/frontend/components/CellInput/pluto_autocomplete.js
@@ -265,7 +265,8 @@ const julia_code_completions_to_cm = (/** @type {PlutoRequestAutocomplete} */ re
             ...results.map(([text, type_description, is_exported, is_from_notebook, completion_type], i) => {
                 // (quick) fix for identifiers that need to be escaped
                 // Ideally this is done with Meta.isoperator on the julia side
-                let text_to_apply = is_field_expression ? override_text_to_apply_in_field_expression(text) ?? text : text
+                let text_to_apply =
+                    completion_type === "method" ? to_complete : is_field_expression ? override_text_to_apply_in_field_expression(text) ?? text : text
 
                 if (definitions.has(text)) proposed.add(text)
 

--- a/frontend/components/CellInput/pluto_autocomplete.js
+++ b/frontend/components/CellInput/pluto_autocomplete.js
@@ -17,6 +17,7 @@ import { get_selected_doc_from_state } from "./LiveDocsFromCursor.js"
 import { cl } from "../../common/ClassTable.js"
 import { ScopeStateField } from "./scopestate_statefield.js"
 import { open_bottom_right_panel } from "../BottomRightPanel.js"
+import { ENABLE_CM_AUTOCOMPLETE_ON_TYPE } from "../CellInput.js"
 
 let { autocompletion, completionKeymap, completionStatus, acceptCompletion } = autocomplete
 
@@ -405,7 +406,7 @@ export let pluto_autocomplete = ({ request_autocomplete, on_update_doc_query }) 
     return [
         tabCompletionState,
         autocompletion({
-            activateOnTyping: false,
+            activateOnTyping: ENABLE_CM_AUTOCOMPLETE_ON_TYPE,
             override: [
                 pluto_completion_fetcher(memoize_last_request_autocomplete),
                 complete_anyword,

--- a/frontend/components/CellInput/pluto_autocomplete.js
+++ b/frontend/components/CellInput/pluto_autocomplete.js
@@ -83,11 +83,15 @@ const tab_completion_command = (cm) => {
     }
 
     let selection = cm.state.selection.main
-    let last_char = cm.state.sliceDoc(selection.from - 1, selection.from)
-
     if (!selection.empty) return false
+
+    let last_char = cm.state.sliceDoc(selection.from - 1, selection.from)
+    let last_line = cm.state.sliceDoc(cm.state.doc.lineAt(selection.from).from, selection.from)
+
     // Some exceptions for when to trigger tab autocomplete
-    if (/^(\t| |\n|\=|\)|)$/.test(last_char)) return false
+    if ("\t \n=".includes(last_char)) return false
+    // ?([1,2], 3)<TAB> should trigger autocomplete
+    if (last_char === ")" && !last_line.includes("?")) return false
 
     cm.dispatch({
         effects: TabCompletionEffect.of(10),

--- a/frontend/components/CellInput/pluto_autocomplete.js
+++ b/frontend/components/CellInput/pluto_autocomplete.js
@@ -313,6 +313,7 @@ const pluto_completion_fetcher = (request_autocomplete) => {
     const code_completions = julia_code_completions_to_cm(request_autocomplete)
 
     return (ctx) => {
+        if (ctx.tokenBefore(["Number"]) != null) return null
         let unicode_match = match_latex_complete(ctx) || match_expanduser_complete(ctx)
         if (unicode_match === null) {
             return code_completions(ctx)
@@ -325,6 +326,9 @@ const pluto_completion_fetcher = (request_autocomplete) => {
 const complete_anyword = async (ctx) => {
     const results_from_cm = await autocomplete.completeAnyWord(ctx)
     if (results_from_cm === null) return null
+
+    const last_token = ctx.tokenBefore(["Identifier", "Number"])
+    if (last_token == null || last_token.type?.name === "Number") return null
 
     return {
         from: results_from_cm.from,

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -3469,6 +3469,10 @@ pluto-cell.errored .cm-editor .cm-lineNumbers .cm-gutterElement::after {
     color: var(--cm-string-color);
 }
 
+.cm-completionIcon-completion_keyword::before {
+    color: var(--cm-keyword-color);
+}
+
 .cm-completionIcon-c_Any::before,
 pluto-output > assignee,
 pluto-popup code.auto_disabled_variable {


### PR DESCRIPTION
I would like to enable autocomplete on type (without having to press `<TAB>`), but it needs to be in a better shape before we do that :)

This PR makes some improvements and adds a setting to preview always on autocomplete 

# In this PR
- new browser setting `PLUTO_TOGGLE_CM_AUTOCOMPLETE_ON_TYPE(true)` to enable always on autocomplete
- don't autocomplete numbers
- enable `complete_anyword` for `Identifier`s only
- when autocompleting `sqrt(`, show a list of methods but ignore selecting one
- cleanup backend code
- the `validFor` setting
- autocomplete global variables instantly
- more option colors

# Using `validFor`
Codemirror gives the option `validFor`, which lets you say "i found the completions for the currently typed text, and if you type one of these characters, you can just filter the results instead of asking me again". I implemented this, and now it's more snappy!

### Before

https://github.com/fonsp/Pluto.jl/assets/6933510/4c39ae99-3ac5-4d80-9fbb-9be5eed5f35d



### After

https://github.com/fonsp/Pluto.jl/assets/6933510/d6dbb238-e2b2-4461-a51a-f2d68ef81f39

