### PR TITLE
Add support for custom name in `@progress` (ProgressLogging.jl)

### DIFF
--- a/frontend/components/Logs.js
+++ b/frontend/components/Logs.js
@@ -88,7 +88,13 @@ export const Logs = ({ logs, line_heights, set_cm_highlighted_line, sanitize_htm
     `
 }
 
-const Progress = ({ progress }) => {
+const Progress = ({ name, progress }) => {
+    console.log("Progress Name: ", name)
+    return html`<pluto-progress-name class=${name === "" ? "no_name" : null}>${name}</pluto-progress-name>
+        <pluto-progress-bar-container><${ProgressBar} progress=${progress} /></pluto-progress-bar-container>`
+}
+
+const ProgressBar = ({ progress }) => {
     const bar_ref = useRef(/** @type {HTMLElement?} */ (null))
 
     useLayoutEffect(() => {
@@ -136,7 +142,7 @@ const Dot = ({ set_cm_highlighted_line, msg, kwargs, y, level, sanitize_html }) 
         <pluto-log-icon></pluto-log-icon>
         <pluto-log-dot class=${level}
             >${is_progress
-                ? html`<${Progress} progress=${progress} />`
+                ? html`<${Progress} name="${msg[0]}" progress=${progress} />`
                 : is_stdout
                 ? html`<${MoreInfo}
                           body=${html`${"This text was written to the "}

--- a/frontend/components/Logs.js
+++ b/frontend/components/Logs.js
@@ -89,8 +89,7 @@ export const Logs = ({ logs, line_heights, set_cm_highlighted_line, sanitize_htm
 }
 
 const Progress = ({ name, progress }) => {
-    console.log("Progress Name: ", name)
-    return html`<pluto-progress-name class=${name === "" ? "no_name" : null}>${name}</pluto-progress-name>
+    return html`<pluto-progress-name>${name}</pluto-progress-name>
         <pluto-progress-bar-container><${ProgressBar} progress=${progress} /></pluto-progress-bar-container>`
 }
 

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -3090,6 +3090,9 @@ pluto-log-dot-positioner.Debug {
     --accent-color: var(--pluto-logs-debug-accent-color);
     --icon-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/information-circle-outline.svg");
 }
+pluto-log-dot-positioner.Progress {
+    --icon-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/sync-outline.svg");
+}
 pluto-log-dot-positioner.Stdout {
     --icon-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/terminal-outline.svg");
 }

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -2991,11 +2991,10 @@ pluto-logs-container pluto-progress-bar-container {
     border-radius: 6px;
     background: var(--pluto-logs-progress-bg);
     font-size: 0.7rem;
-    width: 100%;
+    flex: 0 1 200px;
 }
 
 pluto-logs-container pluto-progress-name {
-    align-self: center;
     white-space: pre-wrap;
     font-family: var(--julia-mono-font-stack);
     font-size: 0.8rem;
@@ -3119,10 +3118,9 @@ pluto-log-dot-positioner.Stdout pluto-log-icon::before {
 
 pluto-log-dot.Progress {
     padding: 0px;
-    flex: 0 1 200px;
     display: flex;
     flex-direction: row;
-    align-items: stretch;
+    align-items: center;
     align-self: center;
 }
 pluto-log-dot.Stdout {

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -3001,7 +3001,7 @@ pluto-logs-container pluto-progress-name {
     font-variant-ligatures: none;
     padding: 0 0.4rem 0 0.1rem;
 }
-pluto-logs-container pluto-progress-name.no_name {
+pluto-logs-container pluto-progress-name:empty {
     padding: 0;
 }
 
@@ -3105,9 +3105,6 @@ pluto-log-dot-positioner.Debug {
     --bg-color: var(--pluto-logs-debug-color);
     --accent-color: var(--pluto-logs-debug-accent-color);
     --icon-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/information-circle-outline.svg");
-}
-pluto-log-dot-positioner.Progress {
-    --icon-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/sync-outline.svg");
 }
 pluto-log-dot-positioner.Stdout {
     --icon-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/terminal-outline.svg");

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -2984,10 +2984,6 @@ pluto-logs-container > header {
     /* background: #494949; */
 }
 
-pluto-logs-container pluto-progress-bars pluto-progress:not(:first-child) {
-    margin-top: 10px;
-}
-
 pluto-logs-container pluto-progress-bar-container {
     overflow: hidden;
     outline: 3px solid var(--pluto-logs-progress-border);

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -2988,12 +2988,33 @@ pluto-logs-container pluto-progress-bars pluto-progress:not(:first-child) {
     margin-top: 10px;
 }
 
+pluto-logs-container pluto-progress-bar-container {
+    overflow: hidden;
+    outline: 3px solid var(--pluto-logs-progress-border);
+    outline-offset: -2px;
+    border-radius: 6px;
+    background: var(--pluto-logs-progress-bg);
+    font-size: 0.7rem;
+    width: 100%;
+}
+
+pluto-logs-container pluto-progress-name {
+    align-self: center;
+    white-space: pre-wrap;
+    font-family: var(--julia-mono-font-stack);
+    font-size: 0.8rem;
+    font-variant-ligatures: none;
+    padding: 0 0.4rem 0 0.1rem;
+}
+pluto-logs-container pluto-progress-name.no_name {
+    padding: 0;
+}
+
 pluto-logs-container pluto-progress-bar {
     --c: var(--pluto-logs-progress-fill);
     padding: 0.3em 0.6em;
     background: linear-gradient(90deg, var(--c), var(--c));
     background-repeat: no-repeat;
-    width: 100%;
     transition: background-size cubic-bezier(0.14, 0.71, 0, 0.99) 0.5s, opacity linear 0.2s;
     display: grid;
     align-items: center;
@@ -3101,18 +3122,12 @@ pluto-log-dot-positioner.Stdout pluto-log-icon::before {
 }
 
 pluto-log-dot.Progress {
-    overflow: hidden;
     padding: 0px;
     flex: 0 1 200px;
     display: flex;
     flex-direction: row;
     align-items: stretch;
     align-self: center;
-    outline: 3px solid var(--pluto-logs-progress-border);
-    outline-offset: -2px;
-    border-radius: 6px;
-    background: var(--pluto-logs-progress-bg);
-    font-size: 0.7rem;
 }
 pluto-log-dot.Stdout {
     --inner: hsl(36deg 20% 37%);


### PR DESCRIPTION
This PR adds support for the visualization of custom names of progress bars created with `@progress` from ProgressLogging.

I also added a small sync icon to the logs of ProgressLogging as there was no icon at the moment.

## Before this PR
![image](https://github.com/user-attachments/assets/1f2dc2a1-013b-4c3a-9ebf-eb5cbfa6d3f3)

## After the PR:
![image](https://github.com/user-attachments/assets/059a4302-7615-4149-ba41-4982c1ab8e02)
