### PR TITLE
Font sizing rework

### DIFF
--- a/frontend/alegreya.css
+++ b/frontend/alegreya.css
@@ -1,0 +1,515 @@
+/* alegreya-sans-cyrillic-ext-400-normal */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: normal;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 400;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-ext-400-normal.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-ext-400-normal.woff) format("woff");
+    unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+
+/* alegreya-sans-cyrillic-400-normal */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: normal;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 400;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-400-normal.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-400-normal.woff) format("woff");
+    unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+
+/* alegreya-sans-greek-ext-400-normal */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: normal;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 400;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-ext-400-normal.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-ext-400-normal.woff) format("woff");
+    unicode-range: U+1F00-1FFF;
+}
+
+/* alegreya-sans-greek-400-normal */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: normal;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 400;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-400-normal.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-400-normal.woff) format("woff");
+    unicode-range: U+0370-0377, U+037A-037F, U+0384-038A, U+038C, U+038E-03A1, U+03A3-03FF;
+}
+
+/* alegreya-sans-vietnamese-400-normal */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: normal;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 400;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-vietnamese-400-normal.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-vietnamese-400-normal.woff) format("woff");
+    unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329,
+        U+1EA0-1EF9, U+20AB;
+}
+
+/* alegreya-sans-latin-ext-400-normal */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: normal;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 400;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-ext-400-normal.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-ext-400-normal.woff) format("woff");
+    unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+/* alegreya-sans-latin-400-normal */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: normal;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 400;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-400-normal.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-400-normal.woff) format("woff");
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191,
+        U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+/* alegreya-sans-cyrillic-ext-500-normal */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: normal;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 500;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-ext-500-normal.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-ext-500-normal.woff) format("woff");
+    unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+
+/* alegreya-sans-cyrillic-500-normal */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: normal;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 500;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-500-normal.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-500-normal.woff) format("woff");
+    unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+
+/* alegreya-sans-greek-ext-500-normal */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: normal;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 500;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-ext-500-normal.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-ext-500-normal.woff) format("woff");
+    unicode-range: U+1F00-1FFF;
+}
+
+/* alegreya-sans-greek-500-normal */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: normal;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 500;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-500-normal.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-500-normal.woff) format("woff");
+    unicode-range: U+0370-0377, U+037A-037F, U+0384-038A, U+038C, U+038E-03A1, U+03A3-03FF;
+}
+
+/* alegreya-sans-vietnamese-500-normal */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: normal;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 500;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-vietnamese-500-normal.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-vietnamese-500-normal.woff) format("woff");
+    unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329,
+        U+1EA0-1EF9, U+20AB;
+}
+
+/* alegreya-sans-latin-ext-500-normal */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: normal;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 500;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-ext-500-normal.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-ext-500-normal.woff) format("woff");
+    unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+/* alegreya-sans-latin-500-normal */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: normal;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 500;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-500-normal.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-500-normal.woff) format("woff");
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191,
+        U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+/* alegreya-sans-cyrillic-ext-700-normal */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: normal;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 700;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-ext-700-normal.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-ext-700-normal.woff) format("woff");
+    unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+
+/* alegreya-sans-cyrillic-700-normal */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: normal;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 700;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-700-normal.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-700-normal.woff) format("woff");
+    unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+
+/* alegreya-sans-greek-ext-700-normal */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: normal;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 700;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-ext-700-normal.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-ext-700-normal.woff) format("woff");
+    unicode-range: U+1F00-1FFF;
+}
+
+/* alegreya-sans-greek-700-normal */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: normal;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 700;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-700-normal.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-700-normal.woff) format("woff");
+    unicode-range: U+0370-0377, U+037A-037F, U+0384-038A, U+038C, U+038E-03A1, U+03A3-03FF;
+}
+
+/* alegreya-sans-vietnamese-700-normal */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: normal;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 700;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-vietnamese-700-normal.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-vietnamese-700-normal.woff) format("woff");
+    unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329,
+        U+1EA0-1EF9, U+20AB;
+}
+
+/* alegreya-sans-latin-ext-700-normal */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: normal;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 700;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-ext-700-normal.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-ext-700-normal.woff) format("woff");
+    unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+/* alegreya-sans-latin-700-normal */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: normal;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 700;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-700-normal.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-700-normal.woff) format("woff");
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191,
+        U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+/* alegreya-sans-cyrillic-ext-400-italic */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: italic;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 400;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-ext-400-italic.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-ext-400-italic.woff) format("woff");
+    unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+
+/* alegreya-sans-cyrillic-400-italic */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: italic;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 400;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-400-italic.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-400-italic.woff) format("woff");
+    unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+
+/* alegreya-sans-greek-ext-400-italic */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: italic;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 400;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-ext-400-italic.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-ext-400-italic.woff) format("woff");
+    unicode-range: U+1F00-1FFF;
+}
+
+/* alegreya-sans-greek-400-italic */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: italic;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 400;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-400-italic.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-400-italic.woff) format("woff");
+    unicode-range: U+0370-0377, U+037A-037F, U+0384-038A, U+038C, U+038E-03A1, U+03A3-03FF;
+}
+
+/* alegreya-sans-vietnamese-400-italic */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: italic;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 400;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-vietnamese-400-italic.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-vietnamese-400-italic.woff) format("woff");
+    unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329,
+        U+1EA0-1EF9, U+20AB;
+}
+
+/* alegreya-sans-latin-ext-400-italic */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: italic;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 400;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-ext-400-italic.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-ext-400-italic.woff) format("woff");
+    unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+/* alegreya-sans-latin-400-italic */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: italic;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 400;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-400-italic.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-400-italic.woff) format("woff");
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191,
+        U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+/* alegreya-sans-cyrillic-ext-500-italic */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: italic;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 500;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-ext-500-italic.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-ext-500-italic.woff) format("woff");
+    unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+
+/* alegreya-sans-cyrillic-500-italic */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: italic;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 500;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-500-italic.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-500-italic.woff) format("woff");
+    unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+
+/* alegreya-sans-greek-ext-500-italic */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: italic;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 500;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-ext-500-italic.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-ext-500-italic.woff) format("woff");
+    unicode-range: U+1F00-1FFF;
+}
+
+/* alegreya-sans-greek-500-italic */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: italic;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 500;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-500-italic.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-500-italic.woff) format("woff");
+    unicode-range: U+0370-0377, U+037A-037F, U+0384-038A, U+038C, U+038E-03A1, U+03A3-03FF;
+}
+
+/* alegreya-sans-vietnamese-500-italic */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: italic;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 500;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-vietnamese-500-italic.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-vietnamese-500-italic.woff) format("woff");
+    unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329,
+        U+1EA0-1EF9, U+20AB;
+}
+
+/* alegreya-sans-latin-ext-500-italic */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: italic;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 500;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-ext-500-italic.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-ext-500-italic.woff) format("woff");
+    unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+/* alegreya-sans-latin-500-italic */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: italic;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 500;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-500-italic.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-500-italic.woff) format("woff");
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191,
+        U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}
+
+/* alegreya-sans-cyrillic-ext-700-italic */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: italic;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 700;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-ext-700-italic.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-ext-700-italic.woff) format("woff");
+    unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+}
+
+/* alegreya-sans-cyrillic-700-italic */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: italic;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 700;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-700-italic.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-700-italic.woff) format("woff");
+    unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
+}
+
+/* alegreya-sans-greek-ext-700-italic */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: italic;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 700;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-ext-700-italic.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-ext-700-italic.woff) format("woff");
+    unicode-range: U+1F00-1FFF;
+}
+
+/* alegreya-sans-greek-700-italic */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: italic;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 700;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-700-italic.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-700-italic.woff) format("woff");
+    unicode-range: U+0370-0377, U+037A-037F, U+0384-038A, U+038C, U+038E-03A1, U+03A3-03FF;
+}
+
+/* alegreya-sans-vietnamese-700-italic */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: italic;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 700;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-vietnamese-700-italic.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-vietnamese-700-italic.woff) format("woff");
+    unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329,
+        U+1EA0-1EF9, U+20AB;
+}
+
+/* alegreya-sans-latin-ext-700-italic */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: italic;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 700;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-ext-700-italic.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-ext-700-italic.woff) format("woff");
+    unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
+}
+
+/* alegreya-sans-latin-700-italic */
+@font-face {
+    font-family: "Alegreya Sans";
+    font-style: italic;
+    font-display: swap;
+    size-adjust: 119%;
+    font-weight: 700;
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-700-italic.woff2) format("woff2"),
+        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-700-italic.woff) format("woff");
+    unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191,
+        U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+}

