### PR TITLE
Use `ch` CSS unit to simplify awesome_line_wrapping CM plugin

### DIFF
--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -804,7 +804,6 @@ export const CellInput = ({
                     EditorView.contentAttributes.of({ spellcheck: String(ENABLE_CM_SPELLCHECK) }),
 
                     EditorView.lineWrapping,
-                    // Wowww this has been enabled for some time now... wonder if there are issues about this yet ;) - DRAL
                     awesome_line_wrapping,
 
                     // Reset diagnostics on change

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -46,7 +46,7 @@ import { markdown, html as htmlLang, javascript, sqlLang, python, julia_mixed } 
 import { julia_andrey } from "../imports/CodemirrorPlutoSetup.js"
 import { pluto_autocomplete } from "./CellInput/pluto_autocomplete.js"
 import { NotebookpackagesFacet, pkgBubblePlugin } from "./CellInput/pkg_bubble_plugin.js"
-import { awesome_line_wrapping } from "./CellInput/awesome_line_wrapping.js"
+import { awesome_line_wrapping, get_start_tabs } from "./CellInput/awesome_line_wrapping.js"
 import { cell_movement_plugin, prevent_holding_a_key_from_doing_things_across_cells } from "./CellInput/cell_movement_plugin.js"
 import { pluto_paste_plugin } from "./CellInput/pluto_paste_plugin.js"
 import { bracketMatching } from "./CellInput/block_matcher_plugin.js"
@@ -1126,7 +1126,7 @@ const InputContextMenuItem = ({ contents, title, onClick, setOpen, tag }) =>
 
 const StaticCodeMirrorFaker = ({ value }) => {
     const lines = value.split("\n").map((line, i) => {
-        const start_tabs = /^\t*/.exec(line)?.[0] ?? ""
+        const start_tabs = get_start_tabs(line)
 
         const tabbed_line =
             start_tabs.length == 0

--- a/frontend/components/CellInput/awesome_line_wrapping.js
+++ b/frontend/components/CellInput/awesome_line_wrapping.js
@@ -1,5 +1,5 @@
 import _ from "../../imports/lodash.js"
-import { StateEffect, StateField, EditorView, Decoration } from "../../imports/CodemirrorPlutoSetup.js"
+import { StateField, EditorView, Decoration } from "../../imports/CodemirrorPlutoSetup.js"
 import { ReactWidget } from "./ReactWidget.js"
 import { html } from "../../imports/Preact.js"
 
@@ -88,87 +88,4 @@ let line_wrapping_decorations = StateField.define({
     provide: (f) => EditorView.decorations.from(f),
 })
 
-// Add this back in
-// let dont_break_before_spaces_matcher = new MatchDecorator({
-//     regexp: /[^ \t]+[ \t]+/g,
-//     decoration: Decoration.mark({
-//         class: "indentation-so-dont-break",
-//     }),
-// })
-
-let identation_so_dont_break_marker = Decoration.mark({
-    class: "indentation-so-dont-break",
-})
-
-let dont_break_before_spaces = StateField.define({
-    create() {
-        return Decoration.none
-    },
-    update(deco, tr) {
-        let decorations = []
-        let pos = 0
-        for (const line of tr.newDoc) {
-            for (const match of /** @type{string} */ (line).matchAll(/[^ \t]+([ \t]|$)+/g)) {
-                if (match.index == null || match.index === 0) continue // Sneaky negative lookbehind
-                decorations.push(identation_so_dont_break_marker.range(pos + match.index, pos + match.index + match[0].length))
-            }
-        }
-        return Decoration.set(decorations, true)
-    },
-    provide: (f) => EditorView.decorations.from(f),
-})
-
-// let break_after_space_matcher = new MatchDecorator({
-//     regexp: /[ ](?=[^ \t])/g,
-//     decoration: Decoration.widget({
-//         widget: new ReactWidget(html` <wbr></wbr>`),
-//         block: false,
-//         side: 1,
-//     }),
-// })
-
-// let break_after_space = ViewPlugin.define(
-//     (view) => {
-//         return {
-//             decorations: break_after_space_matcher.createDeco(view),
-//             update(update) {
-//                 this.decorations = break_after_space_matcher.updateDeco(update, this.decorations)
-//             },
-//         }
-//     },
-//     {
-//         decorations: (v) => v.decorations,
-//     }
-// )
-
-// let dont_break_start_of_line_matcher = new MatchDecorator({
-//     regexp: /^[ \t]+[^ \t]/g,
-//     decoration: Decoration.mark({
-//         class: "Uhhh",
-//     }),
-// })
-
-// let dont_break_start_of_line = ViewPlugin.define(
-//     (view) => {
-//         return {
-//             decorations: dont_break_start_of_line_matcher.createDeco(view),
-//             update(update) {
-//                 this.decorations = dont_break_start_of_line_matcher.updateDeco(update, this.decorations)
-//             },
-//         }
-//     },
-//     {
-//         decorations: (v) => v.decorations,
-//     }
-// )
-
-// console.log(`awesome_line_wrapping:`, indent_decorations)
-export let awesome_line_wrapping = [
-    // dont_break_start_of_line,
-    line_wrapping_decorations,
-    // break_after_space,
-    // dont_break_before_spaces,
-]
-// export let awesome_line_wrapping = []
-// export let awesome_line_wrapping = indent_decorations
-// export let awesome_line_wrapping = [dont_break_before_spaces, break_after_space]
+export let awesome_line_wrapping = [line_wrapping_decorations]

--- a/frontend/components/CellInput/awesome_line_wrapping.js
+++ b/frontend/components/CellInput/awesome_line_wrapping.js
@@ -30,6 +30,7 @@ export const awesome_line_wrapping = StateField.define({
             if (line.length === 0) continue
 
             const indented_tabs = get_start_tabs(line.text).length
+            if (indented_tabs === 0) continue
 
             const characters_to_count = Math.min(indented_tabs, ARBITRARY_INDENT_LINE_WRAP_LIMIT)
             const offset = characters_to_count * tabSize

--- a/frontend/components/CellInput/awesome_line_wrapping.js
+++ b/frontend/components/CellInput/awesome_line_wrapping.js
@@ -3,51 +3,39 @@ import { StateField, EditorView, Decoration } from "../../imports/CodemirrorPlut
 import { ReactWidget } from "./ReactWidget.js"
 import { html } from "../../imports/Preact.js"
 
+const ARBITRARY_INDENT_LINE_WRAP_LIMIT = 12
+
+export const get_start_tabs = (line) => /^\t*/.exec(line)?.[0] ?? ""
+
 /**
  * Plugin that makes line wrapping in the editor respect the identation of the line.
  * It does this by adding a line decoration that adds padding-left (as much as there is indentation),
  * and adds the same amount as negative "text-indent". The nice thing about text-indent is that it
  * applies to the initial line of a wrapped line.
  */
-
-let ARBITRARY_INDENT_LINE_WRAP_LIMIT = 12
-let line_wrapping_decorations = StateField.define({
+export const awesome_line_wrapping = StateField.define({
     create() {
         return Decoration.none
     },
     update(deco, tr) {
-        // let tabSize = tr.state.tabSize
-        let tabSize = 4
+        const tabSize = tr.state.tabSize
 
         if (!tr.docChanged && deco !== Decoration.none) return deco
 
         let decorations = []
 
-        // TODO? Only apply to visible lines? Wouldn't that screw stuff up??
         // TODO? Don't create new decorations when a line hasn't changed?
         for (let i of _.range(0, tr.state.doc.lines)) {
             let line = tr.state.doc.line(i + 1)
             if (line.length === 0) continue
 
-            let indented_tabs = 0
-            for (let ch of line.text) {
-                if (ch === "\t") {
-                    indented_tabs++
-                    // For now I ignore spaces... because they are weird... and stupid!
-                    // } else if (ch === " ") {
-                    //     indented_chars = indented_chars + 1
-                    //     indented_text_characters++
-                } else {
-                    break
-                }
-            }
+            const indented_tabs = get_start_tabs(line.text).length
 
             const characters_to_count = Math.min(indented_tabs, ARBITRARY_INDENT_LINE_WRAP_LIMIT)
             const offset = characters_to_count * tabSize
 
             const linerwapper = Decoration.line({
                 attributes: {
-                    // style: rules.cssText,
                     style: `--indented: ${offset}ch;`,
                     class: "awesome-wrapping-plugin-the-line",
                 },
@@ -55,7 +43,7 @@ let line_wrapping_decorations = StateField.define({
             // Need to push before the tabs one else codemirror gets madddd
             decorations.push(linerwapper.range(line.from, line.from))
 
-            if (characters_to_count !== 0) {
+            if (characters_to_count > 0) {
                 decorations.push(
                     Decoration.mark({
                         class: "awesome-wrapping-plugin-the-tabs",
@@ -72,20 +60,8 @@ let line_wrapping_decorations = StateField.define({
                     )
                 }
             }
-
-            // let tabs_in_front = Math.min(line.text.match(/^\t*/)[0].length) * tabSize
-
-            // TODO? Cache the CSSStyleDeclaration?
-            // This is used when we don't use a css class, but we do need a css class because
-            // text-indent normally cascades, and we have to prevent that.
-            // const rules = document.createElement("span").style
-            // rules.setProperty("--idented", `${offset}px`)
-            // rules.setProperty("text-indent", "calc(-1 * var(--idented) - 1px)") // I have no idea why, but without the - 1px it behaves weirdly periodically
-            // rules.setProperty("padding-left", "calc(var(--idented) + var(--cm-left-padding, 4px))")
         }
         return Decoration.set(decorations)
     },
     provide: (f) => EditorView.decorations.from(f),
 })
-
-export let awesome_line_wrapping = [line_wrapping_decorations]


### PR DESCRIPTION
The `awesome_line_wrapping` that wraps lines in a tab-aware currently works by counting tabs at the start of the line, calculates their width in pixels, and offsets the subsequent text by a negative amount.

<img width="670" alt="image" src="https://github.com/fonsp/Pluto.jl/assets/6933510/7ec3030c-3500-46fc-a48d-745ff651d039">

It's quite complicated because the space width needs to be measured. This can be simplified by using the `ch` CSS unit, and taking `1ch` as the space width.

I also removed some stale code