### PR TITLE
Error message title

### DIFF
--- a/frontend/treeview.css
+++ b/frontend/treeview.css
@@ -292,6 +292,10 @@ jlerror > section > ol > li {
 jlerror > section > ol > li:not(.important):not(:hover) {
     opacity: 0.5;
 }
+
+jlerror > section > ol > li:not(.important)::marker {
+    font-weight: 100;
+}
 jlerror > section > ol > li.from_this_notebook {
     --bg: var(--jl-info-acccolor);
     background: var(--bg);


### PR DESCRIPTION
New title above the error: "Error message"

If we can deduce which package threw the error, we say "Error message from Example"

<img width="781" alt="image" src="https://github.com/user-attachments/assets/5968e23a-ae1c-405a-8d29-0bce45c5000b">

<img width="892" alt="image" src="https://github.com/user-attachments/assets/a88c3932-8a20-45d8-84cb-9d019ffcb800">

<img width="727" alt="image" src="https://github.com/user-attachments/assets/fd39b850-83f8-4252-9e75-d776fe5a6698">