--- a/frontend/binder.css
+++ b/frontend/binder.css
@@ -67,12 +67,6 @@ binder-spinner {
     background: #fffdf7;
     box-shadow: 0px 0px 20px 0px #ffffff;
     cursor: pointer;
-    font-size: 14px;
-    font-style: italic;
-    font-family: "Roboto Mono";
-    letter-spacing: -0.2px;
-    color: #0000009c;
-    white-space: nowrap;
     display: block;
 }
 
@@ -117,7 +111,6 @@ body.wiggle_binder .edit_or_run > button {
     border: 3px solid hsl(236deg 28% 50% / 46%);
     font-size: 16px;
     /* font-style: italic; */
-    font-family: "Roboto Mono";
     font-family: var(--lato-ui-font-stack);
     letter-spacing: 0.1px;
     color: var(--black);

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -190,7 +190,7 @@ pluto-output p {
     margin-block-start: 0px;
     margin-block-end: var(--pluto-cell-spacing);
     word-spacing: 0.053em;
-    line-height: 1.45em;
+    line-height: 1.55em;
 }
 
 /* This allows a linebreak in Markdown using backslash with smaller spacing compared to paragraph in firefox */
@@ -523,7 +523,7 @@ header#pluto-nav {
     border-bottom: solid 1px var(--header-border-color);
     font-family: "Roboto Mono", monospace;
     font-weight: 400;
-    font-size: 0.75rem;
+    font-size: 0.8rem;
 }
 
 header#pluto-nav.show_export {
