### PR TITLE
Rework horizontal spacing code to better support embedded notebooks

### DIFF
--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -90,18 +90,12 @@ body:not(.disable_ui) {
 /* | main=25px+700px+6px=731px | pluto-helpbox=350px - 500px | */
 /* min-width: 731px+ */
 
-/* CAN WE HAVE CONTAINER QUERIES PLESSSSS */
-@media screen and (min-width: calc(700px + 25px + 6px)) and (max-width: calc(700px + 25px + 6px + 500px)) {
-    body:not(.disable_ui) pluto-editor.fullscreen main {
-        margin-left: 0px;
-        align-self: flex-start;
-    }
-}
-@media screen and (min-width: calc(700px + 25px + 6px + 500px)) and (max-width: calc(700px + 25px + 6px + 500px + 500px)) {
-    body:not(.disable_ui) pluto-editor.fullscreen main {
-        margin-right: 500px;
-        align-self: flex-end;
-    }
+pluto-editor main {
+    align-self: flex-end;
+    margin-right: max(
+        /* First part: center it */ max(0px, (100% - (700px + 25px + 6px)) / 2),
+        /* Second part: push away from the right to take up all free space */ min((100% - (700px + 25px + 6px)), /* but don't do this more than */ 500px)
+    );
 }
 
 pluto-notebook {

--- a/frontend/editor.html
+++ b/frontend/editor.html
@@ -48,7 +48,7 @@
 </head>
 
 <body class="loading no-MαθJax">
-    <div style="display: flex; min-height: 100vh;">
+    <div style="min-height: 100vh;">
         <pluto-editor class="fullscreen">
             <progress style="filter: grayscale(1)" class="statefile-fetch-progress delete-me-when-live" max="100"></progress>
         </pluto-editor>

--- a/frontend/editor.html
+++ b/frontend/editor.html
@@ -48,7 +48,7 @@
 </head>
 
 <body class="loading no-MαθJax">
-    <div style="min-height: 100vh;">
+    <div style="display: flex; min-height: 100vh;">
         <pluto-editor class="fullscreen">
             <progress style="filter: grayscale(1)" class="statefile-fetch-progress delete-me-when-live" max="100"></progress>
         </pluto-editor>


### PR DESCRIPTION
After 4 years, I finally found the CSS code that I wanted 💛

- On very large screen, I want the notebook to be centered in the screen.
- On medium screens, I want the notebook on the left, with any free space on the right (for the Live Docs panel).
- On small screens, the notebook should take up all space.

Before, I implemented this with media queries, to detect each of the three situations. But this does not look good when the notebook is embedded on a site with a sidebar on the left, like https://plutojl.org/en/docs/abstractplutodingetjes/

<img width="961" alt="image" src="https://github.com/fonsp/Pluto.jl/assets/6933510/36006976-dbdb-4a21-8ef0-f85d7d741e55">

Here, I would want the notebook to be pushed to the left, to make space for widgets (like to ToC on the right). But the media queries won't work, because the window width is not the editor width. And [container queries](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_queries) are still not implemented.

Solution! I took a long train and found this solution:

```css
pluto-editor main {
    align-self: flex-end;
    margin-right: max(
        /* First part: push away from the right */ min(/* taking up all free space */ (100% - (700px + 25px + 6px)), /* but don't do this more than */ 500px)
            /* Second part: center it */ max(0px, (100% - (700px + 25px + 6px)) / 2)
    );
}
```

Because it uses `100%` in the calculations, it's relative to the editor (without container queries!). And all the min maxes make all the situations work.

Two videos of the new behaviour, one with a simulated sidebar on the left.

https://github.com/fonsp/Pluto.jl/assets/6933510/76586653-69a7-4267-a344-e91d9b938a81



https://github.com/fonsp/Pluto.jl/assets/6933510/acd8b2bc-5db0-4c1d-85f8-5db8a68e9b6a

