### PR TITLE
Give "Loading more cells..." lots of vertical space so scroll restoration works better on Firefox

### DIFF
--- a/frontend/components/Notebook.js
+++ b/frontend/components/Notebook.js
@@ -214,7 +214,13 @@ export const Notebook = ({
                     />`
                 )}
             ${cell_outputs_delayed && notebook.cell_order.length >= render_cell_outputs_minimum
-                ? html`<div style="font-family: system-ui; font-style: italic; text-align: center; padding: 5rem 1rem;">Loading more cells...</div>`
+                ? html`<div
+                      style="font-family: system-ui; font-style: italic; text-align: center; padding: 5rem 1rem; margin-bottom: ${(notebook.cell_order.length -
+                          render_cell_outputs_minimum) *
+                      10}rem;"
+                  >
+                      Loading more cells...
+                  </div>`
                 : null}
         </pluto-notebook>
     `


### PR DESCRIPTION
After this PR, if you refresh a long notebook on firefox, you might just end up at the same scroll position as before the reload. This used to not work because of the "Loading more cells..." mechanism.