### PR TITLE
Use <link rel=prefetch> for the statefile

### DIFF
--- a/src/notebook/Export.jl
+++ b/src/notebook/Export.jl
@@ -76,9 +76,9 @@ inserted_html(original_contents::AbstractString;
     """
 )
 
-function prefetch_html(statefile_js::AbstractString)
+function preload_statefile_html(statefile_js::AbstractString)
     if length(statefile_js) < 300 && startswith(statefile_js, '"') && endswith(statefile_js, '"') && !startswith(statefile_js, "\"data:")
-        """\n<link rel="prefetch" href=$(statefile_js)>\n"""
+        """\n<link rel="preload" href=$(statefile_js)>\n"""
     else
         ""
     end
@@ -110,7 +110,7 @@ function generate_html(;
     length(statefile_js) > 32000000 && @error "Statefile embedded in HTML is very large. The file can be opened with Chrome and Safari, but probably not with Firefox. If you are using PlutoSliderServer to generate this file, then we recommend the setting `baked_statefile=false`. If you are not using PlutoSliderServer, then consider reducing the size of figures and output in the notebook." length(statefile_js)
     
     parameters = """
-    $(prefetch_html(statefile_js))
+    $(preload_statefile_html(statefile_js))
     <script data-pluto-file="launch-parameters">
     window.pluto_notebook_id = $(notebook_id_js);
     window.pluto_isolated_cell_ids = $(isolated_cell_ids_js);

--- a/src/notebook/Export.jl
+++ b/src/notebook/Export.jl
@@ -76,6 +76,14 @@ inserted_html(original_contents::AbstractString;
     """
 )
 
+function prefetch_html(statefile_js::AbstractString)
+    if length(statefile_js) < 300 && startswith(statefile_js, '"') && endswith(statefile_js, '"') && !startswith(statefile_js, "\"data:")
+        """\n<link rel="prefetch" href=$(statefile_js)>\n"""
+    else
+        ""
+    end
+end
+
 """
 See [PlutoSliderServer.jl](https://github.com/JuliaPluto/PlutoSliderServer.jl) if you are interested in exporting notebooks programatically.
 """
@@ -102,6 +110,7 @@ function generate_html(;
     length(statefile_js) > 32000000 && @error "Statefile embedded in HTML is very large. The file can be opened with Chrome and Safari, but probably not with Firefox. If you are using PlutoSliderServer to generate this file, then we recommend the setting `baked_statefile=false`. If you are not using PlutoSliderServer, then consider reducing the size of figures and output in the notebook." length(statefile_js)
     
     parameters = """
+    $(prefetch_html(statefile_js))
     <script data-pluto-file="launch-parameters">
     window.pluto_notebook_id = $(notebook_id_js);
     window.pluto_isolated_cell_ids = $(isolated_cell_ids_js);

--- a/test/Notebook.jl
+++ b/test/Notebook.jl
@@ -574,12 +574,15 @@ end
         @test_notebook_inputs_equal(nb, result, false)
 
         
-        filename = "howdy.jl"
-
+        filename = "\"howdy.jl\""
         export_html = Pluto.generate_html(nb; notebookfile_js=filename)
         @test occursin(filename, export_html)
         @test_throws ArgumentError Pluto.embedded_notebookfile(export_html)
         
+        filename = "\"some where/thing.plutostate\""
+        export_html = Pluto.generate_html(nb; statefile_js=filename)
+        @test occursin("""pluto_statefile = "some where/""", export_html)
+        @test occursin("""<link rel="preload" href="some where/""", export_html)
         
         export_html = Pluto.generate_index_html()
         @test occursin("</html>", export_html)


### PR DESCRIPTION
When viewing a static notebook online (like https://featured.plutojl.org/language/structure%20and%20language ), the statefile is downloaded **by the editor** and displayed. But this can be optimized! We can download the statefile in parallel to the editor!

# Before
![image](https://github.com/fonsp/Pluto.jl/assets/6933510/6055fc7e-b0c5-4084-b550-f9265e28d523)

You can see the waterfall effect:  the request for the statefile happens after the editor has loaded.

# Doubts
This article https://web.dev/learn/performance/resource-hints makes me a bit doubtful, it looks like you can easily make the browser download the resource twice... 

I am also not able to debug this very well, I can't find the prefetch/preload in the browser dev tools. Maybe just merge and see if featured.plutojl.org is faster?

Maybe the type of prefetch should be a setting in PlutoSliderServer?