### PR TITLE
Fix intermediate bond values again

### DIFF
--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -805,7 +805,9 @@ patch: ${JSON.stringify(
                         const set_waiting = () => {
                             let from_update = message?.response?.update_went_well != null
                             let is_just_acknowledgement = from_update && message.patches.length === 0
-                            // console.log("Received patches!", message.patches, message.response, is_just_acknowledgement)
+                            let is_relevant_for_bonds = message.patches.some(({ path }) => path.length === 0 || path[0] !== "status_tree")
+
+                            // console.debug("Received patches!", is_just_acknowledgement, is_relevant_for_bonds, message.patches, message.response)
 
                             if (!is_just_acknowledgement) {
                                 this.waiting_for_bond_to_trigger_execution = false

--- a/sample/test_bind_dynamics.jl
+++ b/sample/test_bind_dynamics.jl
@@ -1,0 +1,91 @@
+### A Pluto.jl notebook ###
+# v0.19.45
+
+using Markdown
+using InteractiveUtils
+
+# This Pluto notebook uses @bind for interactivity. When running this notebook outside of Pluto, the following 'mock version' of @bind gives bound variables a default value (instead of an error).
+macro bind(def, element)
+    quote
+        local iv = try Base.loaded_modules[Base.PkgId(Base.UUID("6e696c72-6542-2067-7265-42206c756150"), "AbstractPlutoDingetjes")].Bonds.initial_value catch; b -> missing; end
+        local el = $(esc(element))
+        global $(esc(def)) = Core.applicable(Base.get, el) ? Base.get(el) : iv(el)
+        el
+    end
+end
+
+# ╔═╡ a0fe4e4d-eee5-4420-bd58-3f12749a9ed1
+@bind reset_xs html"<input id=resetxs type=button value=reset_xs>"
+
+# ╔═╡ 58db6bd4-58a6-11ef-3795-fd6e57eceb68
+@bind x html"""<div>
+<script>
+const div = currentScript.parentElement
+const btn = div.querySelector("button")
+
+let start_time = 0
+let max_duration = 1000
+
+const set = (x) => {
+		div.value = x
+		div.dispatchEvent(new CustomEvent("input"))
+}
+
+function go() { 
+	if(Date.now() - start_time < max_duration) {
+		set(div.value + 1)
+		requestAnimationFrame(go)
+	} else {
+		set("done")
+	}
+}
+
+btn.onclick = () => {
+	div.value = 0
+	start_time = Date.now()
+	go()
+}
+</script>
+<button id=startx>Start</button>
+</div>"""
+
+# ╔═╡ 8568c646-0233-4a95-8332-2351e9c56027
+@bind withsleep html"<input id=withsleep type=checkbox checked>"
+
+# ╔═╡ 8a20fa4a-ac02-4a37-a54e-e4224628db66
+x
+
+# ╔═╡ 29f1d840-574e-463c-87d3-4b938e123493
+begin
+	reset_xs
+	xs = []
+end
+
+# ╔═╡ 3155b6e0-8e19-4583-b2ab-4ab2db1f10b9
+md"""
+Click **reset_xs**.
+
+Click **Start**.
+
+The cell below should give: `1,done`.
+
+Not: `1,2,done` or something like that. That means that an intermediate bond value (`2`) found its way through: [https://github.com/fonsp/Pluto.jl/issues/1891](https://github.com/fonsp/Pluto.jl/issues/1891)
+"""
+
+# ╔═╡ 029e1d1c-bf42-4e2c-a141-1e2eecc0800d
+begin
+	withsleep && sleep(1.5)
+	push!(xs, x)
+	xs_done = true
+
+	join(xs[2:end], ",") |> Text
+end
+
+# ╔═╡ Cell order:
+# ╟─a0fe4e4d-eee5-4420-bd58-3f12749a9ed1
+# ╟─58db6bd4-58a6-11ef-3795-fd6e57eceb68
+# ╟─8568c646-0233-4a95-8332-2351e9c56027
+# ╠═8a20fa4a-ac02-4a37-a54e-e4224628db66
+# ╠═29f1d840-574e-463c-87d3-4b938e123493
+# ╟─3155b6e0-8e19-4583-b2ab-4ab2db1f10b9
+# ╠═029e1d1c-bf42-4e2c-a141-1e2eecc0800d

--- a/src/evaluation/Run.jl
+++ b/src/evaluation/Run.jl
@@ -57,6 +57,9 @@ function run_reactive_core!(
 	
     old_workspace_name, _ = WorkspaceManager.bump_workspace_module((session, notebook))
 	
+	# A state sync will come soon from this function, so let's delay anything coming from the status_tree listener, see https://github.com/fonsp/Pluto.jl/issues/2978
+	Throttled.force_throttle_without_run(notebook.status_tree.update_listener_ref[])
+	
 	run_status = Status.report_business_started!(notebook.status_tree, :run)
 	Status.report_business_started!(run_status, :resolve_topology)
 	cell_status = Status.report_business_planned!(run_status, :evaluate)

--- a/test/frontend/fixtures/test_bind_dynamics.jl
+++ b/test/frontend/fixtures/test_bind_dynamics.jl
@@ -15,7 +15,7 @@ macro bind(def, element)
 end
 
 # ╔═╡ a0fe4e4d-eee5-4420-bd58-3f12749a9ed1
-@bind reset_xs html"<input id=resetxs type=button value=reset_xs>"
+@bind reset_xs html"<input id=reset_xs_button type=button value=reset_xs>"
 
 # ╔═╡ 58db6bd4-58a6-11ef-3795-fd6e57eceb68
 @bind x html"""<div>
@@ -46,7 +46,7 @@ btn.onclick = () => {
 	go()
 }
 </script>
-<button id=startx>Start</button>
+<button id=add_x_button>Start</button>
 </div>"""
 
 # ╔═╡ 8568c646-0233-4a95-8332-2351e9c56027
@@ -86,6 +86,6 @@ end
 # ╟─58db6bd4-58a6-11ef-3795-fd6e57eceb68
 # ╟─8568c646-0233-4a95-8332-2351e9c56027
 # ╠═8a20fa4a-ac02-4a37-a54e-e4224628db66
-# ╠═29f1d840-574e-463c-87d3-4b938e123493
 # ╟─3155b6e0-8e19-4583-b2ab-4ab2db1f10b9
 # ╠═029e1d1c-bf42-4e2c-a141-1e2eecc0800d
+# ╠═29f1d840-574e-463c-87d3-4b938e123493


### PR DESCRIPTION
This will fix #1891 again which got reopened by #2399

This PR actually contains two fixes! So now it's superfixed!!!
1. The heuristic from #1892 was updated to ignore patches related to `status_tree`.
2. I continued https://github.com/fonsp/Pluto.jl/issues/2978 and made sure that the status tree sync loop is also throttled at the start of the reactive run. #1891 was happening because of the initial status updates.

This time the fix also includes an end-to-end test with puppeteer :)