### PR TITLE
Stack trace: bracket-matched hiding and expanding and more

### DIFF
--- a/frontend/components/ErrorMessage.js
+++ b/frontend/components/ErrorMessage.js
@@ -32,7 +32,7 @@ const DocLink = ({ frame }) => {
     if (frame.parent_module == null) return null
     if (ignore_funccall(frame)) return null
 
-    const funcname = frame.call.split("(")[0]
+    const funcname = frame.func
     if (funcname === "") return null
 
     const nb = pluto_actions.get_notebook()
@@ -88,6 +88,20 @@ const at = html`<span> from </span>`
 const ignore_funccall = (frame) => frame.call === "top-level scope"
 const ignore_location = (frame) => frame.file === "none"
 
+const funcname_args = (call) => {
+    const anon_match = call.indexOf(")(")
+    if (anon_match != -1) {
+        return [call.substring(0, anon_match + 1), call.substring(anon_match + 1)]
+    } else {
+        const bracket_index = call.indexOf("(")
+        if (bracket_index != -1) {
+            return [call.substring(0, bracket_index), call.substring(bracket_index)]
+        } else {
+            return [call, ""]
+        }
+    }
+}
+
 const Funccall = ({ frame }) => {
     let [expanded_state, set_expanded] = useState(false)
     useEffect(() => {
@@ -96,14 +110,14 @@ const Funccall = ({ frame }) => {
 
     const silly_to_hide = (frame.call_short.match(/…/g) ?? "").length <= 1 && frame.call.length < frame.call_short.length + 7
 
-    const expanded = expanded_state || (frame.call === frame.call_short && frame.func === frame.call.split("(", 2)[0]) || silly_to_hide
+    const expanded = expanded_state || (frame.call === frame.call_short && frame.func === funcname_args(frame.call)[0]) || silly_to_hide
 
     if (ignore_funccall(frame)) return null
 
     const call = expanded ? frame.call : frame.call_short
 
-    const bracket_index = call.indexOf("(")
-    const funcname = expanded ? call.split("(", 2)[0] : frame.func
+    const call_funcname_args = funcname_args(call)
+    const funcname = expanded ? call_funcname_args[0] : frame.func
 
     // if function name is #12 or #15#16 then it is an anonymous function
 
@@ -112,7 +126,7 @@ const Funccall = ({ frame }) => {
         : funcname
     console.log(funcname, funcname.match(/^#\d+(#\d+)?$/), funcname_display)
 
-    let inner = bracket_index != -1 ? html`<strong>${funcname_display}</strong>${call.substr(bracket_index)}` : html`<strong>${funcname_display}</strong>`
+    let inner = html`<strong>${funcname_display}</strong><${HighlightCallArgumentNames} code=${call_funcname_args[1]} />`
 
     const id = useMemo(() => Math.random().toString(36).substring(7), [frame])
 
@@ -181,6 +195,19 @@ const JuliaHighlightedLine = ({ code, frameLine, i }) => {
     ></code>`
 }
 
+const HighlightCallArgumentNames = ({ code }) => {
+    const code_ref = useRef(/** @type {HTMLPreElement?} */ (null))
+    useLayoutEffect(() => {
+        if (code_ref.current) {
+            const html = code.replaceAll(/([^():{},; ]*)::/g, "<span class='argument_name'>$1</span>::")
+
+            code_ref.current.innerHTML = html
+        }
+    }, [code_ref.current, code])
+
+    return html`<s-span ref=${code_ref} class="language-julia"></s-span>`
+}
+
 const insert_commas_and_and = (/** @type {any[]} */ xs) => xs.flatMap((x, i) => (i === xs.length - 1 ? [x] : i === xs.length - 2 ? [x, " and "] : [x, ", "]))
 
 export const ParseError = ({ cell_id, diagnostics }) => {
@@ -227,7 +254,7 @@ export const ParseError = ({ cell_id, diagnostics }) => {
 const frame_is_important_heuristic = (frame, frame_index, limited_stacktrace, frame_cell_id) => {
     if (frame_cell_id != null) return true
 
-    const [funcname, params] = frame.call.split("(", 2)
+    const [funcname, params] = funcname_args(frame.call)
 
     if (["_collect", "collect_similar", "iterate", "error", "macro expansion"].includes(funcname)) {
         return false

--- a/frontend/treeview.css
+++ b/frontend/treeview.css
@@ -317,6 +317,14 @@ jlerror > section .classical-frame > mark {
 jlerror > section .classical-frame > mark > strong {
     color: var(--black);
 }
+jlerror > section .classical-frame s-span {
+    /* color: var(--cm-color-type); */
+}
+jlerror > section .classical-frame s-span .argument_name {
+    color: var(--jlerror-mark-color);
+    color: var(--cm-color-var);
+    color: var(--cm-color-type);
+}
 jlerror > section .frame-source {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
We now use Julia's built-in (curly-bracket matched) method to shorten type information. (From https://github.com/JuliaLang/julia/pull/49795, suggested by https://github.com/fonsp/Pluto.jl/issues/3006.)

You can click to expand and see all types.

https://github.com/user-attachments/assets/9800dc79-b47a-4392-b564-7f62753d0ced

Also notice: the first frame has a big parameterized callable type, but in the unexpanded form, just the name is shown.

# Anonymous function

This PR also adds a special case for anonymous functions. Instead of a generated name like `#15` or `#24#25`, it shows "anonymous function" and you can hover to learn what that phrase means:

![image](https://github.com/user-attachments/assets/bc77fdd9-7c9d-4ee7-ab26-b9132d15e77a)

Compare this to the REPL:

![image](https://github.com/user-attachments/assets/8e29e675-0b90-48d9-b8c3-5b0b08a58fd4)


# Highlighted function argument names

The argument names are now highlighted in grey (`x` in `sqrt(x::Float64)`)

![image](https://github.com/user-attachments/assets/580fbffc-03f3-4eed-b623-0d25450c0839)



## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/fonsp/Pluto.jl", rev="stack-trace-expand-types")
julia> using Pluto
```
