### PR TITLE
⌨️ Keyboard shortcut for folding cell

### DIFF
--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -630,7 +630,7 @@ export const CellInput = ({
         }
         const keyMapFold = (/** @type {EditorView} */ cm, new_value) => {
             set_cm_forced_focus(true)
-            pluto_actions.fold_remote_cells([cell_id], new_value).catch(console.warn)
+            pluto_actions.fold_remote_cells([cell_id], new_value)
             return true
         }
 
@@ -1043,7 +1043,6 @@ const InputContextMenu = ({ on_delete, cell_id, run_cell, skip_as_script, runnin
         if (e.key === "Escape") {
             setOpen(false)
         }
-        e.stopPropagation()
     })
 
     return html`

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -629,7 +629,6 @@ export const CellInput = ({
             }
         }
         const keyMapFold = async (/** @type {EditorView} */ cm) => {
-            console.log(cm)
             set_cm_forced_focus(true)
             await pluto_actions.fold_remote_cells([cell_id]).catch(console.warn)
             return true

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -630,16 +630,8 @@ export const CellInput = ({
         }
         const keyMapFold = async (/** @type {EditorView} */ cm) => {
             console.log(cm)
-            await pluto_actions.fold_remote_cells([cell_id], true).catch(console.warn)
-            const cell = dom_node_ref.current?.closest("pluto-cell")
-            const next_cell = cell?.nextElementSibling
-            if (next_cell?.nodeName === "PLUTO-CELL") {
-                // @ts-ignore
-                next_cell?.querySelector("button.add_cell.before")?.focus?.()
-            } else {
-                // @ts-ignore
-                cell?.querySelector("button.add_cell.after")?.focus?.()
-            }
+            set_cm_forced_focus(true)
+            await pluto_actions.fold_remote_cells([cell_id]).catch(console.warn)
             return true
         }
 
@@ -659,7 +651,10 @@ export const CellInput = ({
             { key: "Ctrl-Backspace", run: keyMapBackspace },
             { key: "Alt-ArrowUp", run: (x) => keyMapMoveLine(x, -1) },
             { key: "Alt-ArrowDown", run: (x) => keyMapMoveLine(x, 1) },
-            { key: "Alt-Escape", run: keyMapFold },
+            { key: "Ctrl-k", mac: "Cmd-k", run: keyMapFold },
+            { key: "Ctrl-k", run: keyMapFold },
+            // Codemirror6 doesn't like capslock
+            { key: "Ctrl-K", run: keyMapFold },
 
             mod_d_command,
         ]
@@ -932,6 +927,7 @@ export const CellInput = ({
                     head: cm.state.selection.main.head,
                 },
             })
+        } else if (cm_forced_focus === true) {
         } else {
             let new_selection = {
                 anchor: line_and_ch_to_cm6_position(cm.state.doc, cm_forced_focus[0]),

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -628,9 +628,9 @@ export const CellInput = ({
                 return direction === 1 ? moveLineDown(cm) : moveLineUp(cm)
             }
         }
-        const keyMapFold = async (/** @type {EditorView} */ cm) => {
+        const keyMapFold = (/** @type {EditorView} */ cm) => {
             set_cm_forced_focus(true)
-            await pluto_actions.fold_remote_cells([cell_id]).catch(console.warn)
+            pluto_actions.fold_remote_cells([cell_id]).catch(console.warn)
             return true
         }
 

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -628,9 +628,9 @@ export const CellInput = ({
                 return direction === 1 ? moveLineDown(cm) : moveLineUp(cm)
             }
         }
-        const keyMapFold = (/** @type {EditorView} */ cm) => {
+        const keyMapFold = (/** @type {EditorView} */ cm, new_value) => {
             set_cm_forced_focus(true)
-            pluto_actions.fold_remote_cells([cell_id]).catch(console.warn)
+            pluto_actions.fold_remote_cells([cell_id], new_value).catch(console.warn)
             return true
         }
 
@@ -650,11 +650,8 @@ export const CellInput = ({
             { key: "Ctrl-Backspace", run: keyMapBackspace },
             { key: "Alt-ArrowUp", run: (x) => keyMapMoveLine(x, -1) },
             { key: "Alt-ArrowDown", run: (x) => keyMapMoveLine(x, 1) },
-            { key: "Ctrl-k", mac: "Cmd-k", run: keyMapFold },
-            { key: "Ctrl-k", run: keyMapFold },
-            // Codemirror6 doesn't like capslock
-            { key: "Ctrl-K", run: keyMapFold },
-
+            { key: "Ctrl-Shift-[", mac: "Cmd-Alt-[", run: (x) => keyMapFold(x, true) },
+            { key: "Ctrl-Shift-]", mac: "Cmd-Alt-]", run: (x) => keyMapFold(x, false) },
             mod_d_command,
         ]
 

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -628,6 +628,20 @@ export const CellInput = ({
                 return direction === 1 ? moveLineDown(cm) : moveLineUp(cm)
             }
         }
+        const keyMapFold = async (/** @type {EditorView} */ cm) => {
+            console.log(cm)
+            await pluto_actions.fold_remote_cells([cell_id], true).catch(console.warn)
+            const cell = dom_node_ref.current?.closest("pluto-cell")
+            const next_cell = cell?.nextElementSibling
+            if (next_cell?.nodeName === "PLUTO-CELL") {
+                // @ts-ignore
+                next_cell?.querySelector("button.add_cell.before")?.focus?.()
+            } else {
+                // @ts-ignore
+                cell?.querySelector("button.add_cell.after")?.focus?.()
+            }
+            return true
+        }
 
         const plutoKeyMaps = [
             { key: "Shift-Enter", run: keyMapSubmit },
@@ -645,6 +659,7 @@ export const CellInput = ({
             { key: "Ctrl-Backspace", run: keyMapBackspace },
             { key: "Alt-ArrowUp", run: (x) => keyMapMoveLine(x, -1) },
             { key: "Alt-ArrowDown", run: (x) => keyMapMoveLine(x, 1) },
+            { key: "Alt-Escape", run: keyMapFold },
 
             mod_d_command,
         ]
@@ -1032,10 +1047,11 @@ const InputContextMenu = ({ on_delete, cell_id, run_cell, skip_as_script, runnin
             })
     }
 
-    useEventListener(window, "keydown", (e) => {
+    useEventListener(window, "keydown", (/** @type {KeyboardEvent} */ e) => {
         if (e.key === "Escape") {
             setOpen(false)
         }
+        e.stopPropagation()
     })
 
     return html`

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -1273,29 +1273,32 @@ patch: ${JSON.stringify(
                 // On mac "cmd+shift+?" is used by chrome, so that is why this needs to be ctrl as well on mac
                 // Also pressing "ctrl+shift" on mac causes the key to show up as "/", this madness
                 // I hope we can find a better solution for this later - Dral
+
+                const fold_prefix = is_mac_keyboard ? `⌥${and}⌘` : `Ctrl${and}Shift`
+
                 alert(
-                    `Shortcuts 🎹
+                    `
+⇧${and}Enter:   run cell
+${ctrl_or_cmd_name}${and}Enter:   run cell and add cell below
+${ctrl_or_cmd_name}${and}S:   submit all changes
+Delete or Backspace:   delete empty cell
 
-    ⇧${and}Enter:   run cell
-    ${ctrl_or_cmd_name}${and}Enter:   run cell and add cell below
-    ${ctrl_or_cmd_name}${and}S:   submit all changes
-    Delete or Backspace:   delete empty cell
+PageUp or fn${and}↑:   jump to cell above
+PageDown or fn${and}↓:   jump to cell below
+${alt_or_options_name}${and}↑:   move line/cell up
+${alt_or_options_name}${and}↓:   move line/cell down
 
-    page up or fn${and}↑:   jump to cell above
-    page down or fn${and}↓:   jump to cell below
-    ${alt_or_options_name}${and}↑:   move line/cell up
-    ${alt_or_options_name}${and}↓:   move line/cell down
+${control_name}${and}M:   toggle markdown
+${fold_prefix}${and}[:   hide cell code
+${fold_prefix}${and}]:   show cell code
+${ctrl_or_cmd_name}${and}Q:   interrupt notebook
 
-    
-    Select multiple cells by dragging a selection box from the space between cells.
-    ${ctrl_or_cmd_name}${and}C:   copy selected cells
-    ${ctrl_or_cmd_name}${and}X:   cut selected cells
-    ${ctrl_or_cmd_name}${and}V:   paste selected cells
-    
-    ${control_name}${and}M:   toggle markdown
-    ${ctrl_or_cmd_name}${and}Q:   interrupt notebook
+Select multiple cells by dragging a selection box from the space between cells.
+${ctrl_or_cmd_name}${and}C:   copy selected cells
+${ctrl_or_cmd_name}${and}X:   cut selected cells
+${ctrl_or_cmd_name}${and}V:   paste selected cells
 
-    The notebook file saves every time you run a cell.`
+The notebook file saves every time you run a cell.`
                 )
                 e.preventDefault()
             } else if (e.key === "Escape") {

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -583,7 +583,7 @@ export class Editor extends Component {
             fold_remote_cells: async (cell_ids, new_value) => {
                 await update_notebook((notebook) => {
                     for (let cell_id of cell_ids) {
-                        notebook.cell_inputs[cell_id].code_folded = new_value
+                        notebook.cell_inputs[cell_id].code_folded = new_value ?? !notebook.cell_inputs[cell_id].code_folded
                     }
                 })
             },
@@ -1188,6 +1188,12 @@ patch: ${JSON.stringify(
         this.run_selected = () => {
             return this.actions.set_and_run_multiple(this.state.selected_cells)
         }
+        this.fold_selected = () => {
+            if (_.isEmpty(this.state.selected_cells)) return
+            const any_unfolded = this.state.selected_cells.some((cell_id) => !this.state.notebook.cell_inputs[cell_id].code_folded)
+            const new_val = any_unfolded
+            return this.actions.fold_remote_cells(this.state.selected_cells, new_val)
+        }
         this.move_selected = (/** @type {KeyboardEvent} */ e, /** @type {1|-1} */ delta) => {
             if (this.state.selected_cells.length > 0) {
                 const current_indices = this.state.selected_cells.map((id) => this.state.notebook.cell_order.indexOf(id))
@@ -1253,6 +1259,8 @@ patch: ${JSON.stringify(
                     // TODO: let user know that the notebook autosaves
                 }
                 e.preventDefault()
+            } else if (e.key?.toLowerCase() === "k" && has_ctrl_or_cmd_pressed(e)) {
+                this.fold_selected()
             } else if (e.key === "Backspace" || e.key === "Delete") {
                 if (this.delete_selected("Delete")) {
                     e.preventDefault()

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -1188,10 +1188,8 @@ patch: ${JSON.stringify(
         this.run_selected = () => {
             return this.actions.set_and_run_multiple(this.state.selected_cells)
         }
-        this.fold_selected = () => {
+        this.fold_selected = (new_val) => {
             if (_.isEmpty(this.state.selected_cells)) return
-            const any_unfolded = this.state.selected_cells.some((cell_id) => !this.state.notebook.cell_inputs[cell_id].code_folded)
-            const new_val = any_unfolded
             return this.actions.fold_remote_cells(this.state.selected_cells, new_val)
         }
         this.move_selected = (/** @type {KeyboardEvent} */ e, /** @type {1|-1} */ delta) => {
@@ -1259,8 +1257,8 @@ patch: ${JSON.stringify(
                     // TODO: let user know that the notebook autosaves
                 }
                 e.preventDefault()
-            } else if (e.key?.toLowerCase() === "k" && has_ctrl_or_cmd_pressed(e)) {
-                this.fold_selected()
+            } else if (["BracketLeft", "BracketRight"].includes(e.code) && (is_mac_keyboard ? e.altKey && e.metaKey : e.ctrlKey && e.shiftKey)) {
+                this.fold_selected(e.code === "BracketLeft")
             } else if (e.key === "Backspace" || e.key === "Delete") {
                 if (this.delete_selected("Delete")) {
                     e.preventDefault()

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -1887,7 +1887,8 @@ pluto-input > .preview_hidden_code_info {
     pointer-events: none;
 }
 
-body:not(.process_waiting_for_permission) pluto-cell.code_folded pluto-input > .preview_hidden_code_info {
+body:not(.process_waiting_for_permission) pluto-cell.code_folded pluto-input > .preview_hidden_code_info,
+pluto-cell.code_folded:focus-within pluto-input > .preview_hidden_code_info {
     display: block;
 }
 


### PR DESCRIPTION
Fix #2917

The implemented keyboard shortcut is ~**`Ctrl/Cmd + K`**~

MacOS: `⌥⌘[` to fold, `⌥⌘]` to unfold
Windows/Linx: `Ctrl+Shift+[` to fold, `Ctrl+Shift+]` to unfold

Loosely matching VS Code

You can do this while editing a cell, or with multiple cells selected

I also made #2920 to make it more clear that folding the cell does not hide the code yet because you are still focused on the codemirror.