### PR TITLE
Fix fallback for errors in logging

### DIFF
--- a/src/runner/PlutoRunner/src/PlutoRunner.jl
+++ b/src/runner/PlutoRunner/src/PlutoRunner.jl
@@ -76,4 +76,6 @@ include("./io/logging.jl")
 include("./io/stdout.jl")
 include("./precompile.jl")
 
+__init__() = redirect_original_stderr(stderr)
+
 end

--- a/src/runner/PlutoRunner/src/PlutoRunner.jl
+++ b/src/runner/PlutoRunner/src/PlutoRunner.jl
@@ -76,6 +76,8 @@ include("./io/logging.jl")
 include("./io/stdout.jl")
 include("./precompile.jl")
 
-__init__() = redirect_original_stderr(stderr)
+function __init__()
+    original_stderr[] = stderr
+end
 
 end

--- a/src/runner/PlutoRunner/src/evaluation/deleting globals.jl
+++ b/src/runner/PlutoRunner/src/evaluation/deleting globals.jl
@@ -89,7 +89,7 @@ function move_vars(
                 catch ex
                     if !(ex isa UndefVarError)
                         @warn "Failed to move variable $(symbol) to new workspace:"
-                        showerror(original_stderr, ex, stacktrace(catch_backtrace()))
+                        showerror(original_stderr[], ex, stacktrace(catch_backtrace()))
                     end
                 end
             end
@@ -198,7 +198,7 @@ function try_delete_toplevel_methods(workspace::Module, (cell_id, name_parts)::T
             (val isa Function) && delete_toplevel_methods(val, cell_id)
         catch ex
             @warn "Failed to delete methods for $(name_parts)"
-            showerror(original_stderr, ex, stacktrace(catch_backtrace()))
+            showerror(original_stderr[], ex, stacktrace(catch_backtrace()))
             false
         end
     catch

--- a/src/runner/PlutoRunner/src/io/logging.jl
+++ b/src/runner/PlutoRunner/src/io/logging.jl
@@ -2,21 +2,6 @@ import Logging
 
 const original_stderr = Ref{IO}()
 
-function redirect_original_stderr(io)
-    original_stderr[] = io
-    return nothing
-end
-
-function redirect_original_stderr(f::Function, io)
-    old_stderr = original_stderr[]
-    redirect_original_stderr(io)
-    try
-        return f()
-    finally
-        redirect_original_stderr(old_stderr)
-    end
-end
-
 const old_logger = Ref{Union{Logging.AbstractLogger,Nothing}}(nothing)
 
 struct PlutoCellLogger <: Logging.AbstractLogger

--- a/test/Logging.jl
+++ b/test/Logging.jl
@@ -217,11 +217,14 @@ using Pluto.WorkspaceManager: poll
         🍍.options.evaluation.workspace_use_distributed = false
 
         io = IOBuffer()
-        PlutoRunner.redirect_original_stderr(io) do
-            update_run!(🍍, notebook, notebook.cells[27:29])
-        end
+        old_stderr = PlutoRunner.original_stderr[]
+        PlutoRunner.original_stderr[] = io
+        
+        update_run!(🍍, notebook, notebook.cells[27:29])
+        
         msg = String(take!(io))
         close(io)
+        PlutoRunner.original_stderr[] = old_stderr
 
         @test notebook.cells[27] |> noerror
         @test notebook.cells[28] |> noerror


### PR DESCRIPTION
This fixes the bug identified in #3012, in which the catch block that's supposed to save you in case an error is thrown during logging ends up throwing an error of its own.

* `original_stderr` is now assigned at runtime through the module's `__init__` function, not at compile time as a hardcoded global constant. This was the source of the bug.
* I rewrote the catch block's print/showerror as an `@error` log, which stands out more with the red frame and also looks more consistent with the other information logged to the REPL by Pluto.
* Capturing stderr output for testing is not entirely straightforward. There are tradeoffs between using a local and remote worker. Please review the comments in the testing code and let me know which approach is preferred (or if there's a better design I haven't thought of).

Having looked more deeply at #3012, I think this PR is a sufficient fix on the Pluto side. The reason GPUCompiler's log messages error in the first place is that the purportedly safe logging macros are implemented incorrectly and aren't actually safe. I'll put together a PR to GPUCompiler for that.