### PR TITLE
Warn about using Julia version before 1.10

### DIFF
--- a/src/webserver/WebServer.jl
+++ b/src/webserver/WebServer.jl
@@ -145,7 +145,7 @@ function run!(session::ServerSession)
         @info "Loading..."
     end
 
-    if VERSION < v"1.6.2"
+    if VERSION < v"1.10.0"
         @warn("\nPluto is running on an old version of Julia ($(VERSION)) that is no longer supported. Visit https://julialang.org/downloads/ for more information about upgrading Julia.")
     end
 


### PR DESCRIPTION
Julia 1.10 became LTS and previous versions are no longer supported.