### PR TITLE
Backend performance: delete stale connections

### DIFF
--- a/frontend/common/PlutoConnection.js
+++ b/frontend/common/PlutoConnection.js
@@ -266,7 +266,7 @@ const default_ws_address = () => ws_address_from_base(window.location.href)
  *
  * @param {{
  *  on_unrequested_update: (message: PlutoMessage, by_me: boolean) => void,
- *  on_reconnect: () => boolean,
+ *  on_reconnect: () => Promise<boolean>,
  *  on_connection_status: (connection_status: boolean, hopeless: boolean) => void,
  *  connect_metadata?: Object,
  *  ws_address?: String,
@@ -377,7 +377,7 @@ export const create_pluto_connection = async ({
                     await connect() // reconnect!
 
                     console.log(`Starting state sync`, new Date().toLocaleTimeString())
-                    const accept = on_reconnect()
+                    const accept = await on_reconnect()
                     console.log(`State sync ${accept ? "" : "not "}successful`, new Date().toLocaleTimeString())
                     on_connection_status(accept, false)
                     if (!accept) {

--- a/frontend/common/PlutoConnection.js
+++ b/frontend/common/PlutoConnection.js
@@ -108,6 +108,7 @@ const create_ws_connection = (address, { on_message, on_socket_close }, timeout_
 
         const send_encoded = (message) => {
             const encoded = pack(message)
+            if (socket.readyState === WebSocket.CLOSED || socket.readyState === WebSocket.CLOSING) throw new Error("Socket is closed")
             socket.send(encoded)
         }
 

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -461,8 +461,6 @@ export const CellInput = ({
         if (show_static_fake) return
         if (dom_node_ref.current == null) return
 
-        console.log("Rendering cell input", cell_id)
-
         const keyMapSubmit = (/** @type {EditorView} */ cm) => {
             autocomplete.closeCompletion(cm)
             on_submit()

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -861,7 +861,6 @@ patch: ${JSON.stringify(
                 backend_launch_phase: this.state.backend_launch_phase == null ? null : BackendLaunchPhase.ready,
             })
 
-            // TODO Do this from julia itself
             this.client.send("complete", { query: "sq" }, { notebook_id: this.state.notebook.notebook_id })
             this.client.send("complete", { query: "\\sq" }, { notebook_id: this.state.notebook.notebook_id })
 
@@ -893,8 +892,17 @@ patch: ${JSON.stringify(
             }
         }
 
-        const on_reconnect = () => {
+        const on_reconnect = async () => {
             console.warn("Reconnected! Checking states")
+
+            await this.client.send(
+                "reset_shared_state",
+                {},
+                {
+                    notebook_id: this.state.notebook.notebook_id,
+                },
+                false
+            )
 
             return true
         }

--- a/frontend/components/welcome/Welcome.js
+++ b/frontend/components/welcome/Welcome.js
@@ -68,7 +68,7 @@ export const Welcome = ({ launch_params }) => {
         const client_promise = create_pluto_connection({
             on_unrequested_update: on_update,
             on_connection_status: on_connection_status,
-            on_reconnect: () => true,
+            on_reconnect: async () => true,
             ws_address: launch_params.pluto_server_url ? ws_address_from_base(launch_params.pluto_server_url) : undefined,
         })
         client_promise.then(async (client) => {


### PR DESCRIPTION
After a client disconnects, Pluto continues to calculate and send updates for that client. This can be a performance problem: on every refresh of a notebook, the update logic becomes slower.

This PR fixes that, and removes clients from memory after their websocket disconnects.

This PR also updates the frontend's reconnecting logic. This is currently not implemented (and incorrect: all updates while disconnected are ignored). I replaced it with a call to `reset_shared_state`. 

# TOOD
- [x] test reconnecting logic 


# Reconnecting:

https://github.com/user-attachments/assets/fd44b1ce-4c74-4dd7-be5c-f124b187a870


