### PR TITLE
Support mixed use of `_` and `-` in launch parameter HTML attributes

### DIFF
--- a/frontend/editor.js
+++ b/frontend/editor.js
@@ -32,7 +32,7 @@ const truthy = (x) => x === "" || x === "true"
 const falsey = (x) => x === "false"
 
 const from_attribute = (element, name) => {
-    const val = element.getAttribute(name)
+    const val = element.getAttribute(name) ?? element.getAttribute(name.replaceAll("_", "-"))
     if (name === "disable_ui") {
         return truthy(val) ? true : falsey(val) ? false : null
     } else if (name === "isolated_cell_id") {


### PR DESCRIPTION
The latest version of PlutoPages.jl has a bug where the slider_server_url setting is ignored. See https://github.com/JuliaPluto/PlutoPages.jl/issues/1

This is because of this commit:

https://github.com/JuliaPluto/PlutoPages.jl/commit/089080319eea6f530dc200ad29a0d5bf9b12c178

where the attributes are now passed to HypertextLiteral as a named tuple. The problem is that HypertextLiteral converts `_` to `-` in attribute names (probably because this is better). You can see it in the HTML:

<img width="150" alt="image" src="https://github.com/user-attachments/assets/e375c5cb-3e09-4ec6-b54b-5341abac95d5">

This PR adds a patch to Pluto to also read attributes that use `-` in the name instead of `_`.

This will fix https://github.com/JuliaPluto/PlutoPages.jl/issues/1