### PR TITLE
🐡 Better error message when package fails to load

### DIFF
--- a/frontend/components/BottomRightPanel.js
+++ b/frontend/components/BottomRightPanel.js
@@ -2,7 +2,7 @@ import { html, useState, useRef, useEffect, useMemo } from "../imports/Preact.js
 import { cl } from "../common/ClassTable.js"
 
 import { LiveDocsTab } from "./LiveDocsTab.js"
-import { is_finished, ProcessTab, total_done, total_tasks, useStatusItem } from "./ProcessTab.js"
+import { is_finished, StatusTab, total_done, total_tasks, useStatusItem } from "./StatusTab.js"
 import { useMyClockIsAheadBy } from "../common/clock sync.js"
 import { BackendLaunchPhase } from "../common/Binder.js"
 import { useEventListener } from "../common/useEventListener.js"
@@ -140,7 +140,7 @@ export let BottomRightPanel = ({
                           sanitize_html=${sanitize_html}
                       />`
                     : open_tab === "process"
-                    ? html`<${ProcessTab}
+                    ? html`<${StatusTab}
                           notebook=${notebook}
                           backend_launch_logs=${backend_launch_logs}
                           my_clock_is_ahead_by=${my_clock_is_ahead_by}

--- a/frontend/components/ErrorMessage.js
+++ b/frontend/components/ErrorMessage.js
@@ -5,6 +5,7 @@ import { html, useContext, useEffect, useLayoutEffect, useRef, useState } from "
 import { pluto_syntax_colors } from "./CellInput.js"
 import { highlight } from "./CellOutput.js"
 import { Editor } from "./Editor.js"
+import { PkgTerminalView } from "./PkgTerminalView.js"
 
 const extract_cell_id = (/** @type {string} */ file) => {
     const sep_index = file.indexOf("#==#")
@@ -298,6 +299,26 @@ export const ErrorMessage = ({ msg, stacktrace, cell_id }) => {
                 const erred_upstreams = get_erred_upstreams(pluto_actions.get_notebook(), cell_id)
                 return Object.keys(erred_upstreams).length === 0
             },
+        },
+        {
+            pattern: /^ArgumentError: Package (.*) not found in current path/,
+            display: (/** @type{string} */ x) => {
+                const match = x.match(/^ArgumentError: Package (.*) not found in current path/)
+                const package_name = (match?.[1] ?? "").replaceAll("`", "")
+
+                const pkg_terminal_value = pluto_actions.get_notebook()?.nbpkg?.terminal_outputs?.[package_name]
+
+                return html`<p>The package <strong>${package_name}.jl</strong> could not load because it failed to initialize.</p>
+                    <p>That's not nice! Things you could try:</p>
+                    <ul>
+                        <li>Restart the notebook.</li>
+                        <li>Try a different Julia version.</li>
+                        <li>Contact the developers of ${package_name}.jl about this error.</li>
+                    </ul>
+                    <p>You might find useful information in the package installation log:</p>
+                    <${PkgTerminalView} value=${pkg_terminal_value} />`
+            },
+            show_stacktrace: () => false,
         },
         default_rewriter,
     ]

--- a/frontend/components/NotifyWhenDone.js
+++ b/frontend/components/NotifyWhenDone.js
@@ -1,7 +1,7 @@
 import { html, useEffect, useState } from "../imports/Preact.js"
 
 import { cl } from "../common/ClassTable.js"
-import { is_finished, total_done } from "./ProcessTab.js"
+import { is_finished, total_done } from "./StatusTab.js"
 import { useDelayedTruth } from "./BottomRightPanel.js"
 import { url_logo_small } from "./Editor.js"
 import { open_pluto_popup } from "../common/open_pluto_popup.js"

--- a/frontend/components/StatusTab.js
+++ b/frontend/components/StatusTab.js
@@ -14,7 +14,7 @@ import { NotifyWhenDone } from "./NotifyWhenDone.js"
  * my_clock_is_ahead_by: number,
  * }} props
  */
