### PR TITLE
⚡️ Autocomplete latex and emoji super fast

### DIFF
--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -751,6 +751,7 @@ export const CellInput = ({
                                 results: message.results,
                             }
                         },
+                        request_special_symbols: () => pluto_actions.send("complete_symbols").then(({ message }) => message),
                         on_update_doc_query: on_update_doc_query,
                     }),
 

--- a/frontend/components/CellInput/pluto_autocomplete.js
+++ b/frontend/components/CellInput/pluto_autocomplete.js
@@ -424,13 +424,12 @@ const special_symbols_completion = (/** @type {() => Promise<SpecialSymbols?>} *
 
             if (data != null) {
                 const { latex, emoji } = data
-                console.log({ latex })
-                found = [false, true].map((apply_unicode_completion) =>
-                    [false, true].flatMap((is_emoji) =>
+                found = [true, false].map((is_inside_string) =>
+                    [true, false].flatMap((is_emoji) =>
                         Object.entries(is_emoji ? emoji : latex).map(([label, value]) => {
                             return {
                                 label,
-                                apply: value != null && apply_unicode_completion ? value : label,
+                                apply: value != null && (!is_inside_string || is_emoji) ? value : label,
                                 detail: value ?? undefined,
                             }
                         })
@@ -438,7 +437,6 @@ const special_symbols_completion = (/** @type {() => Promise<SpecialSymbols?>} *
                 )
             }
         }
-        console.log({ found })
         return found
     }
 
@@ -447,9 +445,9 @@ const special_symbols_completion = (/** @type {() => Promise<SpecialSymbols?>} *
 
         const result = await get_special_symbols()
 
-        let should_apply_unicode_completion = !match_string_complete(ctx)
+        let is_inside_string = !match_string_complete(ctx)
 
-        return await autocomplete.completeFromList(should_apply_unicode_completion ? result[1] : result[0])(ctx)
+        return await autocomplete.completeFromList(is_inside_string ? result[0] : result[1])(ctx)
     }
 }
 

--- a/frontend/components/CellInput/pluto_autocomplete.js
+++ b/frontend/components/CellInput/pluto_autocomplete.js
@@ -409,6 +409,8 @@ const local_variables_completion = (/** @type {autocomplete.CompletionContext} *
             })),
     }
 }
+const special_latex_examples = ["\\sqrt", "\\pi", "\\approx"]
+const special_emoji_examples = ["🐶", "🐱", "🐭", "🐰", "🐼", "🐨", "🐸", "🐔", "🐧"]
 
 const special_symbols_completion = (/** @type {() => Promise<SpecialSymbols?>} */ request_special_symbols) => {
     let found = null
@@ -429,6 +431,7 @@ const special_symbols_completion = (/** @type {() => Promise<SpecialSymbols?>} *
                                 label,
                                 apply: value != null && (!is_inside_string || is_emoji) ? value : label,
                                 detail: value ?? undefined,
+                                boost: label === "\\in" ? 3 : special_latex_examples.includes(label) ? 2 : special_emoji_examples.includes(value) ? 1 : 0,
                             }
                         })
                     )

--- a/frontend/components/CellInput/pluto_autocomplete.js
+++ b/frontend/components/CellInput/pluto_autocomplete.js
@@ -509,6 +509,7 @@ export let pluto_autocomplete = ({ request_autocomplete, request_special_symbols
             override: [
                 // writing_variable_name,
                 global_variables_completion,
+                special_symbols_completion(request_special_symbols),
                 pluto_completion_fetcher(memoize_last_request_autocomplete),
                 complete_anyword,
                 // TODO: Disabled because of performance problems, see https://github.com/fonsp/Pluto.jl/pull/1925. Remove `complete_anyword` once fixed. See https://github.com/fonsp/Pluto.jl/pull/2013

--- a/src/webserver/REPLTools.jl
+++ b/src/webserver/REPLTools.jl
@@ -109,6 +109,16 @@ responses[:complete] = function response_complete(🙋::ClientRequest)
     putclientupdates!(🙋.session, 🙋.initiator, msg)
 end
 
+responses[:complete_symbols] = function response_complete_symbols(🙋::ClientRequest)
+    msg = UpdateMessage(:completion_result, 
+        Dict(
+            :latex => REPL.REPLCompletions.latex_symbols,
+            :emoji => REPL.REPLCompletions.emoji_symbols,
+        ), 🙋.notebook, nothing, 🙋.initiator)
+
+    putclientupdates!(🙋.session, 🙋.initiator, msg)
+end
+
 responses[:docs] = function response_docs(🙋::ClientRequest)
     require_notebook(🙋)
     query = 🙋.body["query"]


### PR DESCRIPTION
This PR loads all latex and emoji symbols once, and then completes them locally with JavaScript: https://codemirror.net/docs/ref/#autocomplete.completeFromList

This makes the symbol completions instant, because there is no network overhead.

The initial download of symbols is only 60 kB, it's triggered the first time autocomplete is used.

# Before
With "Slow 3G" network throttling:

https://github.com/fonsp/Pluto.jl/assets/6933510/892afdc1-d501-4330-a582-566539f69467

With "Fast 3G" network throttling:

https://github.com/fonsp/Pluto.jl/assets/6933510/621ba875-3a35-4419-9e1e-56cdfd247df3


# After

https://github.com/fonsp/Pluto.jl/assets/6933510/4c32b60e-4fb8-42df-b53c-5758c2d9689a

