### PR TITLE
Speedup large notebooks: fix cache miss in `notebook_to_js`

### DIFF
--- a/src/notebook/Notebook.jl
+++ b/src/notebook/Notebook.jl
@@ -31,7 +31,7 @@ Base.@kwdef mutable struct Notebook
     path::String
     notebook_id::UUID=uuid1()
     topology::NotebookTopology
-    _cached_topological_order::Union{Nothing,TopologicalOrder}=nothing
+    _cached_topological_order::TopologicalOrder
     _cached_cell_dependencies_source::Union{Nothing,NotebookTopology}=nothing
 
     # buffer will contain all unfetched updates - must be big enough
@@ -96,10 +96,12 @@ function Notebook(cells::Vector{Cell}, @nospecialize(path::AbstractString), note
         (cell.cell_id, cell)
     end)
     cell_order=map(x -> x.cell_id, cells)
+    topology = _initial_topology(cells_dict, cell_order)
     Notebook(;
         cells_dict,
         cell_order,
-        topology=_initial_topology(cells_dict, cell_order),
+        topology,
+        _cached_topological_order=topological_order(topology),
         path,
         notebook_id
     )

--- a/src/notebook/Notebook.jl
+++ b/src/notebook/Notebook.jl
@@ -117,7 +117,14 @@ function Base.getproperty(notebook::Notebook, property::Symbol)
     end
 end
 
-PlutoDependencyExplorer.topological_order(notebook::Notebook) = topological_order(notebook.topology)
+function PlutoDependencyExplorer.topological_order(notebook::Notebook)
+    cached = notebook._cached_topological_order
+	if cached === nothing || cached.input_topology !== notebook.topology
+        topological_order(notebook.topology)
+	else
+		cached
+	end
+end
 
 function PlutoDependencyExplorer.where_referenced(notebook::Notebook, topology::NotebookTopology, something)
     # can't use @deprecate on an overload

--- a/src/notebook/saving and loading.jl
+++ b/src/notebook/saving and loading.jl
@@ -319,13 +319,15 @@ function load_notebook_nobackup(@nospecialize(io::IO), @nospecialize(path::Abstr
     appeared_cells_dict = filter(collected_cells) do (k, v)
         k ∈ appeared_order
     end
+    topology = _initial_topology(appeared_cells_dict, appeared_order)
 
     Notebook(;
         cells_dict=appeared_cells_dict,
         cell_order=appeared_order,
-        topology=_initial_topology(appeared_cells_dict, appeared_order),
-        path=path,
-        nbpkg_ctx=nbpkg_ctx,
+        topology,
+        _cached_topological_order=topological_order(topology),
+        path,
+        nbpkg_ctx,
         nbpkg_installed_versions_cache=nbpkg_cache(nbpkg_ctx),
         metadata=notebook_metadata,
     )

--- a/src/webserver/Dynamic.jl
+++ b/src/webserver/Dynamic.jl
@@ -167,7 +167,7 @@ function notebook_to_js(notebook::Notebook)
             )
         end,
         "status_tree" => Status.tojs(notebook.status_tree),
-        "cell_execution_order" => cell_id.(collect(topological_order(notebook))),
+        "cell_execution_order" => cell_id.(collect(notebook._cached_topological_order)),
     )
 end
 


### PR DESCRIPTION
Fix #2958 

We accidentally removed a caching system in https://github.com/fonsp/Pluto.jl/commit/2183b0aaae03bd98cc393e82fffdf8bc0331500c#diff-def3c256c1eef2beff41b35619e1d28209bf7cbb56c223d408f6cf53ed98582dL139-R137 in 0.19.37 that led to a big slowdown in `notebook_to_js` for large notebooks.

This brings the `notebook_to_js` time for a big notebook from `250ms` to `1.85ms`. 

I also changed the `notebook_to_js` to always use the cached topological order, even if a newer one is possible. Just because this field `cell_execution_order` is not even used by us, it's just there for future experiments.