@@ -594,7 +594,6 @@ div.export_title {
     /* writing-mode: sideways-lr; */
     writing-mode: vertical-lr;
     transform: rotate(180deg);
-
     margin-top: 10px;
     font-weight: 700;
     font-size: 1rem;
@@ -604,7 +603,7 @@ a.export_card header {
     font-family: "Vollkorn", Palatino, sans-serif;
     /* font-family: system-ui; */
     font-feature-settings: "lnum", "pnum";
-    font-size: 1rem;
+    font-size: 17px;
 }
 a.export_card section {
     color: var(--export-card-text-color);

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -37,6 +37,7 @@
     --sans-serif-font-stack: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;
     --lato-ui-font-stack: "Lato", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Cantarell, "Apple Color Emoji", "Segoe UI Emoji",
         "Segoe UI Symbol", system-ui, sans-serif;
+    --roboto-mono-font-stack: "Roboto Mono", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", monospace;
     --system-ui-font-stack: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Cantarell, "Apple Color Emoji", "Segoe UI Emoji",
         "Segoe UI Symbol", system-ui, sans-serif;
     color-scheme: light dark;
@@ -385,7 +386,7 @@ pluto-output div.footnote p.footnote-title::after {
 }
 pluto-output a.footnote,
 pluto-output div.footnote p.footnote-title {
-    font-family: "Roboto Mono", monospace;
+    font-family: var(--roboto-mono-font-stack);
     font-size: 0.75rem;
     font-weight: 700;
     margin-block-end: 0px;
@@ -521,7 +522,7 @@ header#pluto-nav {
     transform: translateY(0px);
     transition: background-color 0.5s ease-in-out, transform 0.25s cubic-bezier(0.18, 0.89, 0.49, 1.13);
     border-bottom: solid 1px var(--header-border-color);
-    font-family: "Roboto Mono", monospace;
+    font-family: var(--roboto-mono-font-stack);
     font-weight: 400;
     font-size: 0.8rem;
 }
@@ -1098,7 +1099,7 @@ main > preamble {
     border: 3px solid var(--overlay-button-border);
     border-radius: 12px;
     height: 35px;
-    font-family: "Segoe UI Emoji", "Roboto Mono", monospace;
+    font-family: var(--roboto-mono-font-stack);
     font-size: 0.75rem;
     pointer-events: all;
     /* break-inside: avoid; */
@@ -1404,7 +1405,7 @@ nav#slide_controls > button {
     cursor: pointer;
     /* color: hsl(204, 86%, 35%); */
     color: var(--ui-button-color);
-    font-family: "Segoe UI Emoji", "Roboto Mono", monospace;
+    font-family: var(--roboto-mono-font-stack);
     font-size: 0.75rem;
     z-index: 30;
     /* CodeMirror is 2 */
@@ -2140,7 +2141,7 @@ pluto-runarea > span {
     left: 22px;
     width: 45px;
 
-    font-family: "Roboto Mono", monospace;
+    font-family: var(--roboto-mono-font-stack);
     font-size: 0.6em;
     font-style: italic;
     color: var(--pluto-runarea-span-color);
@@ -2697,7 +2698,7 @@ pl-status .status-time {
     /* align-self: end; */
     padding-right: 0.5em;
     padding-left: 0.5em;
-    /* font-family: "Roboto Mono", monospace; */
+    /* font-family: var(--roboto-mono-font-stack); */
     opacity: 0.6;
     font-size: 0.7rem;
     font-variant-numeric: tabular-nums;
@@ -2798,7 +2799,7 @@ pluto-helpbox.helpbox-process > section {
 footer {
     width: 100%;
     min-height: 3.5rem;
-    font-family: "Roboto Mono", monospace;
+    font-family: var(--roboto-mono-font-stack);
     font-size: 0.75rem;
     background-color: var(--footer-bg-color);
     color: var(--footer-color);
@@ -2891,7 +2892,7 @@ nav#undo_delete {
     margin: 0.75rem;
     padding: 0.5rem;
 
-    font-family: "Roboto Mono", monospace;
+    font-family: var(--roboto-mono-font-stack);
     font-size: 0.75rem;
 
     background-color: var(--white);
@@ -2948,7 +2949,7 @@ pluto-logs-container:not(:empty) {
 }
 
 pluto-logs-container > header {
-    font-family: "Roboto Mono", monospace;
+    font-family: var(--roboto-mono-font-stack);
     font-size: 1.3rem;
     padding: 0.2em;
     padding-bottom: 0;
@@ -2988,7 +2989,7 @@ pluto-logs:not(:first-child):not(:empty) {
 pluto-log-dot {
     /* part 2 */
     /* box-shadow: -2px 0px 1px #00000014; */
-    font-family: "Roboto Mono", monospace;
+    font-family: var(--roboto-mono-font-stack);
     font-size: 0.6rem;
     position: relative;
     display: flex;

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -126,7 +126,7 @@ pluto-output h3,
 pluto-output h4,
 pluto-output h5,
 pluto-output h6 {
-    font-family: "Vollkorn", Palatino, serif;
+    font-family: "Vollkorn", Palatino, Georgia, serif;
     font-feature-settings: "lnum", "pnum";
     font-weight: 600;
     color: var(--pluto-output-h-color);

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -7,12 +7,13 @@
 @import url("https://cdn.jsdelivr.net/npm/@fontsource/roboto-mono@4.4.5/700.css");
 
 /* @import url("https://fonts.googleapis.com/css?family=Alegreya+Sans:400,400i,500,500i,700,700i&display=swap&subset=cyrillic,cyrillic-ext,greek,greek-ext,latin-ext,vietnamese"); */
-@import url("https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@4.4.5/400.css");
-@import url("https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@4.4.5/500.css");
-@import url("https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@4.4.5/700.css");
-@import url("https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@4.4.5/400-italic.css");
-@import url("https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@4.4.5/500-italic.css");
-@import url("https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@4.4.5/700-italic.css");
+/* @import url("https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/400.css");
+@import url("https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/500.css");
+@import url("https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/700.css");
+@import url("https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/400-italic.css");
+@import url("https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/500-italic.css");
+@import url("https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/700-italic.css"); */
+@import url("./alegreya.css");
 
 @import url("./juliamono.css");
 @import url("./vollkorn.css");
@@ -43,7 +44,7 @@
 
 /* GENERAL PAGE LAYOUT */
 html {
-    font-size: 17px;
+    font-size: 16px;
 }
 
 * {
@@ -239,7 +240,7 @@ a:hover {
 
 pluto-output code {
     font-family: var(--julia-mono-font-stack);
-    font-size: 0.75em; /* not rem */
+    font-size: 0.9em; /* not rem */
     font-variant-ligatures: none;
 }
 
@@ -270,7 +271,7 @@ pluto-output pre {
     tab-size: 4;
     -moz-tab-size: 4; /* https://bugzilla.mozilla.org/show_bug.cgi?id=737785 */
     font-family: var(--julia-mono-font-stack);
-    font-size: 0.75rem;
+    font-size: 0.8rem;
     font-variant-ligatures: none;
 }
 
@@ -2494,7 +2495,7 @@ pluto-helpbox.hidden > section {
 .helpbox-docs {
     font-family: var(--lato-ui-font-stack);
     line-height: 1.5;
-    font-size: 0.9rem;
+    /* font-size: 0.9rem; */
 }
 .helpbox-docs pre,
 .helpbox-docs code,
@@ -3378,7 +3379,7 @@ pluto-input .cm-editor .cm-scroller,
 .cm-editor .cm-tooltip-autocomplete .cm-completionLabel {
     font-family: var(--julia-mono-font-stack) !important;
     font-variant-ligatures: none;
-    font-size: 0.75rem;
+    font-size: 0.8rem;
 }
 
 pluto-input .cm-editor .cm-content {

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -114,7 +114,7 @@ pluto-notebook {
 
 pluto-output {
     font-family: "Alegreya Sans", "Trebuchet MS", sans-serif;
-    font-size: 1em;
+    font-size: 14.5px;
     font-weight: 400;
     color: var(--pluto-output-color);
 }

--- a/frontend/editor.html
+++ b/frontend/editor.html
@@ -35,8 +35,6 @@
     <link rel="stylesheet" href="./hide-ui.css" type="text/css" media="all" data-pluto-file="hide-ui" />
     <link rel="stylesheet" href="./binder.css" type="text/css" />
     <link rel="stylesheet" href="./treeview.css" type="text/css" />
-    <link rel="preload" href="./juliamono.css" as="style" />
-    <link rel="preload" href="./vollkorn.css" as="style" />
     <link rel="stylesheet" href="./highlightjs.css" type="text/css">
 
     <meta name="pluto-insertion-spot-parameters">


### PR DESCRIPTION
We use the font Alegreya Sans for paragraphs in cell output (like Markdown text), but this typeface is scaled small relative to most typefaces, including the fallback fonts: `"Trebuchet MS", sans-serif`.

This means that text appears disproportionally big while Alegreya is loading, or when the font did not load at all. It also makes relative sizing less intuitive: `1rem` is quite a lot bigger than the main text.

# Before

Here I am switching the Alegreya font on an off, to see the difference with the fallback fonts:

https://github.com/fonsp/Pluto.jl/assets/6933510/0aef4e75-0ef6-4a4e-b61d-126ed9d8a833


# After


https://github.com/fonsp/Pluto.jl/assets/6933510/030a9066-5a3f-481b-a19e-09747c9eb522

