### PR TITLE
Try to add already installed versions of packages with `Pkg.PRESERVE_ALL_INSTALLED`

### DIFF
--- a/src/packages/PkgCompat.jl
+++ b/src/packages/PkgCompat.jl
@@ -8,7 +8,7 @@ import Pkg.Types: VersionRange
 import RegistryInstances
 import ..Pluto
 
-
+const PRESERVE_ALL_INSTALLED = isdefined(Pkg, :PRESERVE_ALL_INSTALLED) ? Pkg.PRESERVE_ALL_INSTALLED : Pkg.PRESERVE_ALL
 
 
 @static if isdefined(Pkg,:REPLMode) && isdefined(Pkg.REPLMode,:complete_remote_package)


### PR DESCRIPTION
Using https://github.com/JuliaLang/Pkg.jl/pull/3378

After this PR, when adding a package to your notebook, Pkg will try to add a version that is already installed on your computer. If nothing is available, a new version will be installed.

This should mean that you have a higher chance of skipping installation and precompilation when creating a new notebook and adding some packages that you also used a couple days ago.

If you want the latest versions, you will have to do an update right after adding the packages. This could be unintuitive, but I think it is worth the trade-off as a default, since currently there is much frustration about too-frequent installation and precompilation times.

---

Sorry for the delay! I was not aware of this change to Pkg until @KristofferC mentioned it to me today!