### PR TITLE
Fix broken editor.js prefetch

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -33,7 +33,6 @@
     <script src="warn_old_browsers.js"></script>
 
     <link rel="prefetch" href="editor.css">
-    <link rel="prefetch" type="module" href="editor.js">
     <link rel="prerender" href="editor.html">
 </head>
 


### PR DESCRIPTION
In index.html there are a couple prefetch and prerender statements: 

https://github.com/fonsp/Pluto.jl/pull/1838

But this one was not working well in the bundled version:

https://github.com/fonsp/Pluto.jl/blob/4599fc895e22c0d21f97e1f3b0180267b4c71ac9/frontend/index.html#L36

Parcel would take this as an entry point to bundle `editor.js`, but somehow it produces a different file than the one loaded in the bundled `editor.html`. This was producing an extra 1.5MB js file that was only prefetched in index.html, but never imported.

I tried some things to make the prefetch point to the correct import, but it didn't work.

The `editor.html` prerender should make sure that the correct JS asset gets prefetched.