### PR TITLE
Remove `Main.var"workspace#5"` from stack traces

### DIFF
--- a/src/runner/PlutoRunner/src/display/Exception.jl
+++ b/src/runner/PlutoRunner/src/display/Exception.jl
@@ -65,7 +65,7 @@ function format_output(val::CapturedException; context=default_iocontext)
             pm = VERSION >= v"1.9" && method isa Method ? parentmodule(method) : nothing
 
             Dict(
-                :call => pretty_stackcall(s, s.linfo),
+                :call => replace(pretty_stackcall(s, s.linfo), r"Main\.var\"workspace#\d+\"\." => ""),
                 :inlined => s.inlined,
                 :from_c => s.from_c,
                 :file => basename(String(s.file)),


### PR DESCRIPTION
# Before

![image](https://github.com/user-attachments/assets/aa718bfd-563d-4525-937a-8921d3e581be)


# After

![image](https://github.com/user-attachments/assets/d7b4cf20-6448-4eb0-a29c-f486da7f806c)
