### PR TITLE
Autocomplete-on-type by default on Mac

### DIFF
--- a/frontend/common/KeyboardShortcuts.js
+++ b/frontend/common/KeyboardShortcuts.js
@@ -1,4 +1,5 @@
-export let is_mac_keyboard = /Mac/.test(navigator.platform)
+// @ts-ignore
+export let is_mac_keyboard = /Mac/i.test(navigator.userAgentData.platform ?? navigator.platform)
 
 export let control_name = is_mac_keyboard ? "⌃" : "Ctrl"
 export let ctrl_or_cmd_name = is_mac_keyboard ? "⌘" : "Ctrl"

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -65,7 +65,7 @@ import { is_mac_keyboard } from "../common/KeyboardShortcuts.js"
 export const ENABLE_CM_MIXED_PARSER = window.localStorage.getItem("ENABLE_CM_MIXED_PARSER") === "true"
 export const ENABLE_CM_SPELLCHECK = window.localStorage.getItem("ENABLE_CM_SPELLCHECK") === "true"
 export const ENABLE_CM_AUTOCOMPLETE_ON_TYPE =
-    window.localStorage.getItem("ENABLE_CM_AUTOCOMPLETE_ON_TYPE") ?? (/Mac/.test(navigator.platform) ? "true" : "false") === "true"
+    (window.localStorage.getItem("ENABLE_CM_AUTOCOMPLETE_ON_TYPE") ?? (/Mac/.test(navigator.platform) ? "true" : "false")) === "true"
 
 if (ENABLE_CM_MIXED_PARSER) {
     console.log(`YOU ENABLED THE CODEMIRROR MIXED LANGUAGE PARSER

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -60,10 +60,12 @@ import { timeout_promise } from "../common/PlutoConnection.js"
 import { LastFocusWasForcedEffect, tab_help_plugin } from "./CellInput/tab_help_plugin.js"
 import { useEventListener } from "../common/useEventListener.js"
 import { moveLineDown } from "../imports/CodemirrorPlutoSetup.js"
+import { is_mac_keyboard } from "../common/KeyboardShortcuts.js"
 
 export const ENABLE_CM_MIXED_PARSER = window.localStorage.getItem("ENABLE_CM_MIXED_PARSER") === "true"
 export const ENABLE_CM_SPELLCHECK = window.localStorage.getItem("ENABLE_CM_SPELLCHECK") === "true"
-export const ENABLE_CM_AUTOCOMPLETE_ON_TYPE = window.localStorage.getItem("ENABLE_CM_AUTOCOMPLETE_ON_TYPE") === "true"
+export const ENABLE_CM_AUTOCOMPLETE_ON_TYPE =
+    window.localStorage.getItem("ENABLE_CM_AUTOCOMPLETE_ON_TYPE") ?? (/Win/.test(navigator.platform) ? "true" : "false") === "true"
 
 if (ENABLE_CM_MIXED_PARSER) {
     console.log(`YOU ENABLED THE CODEMIRROR MIXED LANGUAGE PARSER

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -65,7 +65,7 @@ import { is_mac_keyboard } from "../common/KeyboardShortcuts.js"
 export const ENABLE_CM_MIXED_PARSER = window.localStorage.getItem("ENABLE_CM_MIXED_PARSER") === "true"
 export const ENABLE_CM_SPELLCHECK = window.localStorage.getItem("ENABLE_CM_SPELLCHECK") === "true"
 export const ENABLE_CM_AUTOCOMPLETE_ON_TYPE =
-    window.localStorage.getItem("ENABLE_CM_AUTOCOMPLETE_ON_TYPE") ?? (/Win/.test(navigator.platform) ? "true" : "false") === "true"
+    window.localStorage.getItem("ENABLE_CM_AUTOCOMPLETE_ON_TYPE") ?? (/Mac/.test(navigator.platform) ? "true" : "false") === "true"
 
 if (ENABLE_CM_MIXED_PARSER) {
     console.log(`YOU ENABLED THE CODEMIRROR MIXED LANGUAGE PARSER


### PR DESCRIPTION
This enables #2389 by default on Mac as part of a phased roll-out.

This is not because I like Mac the most but because they have the smallest share of our users (20%), which means that this is the least risky group to test on :) 