### PR TITLE
Add featured notebooks from plutojl.org/en/docs

### DIFF
--- a/frontend/featured_sources.js
+++ b/frontend/featured_sources.js
@@ -12,5 +12,11 @@ export default {
             url: "https://cdn.jsdelivr.net/gh/JuliaPluto/featured@v5/pluto_export.json",
             integrity: "sha256-+zI9b/gHEIJGV/DrckBY85hkxNWGIewgYffkAkEq4/w=",
         },
+        {
+            url: "https://plutojl.org/pluto_export.json",
+            // this is one month before the expiry date of our domain registration at njal.la
+            valid_until: "2025-10",
+            id: "pluto website",
+        },
     ],
 }


### PR DESCRIPTION
This adds some notebooks from plutojl.org/en/docs as extra featured notebooks

<img width="801" alt="image" src="https://github.com/fonsp/Pluto.jl/assets/6933510/8b5d0302-e12e-4fb4-8fd8-39a07718b96f">
