### PR TITLE
Show progress bar earlier during load

### DIFF
--- a/frontend/editor.html
+++ b/frontend/editor.html
@@ -49,7 +49,9 @@
 
 <body class="loading no-MαθJax">
     <div style="display: flex; min-height: 100vh;">
-        <pluto-editor class="fullscreen"></pluto-editor>
+        <pluto-editor class="fullscreen">
+            <progress style="filter: grayscale(1)" class="statefile-fetch-progress delete-me-when-live" max="100"></progress>
+        </pluto-editor>
     </div>
 </body>
 

--- a/frontend/editor.js
+++ b/frontend/editor.js
@@ -185,6 +185,7 @@ class PlutoEditorComponent extends HTMLElement {
         const new_launch_params = Object.fromEntries(Object.entries(launch_params).map(([k, v]) => [k, from_attribute(this, k) ?? v]))
         console.log("Launch parameters: ", new_launch_params)
 
+        document.querySelector(".delete-me-when-live")?.remove()
         render(html`<${EditorLoader} launch_params=${new_launch_params} />`, this)
     }
 }


### PR DESCRIPTION
On very slow connections, you need to wait for the full editor JS to be loaded until you see the fetch progress bar.

This PR does some "server side rendering" to show an indeterminate progress bar immediately when the html and CSS loads, which will be "hydrated" when the editor JS is loaded.

Here is a "Fast 3G" throttled load of a featured notebook. Notice first the (greyed out) progress bar, replaced by the real progress bar, and once the statefile is loaded, the notebook. Before this PR, you would see a blank screen.


https://github.com/fonsp/Pluto.jl/assets/6933510/4adee854-a2ae-4d34-b1ba-22c60160f54c

