### PR TITLE
Run basic test on firefox

### DIFF
--- a/.github/workflows/FrontendTest.yml
+++ b/.github/workflows/FrontendTest.yml
@@ -1,4 +1,4 @@
-name: Pluto frontend tests
+name: Chrome frontend tests
 
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the main branch

--- a/.github/workflows/TestFirefox.yml
+++ b/.github/workflows/TestFirefox.yml
@@ -84,11 +84,16 @@ jobs:
             
             @info "Starting firefox..."
             browser_process = @async run(`${{ steps.setup-firefox.outputs.firefox-path }} -headless -private-window $(url)`)
+            
+            tstart = time()
 
             begin
               while get_x() == "missing"
                 @info "Waiting..."
                 sleep(1)
+                if time() - tstart > 30
+                  error("This took too long!")
+                end
               end
               
               @info "yay it worked!" get_x()

--- a/.github/workflows/TestFirefox.yml
+++ b/.github/workflows/TestFirefox.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        firefox: ['latest-esr', 'latest']
+        firefox: ['latest-esr'] #, 'latest']
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4

--- a/.github/workflows/TestFirefox.yml
+++ b/.github/workflows/TestFirefox.yml
@@ -79,10 +79,11 @@ jobs:
 
             process = Pluto.run!(sesh)
 
-            @info "Server started..."
+            @info "Server started"
             sleep(3)
             
-            browser_process = @async run(`${{ steps.setup-firefox.outputs.firefox-path }} -private-window $(url)`)
+            @info "Starting firefox..."
+            browser_process = @async run(`${{ steps.setup-firefox.outputs.firefox-path }} -headless -private-window $(url)`)
 
             begin
               while get_x() == "missing"

--- a/.github/workflows/TestFirefox.yml
+++ b/.github/workflows/TestFirefox.yml
@@ -1,0 +1,97 @@
+name: Firefox basic launch test
+
+# same as the frontend tests
+on:
+    push:
+        paths-ignore:
+            - "**.md"
+        branches:
+            - main
+            - release
+    pull_request:
+        paths-ignore:
+            - "**.md"
+        branches-ignore:
+            - release
+
+
+jobs:
+  firefox-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      matrix:
+        firefox: ['latest-esr', 'latest']
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+
+      # Makes thes `julia` command available
+      - uses: julia-actions/setup-julia@v1
+        with:
+            version: "1.6" # our lowest supported version
+
+      - name: Install Pluto.jl packages
+        run: |
+            julia --project=$GITHUB_WORKSPACE -e "using Pkg; Pkg.instantiate()"
+
+      - name: Setup firefox
+        id: setup-firefox
+        uses: browser-actions/setup-firefox@v1
+        with:
+          firefox-version: ${{ matrix.firefox }}
+
+      - run: |
+          echo Installed firefox versions: ${{ steps.setup-firefox.outputs.firefox-version }}
+          ${{ steps.setup-firefox.outputs.firefox-path }} --version
+
+      - run: |
+          julia --project=$GITHUB_WORKSPACE -e 'import Pluto
+
+            nb = Pluto.Notebook([
+              Pluto.Cell("Text(x)"),
+              Pluto.Cell("""
+            @bind x html"\""
+            <script>
+            currentScript.value = "hello from " + navigator.userAgent
+            currentScript.dispatchEvent(new CustomEvent("input"))
+            </script>
+            "\""
+              """)
+            ])
+
+            sesh = Pluto.ServerSession()
+
+            Pluto.SessionActions.add(sesh, nb)
+
+            @info "Running notebook..."
+            Pluto.update_save_run!(sesh, nb, nb.cells; run_async=false)
+            @info "Running notebook done"
+
+
+            get_x() = nb.cells[1].output.body
+
+            @info "Value before" get_x()
+
+            sesh.options.server.port = 1235
+
+            url = "http://localhost:$(sesh.options.server.port)/edit?secret=$(sesh.secret)&id=$(nb.notebook_id)"
+
+            process = Pluto.run!(sesh)
+
+            @info "Server started..."
+            sleep(3)
+            
+            browser_process = @async run(`${{ steps.setup-firefox.outputs.firefox-path }} -private-window $(url)`)
+
+            begin
+              while get_x() == "missing"
+                @info "Waiting..."
+                sleep(1)
+              end
+              
+              @info "yay it worked!" get_x()
+            end'
+
+
+


### PR DESCRIPTION
I think running all the frontend tests on firefox will cause too much debugging headache, so here is a github action that just runs a Pluto notebook with this code:

```julia
@bind x html"""
<script>
currentScript.value = "hello from " + navigator.userAgent
currentScript.dispatchEvent(new CustomEvent("input"))
</script>
"""
```

```julia
x
```

And it launches a firefox process. When the tab opens, the bond value is set, and the test finishes.