-export let ProcessTab = ({ status, notebook, backend_launch_logs, my_clock_is_ahead_by }) => {
+export const StatusTab = ({ status, notebook, backend_launch_logs, my_clock_is_ahead_by }) => {
     return html`
         <section>
             <${StatusItem}

--- a/frontend/components/StatusTab.js
+++ b/frontend/components/StatusTab.js
@@ -123,14 +123,14 @@ const StatusItem = ({ status_tree, path, my_clock_is_ahead_by, nbpkg, backend_la
     const busy_time = Math.max(local_busy_time, mytime - start - (mystatus.timing === "local" ? 0 : my_clock_is_ahead_by))
 
     useEffect(() => {
-        if (busy) {
+        if (busy || mystatus.success === false) {
             let handle = setTimeout(() => {
                 set_is_open(true)
             }, Math.max(100, 500 - path.length * 200))
 
             return () => clearTimeout(handle)
         }
-    }, [busy])
+    }, [busy || mystatus.success === false])
 
     useEffectWithPrevious(
         ([old_finished]) => {

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -2095,12 +2095,15 @@ pkg-terminal > .scroller {
     width: 100%;
 }
 
-pkg-terminal pre {
+body pkg-terminal:not(.asdf) pre:not(.asdf) {
     white-space: pre-wrap;
     word-break: break-all;
     font-size: 0.6rem;
     font-family: "Space Mono", monospace;
+    font-variant-ligatures: none;
     margin: 0;
+    color: inherit;
+    background: none;
 }
 
 pkg-terminal .make-me-spin {

--- a/src/packages/IOListener.jl
+++ b/src/packages/IOListener.jl
@@ -54,3 +54,11 @@ freeze_loading_spinners(s::AbstractString) = _replaceall(s, '◑' => '◐', '◒
 
 _replaceall(s, p) = replace(s, p)
 _replaceall(s, p, ps...) = @static VERSION >= v"1.7" ? replace(s, p, ps...) : _replaceall(replace(s, p), ps...)
+
+phasemessage(iolistener, phase::String) = phasemessage(iolistener.buffer, phase)
+function phasemessage(io::IO, phase::String)
+    ioc = IOContext(io, :color=>true)
+    printstyled(ioc, "\n$phase...\n"; bold=true)
+    printstyled(ioc, "===\n"; color=:light_black)
+end
+

--- a/src/packages/IOListener.jl
+++ b/src/packages/IOListener.jl
@@ -13,7 +13,7 @@ Base.@kwdef struct IOListener
 end
 
 function trigger(listener::IOListener)
-    if isreadable(listener.buffer)
+    if !eof(listener.buffer) && isreadable(listener.buffer)
         newdata = readavailable(listener.buffer)
         isempty(newdata) && return
         s = String(newdata)

--- a/src/packages/precompile_isolated.jl
+++ b/src/packages/precompile_isolated.jl
@@ -36,7 +36,7 @@ function precompile_isolated(
         ))
     catch e
         if e isa ProcessFailedException
-            error("Precompilation failed\n\n$(String(take!(stderr_buffer)))")
+            throw(PrecompilationFailedException("Precompilation failed\n\n$(String(take!(stderr_buffer)))"))
         else
             rethrow(e)
         end
@@ -46,6 +46,10 @@ function precompile_isolated(
     
     # In the future we could allow interrupting the precompilation process (e.g. when the notebook is shut down)
     # by running this code using Malt.jl
+end
+
+struct PrecompilationFailedException <: Exception
+    msg::String
 end
 
 # Create a new IO object that redirects all writes to the given capture IOs. It's like the `tee` linux command. Return a named tuple with the IO object and a function to close it which you should not forget to call.

--- a/src/webserver/Status.jl
+++ b/src/webserver/Status.jl
@@ -77,11 +77,15 @@ report_business_started!(parent::Business, name::Symbol) = get_child(parent, nam
 report_business_planned!(parent::Business, name::Symbol) = get_child(parent, name)
 
 
-report_business!(f::Function, parent::Business, args...) = try
-    report_business_started!(parent, args...)
-    f()
-finally
-    report_business_finished!(parent, args...)
+function report_business!(f::Function, parent::Business, name::Symbol)
+    local success = false
+    try
+        report_business_started!(parent, name)
+        f()
+        success = true
+    finally
+        report_business_finished!(parent, name, success)
+    end
 end
 
 delete_business!(business::Business, name::Symbol) = lock(business.lock) do


### PR DESCRIPTION
Changes:
- `stderr` content from the precompilation process is captured and displayed in the Pkg log. It used to only show in the terminal that launched Pluto.
- A new error rewriter in the frontend that detects the standard error message and replaces it with something more useful, also displaying a copy of the Pkg terminal with the error mesage for that package. This also hides the advice to `Pkg.add` the package which is wrong and would lead to problems.
- The "precompile" status entry now shows in red if the precomp process failed

# Before

<img width="584" alt="image" src="https://github.com/fonsp/Pluto.jl/assets/6933510/a15167db-4116-4967-9871-56b92f0d0258">

# After
<img width="609" alt="image" src="https://github.com/fonsp/Pluto.jl/assets/6933510/61672477-ff65-44a5-9870-ed49abc6a581">
