### PR TITLE
Disable fake CM on firefox to fix highlighting in PDF export

### DIFF
--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -424,7 +424,9 @@ export const CellInput = ({
 
     const [show_static_fake_state, set_show_static_fake] = useState(!skip_static_fake)
 
-    const show_static_fake = useMemo(() => focus_after_creation || cm_forced_focus != null || skip_static_fake, []) ? false : show_static_fake_state
+    const show_static_fake = useMemo(() => navigator.userAgent.includes("Firefox") || focus_after_creation || cm_forced_focus != null || skip_static_fake, [])
+        ? false
+        : show_static_fake_state
 
     useLayoutEffect(() => {
         if (!show_static_fake) return


### PR DESCRIPTION
#2885 caused an issue on Firefox where printing to PDF directly after opening the notebook does not highlight code:

This is because Firefox does not wait long enough for all DOM manipulation to be done, unlike Chrome and Safari.

This PR disables #2885 on Firefox, cant think of a better way

<img width="954" alt="image" src="https://github.com/fonsp/Pluto.jl/assets/6933510/a8b74524-7176-40fa-b832-b946ac357d4e">
