### PR TITLE
apply unicode completion to all matching cursors

### DIFF
--- a/frontend/components/CellInput/pluto_autocomplete.js
+++ b/frontend/components/CellInput/pluto_autocomplete.js
@@ -404,7 +404,10 @@ const apply_completion = (view, completion, from, to) => {
         }
     }
 
-    view.dispatch({ changes: { from, to, insert }, annotations: autocomplete.pickedCompletion.of(completion) })
+    view.dispatch({
+        ...autocomplete.insertCompletionText(view.state, insert, from, to),
+        annotations: autocomplete.pickedCompletion.of(completion),
+    })
 }
 
 const special_symbols_completion = (/** @type {() => Promise<SpecialSymbols?>} */ request_special_symbols) => {


### PR DESCRIPTION
Fixes #3037.

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/fonsp/Pluto.jl", rev="complete-unicode")
julia> using Pluto
```
