### PR TITLE
Update syntax highlighting colors

### DIFF
--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -97,20 +97,18 @@ window.PLUTO_TOGGLE_CM_AUTOCOMPLETE_ON_TYPE = (val = !ENABLE_CM_AUTOCOMPLETE_ON_
 const common_style_tags = [
     { tag: tags.comment, color: "var(--cm-color-comment)", fontStyle: "italic", filter: "none" },
     { tag: tags.keyword, color: "var(--cm-color-keyword)" },
-    { tag: tags.variableName, color: "var(--cm-color-var)", fontWeight: 700 },
+    { tag: tags.variableName, color: "var(--cm-color-variable)", fontWeight: 700 },
     { tag: tags.typeName, color: "var(--cm-color-type)", fontStyle: "italic" },
     { tag: tags.typeOperator, color: "var(--cm-color-type)", fontStyle: "italic" },
     { tag: tags.tagName, color: "var(--cm-color-tag)" }, // JS
-    { tag: tags.propertyName, color: "var(--cm-color-property)" },
+    { tag: tags.propertyName, color: "var(--cm-color-symbol)", fontWeight: 700 },
     // TODO: tags.labelName
     { tag: tags.macroName, color: "var(--cm-color-macro)", fontWeight: 700 },
     { tag: tags.string, color: "var(--cm-color-string)" },
-    // TODO: tags.character
-    { tag: tags.number, color: "var(--cm-color-number)" },
-    { tag: tags.bool, color: "var(--cm-color-builtin)", fontWeight: 700 },
-    // TODO: tags.escape
+    { tag: tags.character, color: "var(--cm-color-literal)" },
+    { tag: tags.literal, color: "var(--cm-color-literal)" },
     // TODO: tags.self, tags.null
-    { tag: tags.atom, color: "var(--cm-color-atom)" },
+    { tag: tags.atom, color: "var(--cm-color-symbol)" },
     { tag: tags.unit, color: "var(--cm-color-tag)" }, // TODO: Remove
     // TODO? tags.operator
     { tag: tags.bracket, color: "var(--cm-color-bracket)" },

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -96,23 +96,22 @@ window.PLUTO_TOGGLE_CM_AUTOCOMPLETE_ON_TYPE = (val = !ENABLE_CM_AUTOCOMPLETE_ON_
 
 const common_style_tags = [
     { tag: tags.comment, color: "var(--cm-color-comment)", fontStyle: "italic", filter: "none" },
-    { tag: tags.keyword, color: "var(--cm-color-keyword)" },
     { tag: tags.variableName, color: "var(--cm-color-variable)", fontWeight: 700 },
-    { tag: tags.typeName, color: "var(--cm-color-type)", fontStyle: "italic" },
-    { tag: tags.typeOperator, color: "var(--cm-color-type)", fontStyle: "italic" },
-    { tag: tags.tagName, color: "var(--cm-color-tag)" }, // JS
     { tag: tags.propertyName, color: "var(--cm-color-symbol)", fontWeight: 700 },
-    // TODO: tags.labelName
     { tag: tags.macroName, color: "var(--cm-color-macro)", fontWeight: 700 },
+    { tag: tags.typeName, filter: "var(--cm-filter-type)", fontWeight: "lighter" },
+    { tag: tags.atom, color: "var(--cm-color-symbol)" },
     { tag: tags.string, color: "var(--cm-color-string)" },
+    { tag: tags.special(tags.string), color: "var(--cm-color-command)" },
     { tag: tags.character, color: "var(--cm-color-literal)" },
     { tag: tags.literal, color: "var(--cm-color-literal)" },
-    // TODO: tags.self, tags.null
-    { tag: tags.atom, color: "var(--cm-color-symbol)" },
-    { tag: tags.unit, color: "var(--cm-color-tag)" }, // TODO: Remove
-    // TODO? tags.operator
+    { tag: tags.keyword, color: "var(--cm-color-keyword)" },
+    // TODO: normal operators
+    { tag: tags.definitionOperator, color: "var(--cm-color-keyword)" },
+    { tag: tags.logicOperator, color: "var(--cm-color-keyword)" },
+    { tag: tags.controlOperator, color: "var(--cm-color-keyword)" },
     { tag: tags.bracket, color: "var(--cm-color-bracket)" },
-    { tag: tags.special(tags.brace), color: "var(--cm-color-macro)", fontWeight: 700 }, // interp
+    // TODO: tags.self, tags.null
 ]
 
 export const pluto_syntax_colors_julia = HighlightStyle.define(common_style_tags, {

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -3526,7 +3526,7 @@ pluto-cell.errored .cm-editor .cm-lineNumbers .cm-gutterElement::after {
 }
 
 .cm-completionIcon-c_Number::before {
-    color: var(--cm-color-number);
+    color: var(--cm-color-literal);
 }
 
 .cm-completionIcon-c_String::before,
@@ -3536,7 +3536,7 @@ pluto-cell.errored .cm-editor .cm-lineNumbers .cm-gutterElement::after {
 }
 
 .cm-completionIcon-completion_property::before {
-    color: var(--cm-color-property);
+    color: var(--cm-color-symbol);
 }
 
 .cm-completionIcon-completion_keyword::before {
@@ -3548,13 +3548,13 @@ li.completion_keyword_argument .cm-completionLabel {
     font-weight: bold;
 }
 .cm-completionIcon-completion_keyword_argument::before {
-    color: var(--cm-color-number);
+    color: var(--cm-color-literal);
 }
 
 .cm-completionIcon-c_Any::before,
 pluto-output > assignee,
 pluto-popup code.auto_disabled_variable {
-    color: var(--cm-color-var) !important;
+    color: var(--cm-color-variable) !important;
     font-weight: 700;
 }
 

--- a/frontend/highlightjs.css
+++ b/frontend/highlightjs.css
@@ -1,3 +1,4 @@
+/* https://highlightjs.readthedocs.io/en/latest/css-classes-reference.html */
 pre code.hljs {
     display: block;
     overflow-x: auto;
@@ -9,67 +10,49 @@ code.hljs {
 .hljs {
     color: var(--cm-color-editor-text);
 }
-.hljs-comment,
-.hljs-quote {
-    color: var(--cm-color-comment);
-    font-style: italic;
-}
-.hljs-doctag,
-.hljs-formula,
-.hljs-keyword {
-    color: var(--cm-color-keyword);
-}
-.hljs-deletion,
-.hljs-name,
-.hljs-section,
-.hljs-selector-tag,
-.hljs-subst {
-    color: var(--cm-color-var2);
-}
-.hljs-literal {
-    color: var(--cm-color-builtin);
-}
-.hljs-addition,
-.hljs-attribute,
-.hljs-meta .hljs-string,
-.hljs-regexp,
-.hljs-string {
-    color: var(--cm-color-string);
-}
-.hljs-attr,
-.hljs-selector-attr,
-.hljs-selector-class,
-.hljs-selector-pseudo,
-.hljs-template-variable,
-.hljs-type,
-.hljs-variable {
-    color: var(--cm-color-variable);
-}
-.hljs-number {
-    color: var(--cm-color-literal);
-}
-.hljs-bullet,
-.hljs-link,
-.hljs-selector-id,
-.hljs-symbol,
-.hljs-title {
-    color: var(--cm-color-link);
-}
-.hljs-meta {
-    color: var(--cm-color-macro);
-    font-weight: 700;
-}
+
+.hljs-keyword { color: var(--cm-color-keyword); }
+
 .hljs-built_in,
-.hljs-class .hljs-title,
-.hljs-title.class_ {
-    color: var(--cm-color-var2);
-}
-.hljs-emphasis {
-    font-style: italic;
-}
-.hljs-strong {
-    font-weight: 700;
-}
-.hljs-link {
-    text-decoration: underline;
-}
+.hljs-type { color: var(--cm-color-builtin); }
+
+.hljs-literal,
+.hljs-number { color: var(--cm-color-literal); }
+
+.hljs-property { color: var(--cm-color-symbol); }
+
+.hljs-regexp,
+.hljs-string { color: var(--cm-color-string); }
+
+.hljs-char.escape { color: var(--cm-color-literal); }
+.hljs-subst { color: var(--cm-color-editor-text); }
+.hljs-symbol { color: var(--cm-color-symbol); }
+
+.hljs-variable,
+.hljs-title { color: var(--cm-color-variable); }
+
+.hljs-comment { color: var(--cm-color-comment); }
+.hljs-doctag { color: var(--cm-color-keyword); }
+
+.hljs-meta { color: var(--cm-color-macro); font-weight: 700; }
+
+.hljs-bullet { color: var(--cm-color-keyword); }
+.hljs-emphasis { font-style: italic; }
+.hljs-strong { font-weight: 700; }
+.hljs-link { color: var(--cm-color-string); text-decoration: underline; }
+.hljs-quote { color: var(--cm-color-comment); }
+
+.hljs-code,
+.hljs-formula { color: var(--cm-color-comment); }
+
+.hljs-selector-tag,
+.hljs-selector-id,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo { color: var(--cm-color-variable); }
+
+.hljs-template-tag { color: var(--cm-color-symbol); }
+.hljs-template-variable { color: var(--cm-color-variable); }
+
+/* .hljs-addition {} */
+/* .hljs-deletion {} */

--- a/frontend/highlightjs.css
+++ b/frontend/highlightjs.css
@@ -43,10 +43,10 @@ code.hljs {
 .hljs-template-variable,
 .hljs-type,
 .hljs-variable {
-    color: var(--cm-color-var);
+    color: var(--cm-color-variable);
 }
 .hljs-number {
-    color: var(--cm-color-number);
+    color: var(--cm-color-literal);
 }
 .hljs-bullet,
 .hljs-link,

--- a/frontend/themes/dark.css
+++ b/frontend/themes/dark.css
@@ -192,12 +192,11 @@
         /* code highlighting */
         --cm-color-editor-text: #ffe9fc;
         --cm-color-comment: #e96ba8;
-        --cm-color-atom: hsl(8deg 72% 62%);
-        --cm-color-number: hsl(271deg 45% 64%);
-        --cm-color-property: #f99b15;
+        --cm-color-symbol: #f99b15;
+        --cm-color-literal: hsl(271deg 45% 64%);
         --cm-color-keyword: #ff7a6f;
         --cm-color-string: hsl(20deg 69% 59%);
-        --cm-color-var: #afb7d3;
+        --cm-color-variable: #afb7d3;
         --cm-color-var2: #06b6ef;
         --cm-color-macro: #82b38b;
         --cm-color-builtin: #5e7ad3;

--- a/frontend/themes/dark.css
+++ b/frontend/themes/dark.css
@@ -201,15 +201,10 @@
         --cm-color-literal:     oklch(80% 30% 330deg);
         --cm-filter-type:       brightness(80%) saturate(80%);
 
-        /* The colors below are not used in CellInput.js */
-        --cm-color-var2:          #06b6ef;
         --cm-color-builtin:       #5e7ad3;
         --cm-color-function:      #f99b15;
-        --cm-color-bracket:       #a2a273;
-        --cm-color-tag:           #ef6155;
         --cm-color-link:          #815ba4;
-        --cm-color-error-bg:      #ef6155;
-        --cm-color-error:         #f7f7f7;
+        --cm-color-bracket:       #a2a273;
         --cm-color-matchingBracket: white;
         --cm-color-matchingBracket-bg: #c58c237a;
         --cm-color-placeholder-text: rgb(255 255 255 / 20%);

--- a/frontend/themes/dark.css
+++ b/frontend/themes/dark.css
@@ -190,23 +190,26 @@
         --cm-highlighted: #cbceb629;
 
         /* code highlighting */
-        --cm-color-editor-text: #ffe9fc;
-        --cm-color-comment: #e96ba8;
-        --cm-color-symbol: #f99b15;
-        --cm-color-literal: hsl(271deg 45% 64%);
-        --cm-color-keyword: #ff7a6f;
-        --cm-color-string: hsl(20deg 69% 59%);
-        --cm-color-variable: #afb7d3;
-        --cm-color-var2: #06b6ef;
-        --cm-color-macro: #82b38b;
-        --cm-color-builtin: #5e7ad3;
-        --cm-color-function: #f99b15;
-        --cm-color-type: hsl(51deg 32% 44%);
-        --cm-color-bracket: #a2a273;
-        --cm-color-tag: #ef6155;
-        --cm-color-link: #815ba4;
-        --cm-color-error-bg: #ef6155;
-        --cm-color-error: #f7f7f7;
+        --cm-color-editor-text: oklch(90%  3%   0deg);
+        --cm-color-comment:     oklch(80% 30%   0deg);
+        --cm-color-keyword:     oklch(70% 40%  30deg);
+        --cm-color-symbol:      oklch(80% 30%  60deg);
+        --cm-color-macro:       oklch(80% 30% 150deg);
+        --cm-color-command:     oklch(80% 10% 120deg);
+        --cm-color-string:      oklch(80% 10% 180deg);
+        --cm-color-variable:    oklch(80% 10% 270deg);
+        --cm-color-literal:     oklch(80% 30% 330deg);
+        --cm-filter-type:       brightness(80%) saturate(80%);
+
+        /* The colors below are not used in CellInput.js */
+        --cm-color-var2:          #06b6ef;
+        --cm-color-builtin:       #5e7ad3;
+        --cm-color-function:      #f99b15;
+        --cm-color-bracket:       #a2a273;
+        --cm-color-tag:           #ef6155;
+        --cm-color-link:          #815ba4;
+        --cm-color-error-bg:      #ef6155;
+        --cm-color-error:         #f7f7f7;
         --cm-color-matchingBracket: white;
         --cm-color-matchingBracket-bg: #c58c237a;
         --cm-color-placeholder-text: rgb(255 255 255 / 20%);

--- a/frontend/themes/dark.css
+++ b/frontend/themes/dark.css
@@ -204,7 +204,7 @@
         --cm-color-builtin:       #5e7ad3;
         --cm-color-function:      #f99b15;
         --cm-color-link:          #815ba4;
-        --cm-color-bracket:       #a2a273;
+        --cm-color-bracket:       #b8ab87;
         --cm-color-matchingBracket: white;
         --cm-color-matchingBracket-bg: #c58c237a;
         --cm-color-placeholder-text: rgb(255 255 255 / 20%);

--- a/frontend/themes/light.css
+++ b/frontend/themes/light.css
@@ -201,15 +201,10 @@
         --cm-color-literal:     oklch(45%  60% 330deg);
         --cm-filter-type:       brightness(150%) saturate(50%);
 
-        /* The colors below are not used in CellInput.js */
-        --cm-color-var2:        #37768a;
         --cm-color-builtin:     #5e7ad3;
         --cm-color-function:    #cc80ac;
-        --cm-color-bracket:     #41323f;
-        --cm-color-tag:         #ef6155;
         --cm-color-link:        #815ba4;
-        --cm-color-error-bg:    #ef6155;
-        --cm-color-error:       #f7f7f7;
+        --cm-color-bracket:     #41323f;
         --cm-color-matchingBracket: black;
         --cm-color-matchingBracket-bg: #1b4bbb21;
         --cm-color-placeholder-text: rgba(0, 0, 0, 0.2);

--- a/frontend/themes/light.css
+++ b/frontend/themes/light.css
@@ -192,12 +192,11 @@
         /* code highlighting */
         --cm-color-editor-text: #41323f;
         --cm-color-comment:     #e96ba8;
-        --cm-color-atom:        #815ba4;
-        --cm-color-number:      #815ba4;
-        --cm-color-property:    #b67a48;
+        --cm-color-symbol:      #b67a48;
+        --cm-color-literal:     #815ba4;
         --cm-color-keyword:     #ef6155;
         --cm-color-string:      #da5616;
-        --cm-color-var:         #5668a4;
+        --cm-color-variable:    #5668a4;
         --cm-color-var2:        #37768a;
         --cm-color-macro:       #5c8c5f;
         --cm-color-builtin:     #5e7ad3;

--- a/frontend/themes/light.css
+++ b/frontend/themes/light.css
@@ -190,18 +190,21 @@
         --cm-highlighted: #cbceb668;
 
         /* code highlighting */
-        --cm-color-editor-text: #41323f;
-        --cm-color-comment:     #e96ba8;
-        --cm-color-symbol:      #b67a48;
-        --cm-color-literal:     #815ba4;
-        --cm-color-keyword:     #ef6155;
-        --cm-color-string:      #da5616;
-        --cm-color-variable:    #5668a4;
+        --cm-color-editor-text: oklch(30%   0%   0deg);
+        --cm-color-comment:     oklch(45%  60%   0deg);
+        --cm-color-keyword:     oklch(45%  80%  30deg);
+        --cm-color-symbol:      oklch(45%  80%  90deg);
+        --cm-color-command:     oklch(35% 100% 120deg);
+        --cm-color-macro:       oklch(45%  80% 150deg);
+        --cm-color-string:      oklch(35% 100% 180deg);
+        --cm-color-variable:    oklch(45%  40% 270deg);
+        --cm-color-literal:     oklch(45%  60% 330deg);
+        --cm-filter-type:       brightness(150%) saturate(50%);
+
+        /* The colors below are not used in CellInput.js */
         --cm-color-var2:        #37768a;
-        --cm-color-macro:       #5c8c5f;
         --cm-color-builtin:     #5e7ad3;
         --cm-color-function:    #cc80ac;
-        --cm-color-type:        hsl(170deg 7% 56%);
         --cm-color-bracket:     #41323f;
         --cm-color-tag:         #ef6155;
         --cm-color-link:        #815ba4;


### PR DESCRIPTION
- Define colors using `oklch`.
- Add highlight for commands (different from strings).
- Remove highlight for tags (it was the same as types).
- Use color filter for types.
  This is super nice because it means values used as type parameters keep their hue (e.g. when using `Val`.
- Replace `--cm-color-[atom|property]` with `--cm-color-symbol`.
  Use a bolder typeface for properties.
- Replace `--cm-color-number` with `--cm-color-literal`.
  Highlight booleans, characters, and numbers as literal.
- Rename `--cm-color-var` to `-variable`.
- Remove unused variables.

The dark version doesn't really have the same contrast issues as the light version. However, for consistency it was updated to use the same hues as the light theme.

---

- [x] Update light theme "main" colors
- [x] Update dark theme "main" colors
- [ ] Update light theme mixed parser colors
- [ ] Update dark theme mixed parser colors
- [x] Update highlightJS


Closes #2921 