### PR TITLE
Faster page load: delay rendering codemirror until in view

### DIFF
--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -1117,7 +1117,7 @@ const StaticCodeMirrorFaker = ({ value }) => {
     const lines = value.split("\n").map((line, i) => html`<div class="awesome-wrapping-plugin-the-line cm-line" style="--indented: 0px;">${line}</div>`)
 
     return html`
-        <div class="cm-editor ͼ1 ͼ2 ͼ4 ͼ4z">
+        <div class="cm-editor ͼ1 ͼ2 ͼ4 ͼ4z cm-ssr-fake">
             <div tabindex="-1" class="cm-scroller">
                 <div class="cm-gutters" aria-hidden="true">
                     <div class="cm-gutter cm-lineNumbers"></div>

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -430,15 +430,26 @@ export const CellInput = ({
         if (!show_static_fake) return
         let node = dom_node_ref.current
         if (node == null) return
-        let observer = new IntersectionObserver((e) => {
+        let observer
+
+        const show = () => {
+            set_show_static_fake(false)
+            observer.disconnect()
+            window.removeEventListener("beforeprint", show)
+        }
+
+        observer = new IntersectionObserver((e) => {
             if (e.some((e) => e.isIntersecting)) {
-                set_show_static_fake(false)
-                observer.disconnect()
+                show()
             }
         })
 
         observer.observe(node)
-        return () => observer.disconnect()
+        window.addEventListener("beforeprint", show)
+        return () => {
+            observer.disconnect()
+            window.removeEventListener("beforeprint", show)
+        }
     }, [])
 
     useLayoutEffect(() => {

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -367,6 +367,7 @@ export const CellInput = ({
     cm_forced_focus,
     set_cm_forced_focus,
     show_input,
+    skip_static_fake = false,
     on_submit,
     on_delete,
     on_add_after,
@@ -421,13 +422,9 @@ export const CellInput = ({
         }, [on_change])
     )
 
-    const [show_static_fake, set_show_static_fake] = useState(true)
+    const [show_static_fake_state, set_show_static_fake] = useState(!skip_static_fake)
 
-    // useEffect(() => {
-    //     setTimeout(() => {
-    //         set_show_static_fake(false)
-    //     }, Math.random() * 6000)
-    // }, [])
+    const show_static_fake = cm_forced_focus != null || skip_static_fake ? false : show_static_fake_state
 
     useLayoutEffect(() => {
         if (!show_static_fake) return
@@ -948,7 +945,7 @@ export const CellInput = ({
 
     return html`
         <pluto-input ref=${dom_node_ref} class="CodeMirror" translate=${false}>
-            ${show_static_fake ? html`<${StaticCodeMirrorFaker} value=${remote_code} />` : null}
+            ${show_static_fake ? (show_input ? html`<${StaticCodeMirrorFaker} value=${remote_code} />` : null) : null}
             <${InputContextMenu}
                 on_delete=${on_delete}
                 cell_id=${cell_id}

--- a/test/frontend/helpers/pluto.js
+++ b/test/frontend/helpers/pluto.js
@@ -256,6 +256,7 @@ export const runAllChanged = async (page) => {
  * @param {string} text
  */
 export const writeSingleLineInPlutoInput = async (page, plutoInputSelector, text) => {
+    await page.waitForSelector(`${plutoInputSelector} .cm-editor:not(.cm-ssr-fake)`)
     await page.type(`${plutoInputSelector} .cm-content`, text)
     // Wait for CodeMirror to process the input and display the text
     return await page.waitForFunction(
@@ -294,7 +295,7 @@ export const keyboardPressInPlutoInput = async (page, plutoInputSelector, key) =
  * @param {string} plutoInputSelector
  */
 export const clearPlutoInput = async (page, plutoInputSelector) => {
-    await page.waitForSelector(`${plutoInputSelector} .cm-editor`)
+    await page.waitForSelector(`${plutoInputSelector} .cm-editor:not(.cm-ssr-fake)`)
     if ((await page.$(`${plutoInputSelector} .cm-placeholder`)) == null) {
         await page.focus(`${plutoInputSelector} .cm-content`)
         await page.waitForTimeout(500)
@@ -318,7 +319,7 @@ export const manuallyEnterCells = async (page, cells) => {
     for (const cell of cells) {
         const plutoCellId = lastElement(await getCellIds(page))
         plutoCellIds.push(plutoCellId)
-        await page.waitForSelector(`pluto-cell[id="${plutoCellId}"] pluto-input .cm-content`)
+        await page.waitForSelector(`pluto-cell[id="${plutoCellId}"] pluto-input .cm-editor:not(.cm-ssr-fake) .cm-content`)
         await writeSingleLineInPlutoInput(page, `pluto-cell[id="${plutoCellId}"] pluto-input`, cell)
 
         await page.click(`pluto-cell[id="${plutoCellId}"] .add_cell.after`)


### PR DESCRIPTION
Render the code as plaintext (with some fake codemirror classes) until the input is scrolled into view, instead of creating the codemirror on page load.

This makes the page load faster (LCP from 720ms to 560ms) and the page becomes interactive faster (busy CPU time from 2070ms to 1020ms). 

The number of elements in the page goes down (from 8409 to 5206, or 4506 when also skipping folded cells).

This also makes SSR easier if we ever want to do that in the future.

# Before
<img width="746" alt="Scherm­afbeelding 2024-04-08 om 12 10 28" src="https://github.com/fonsp/Pluto.jl/assets/6933510/72ae839b-856b-46d1-acf2-da3e29fd8d6d">

# After
<img width="740" alt="Scherm­afbeelding 2024-04-08 om 12 10 44" src="https://github.com/fonsp/Pluto.jl/assets/6933510/5e05a7d9-7375-4aca-9015-5d778c6ed676">


# TODO
- [x] detect print
- [ ] skip optimization for the first 5 cells
- [ ] start loading in background when idle
- [x] Cross-navigating cells with arrow keys should still work
- [x] Investigate skipping render for folded cells
- [x] frontend tests