### PR TITLE
Make Julia 1.10 minimum

### DIFF
--- a/.github/workflows/FrontendTest.yml
+++ b/.github/workflows/FrontendTest.yml
@@ -26,9 +26,9 @@ jobs:
             - uses: actions/checkout@v4
 
             # Makes thes `julia` command available
-            - uses: julia-actions/setup-julia@v1
+            - uses: julia-actions/setup-julia@v2
               with:
-                  version: "1.6" # our lowest supported version
+                  version: "1.10" # our lowest supported version
 
             - name: Install Pluto.jl packages
               run: |

--- a/.github/workflows/LaunchTest.yml
+++ b/.github/workflows/LaunchTest.yml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             matrix:
                 # We test quite a lot of versions because we do some OS and version specific things unfortunately
-                julia-version: ["1.6", "1.7"]
+                julia-version: ["lts", "1"]
                 os: [windows-latest, ubuntu-latest]
 
         steps:
@@ -21,7 +21,7 @@ jobs:
             - uses: actions/checkout@v4
 
             # Makes thes `julia` command available
-            - uses: julia-actions/setup-julia@v1
+            - uses: julia-actions/setup-julia@v2
               with:
                   version: ${{ matrix.julia-version }}
 

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -34,7 +34,7 @@ jobs:
             fail-fast: false
             matrix:
                 # We test quite a lot of versions because we do some OS and version specific things unfortunately
-                julia-version: ["1.6", "1.10", "1.11"] #, "nightly"] # "~1.12.0-0"]
+                julia-version: ["1.10", "1.11"] #, "nightly"] # "~1.12.0-0"]
                 os: [ubuntu-latest, macOS-latest, windows-latest]
 
         steps:
@@ -45,9 +45,9 @@ jobs:
             - uses: julia-actions/setup-julia@v2
               with:
                   version: ${{ matrix.julia-version }}
-                  arch: ${{ (matrix.julia-version == '1.6') && 'x64' || runner.arch }}
+                  arch: ${{ runner.arch }}
 
-            - uses: julia-actions/cache@v1
+            - uses: julia-actions/cache@v2
 
             # 🚗
             - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/TestBundledExport.yml
+++ b/.github/workflows/TestBundledExport.yml
@@ -12,9 +12,9 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            - uses: julia-actions/setup-julia@v1
+            - uses: julia-actions/setup-julia@v2
               with:
-                  version: "1.8"
+                  version: "1.10"
 
             - name: Generate exports and check for warnings
               run: |

--- a/.github/workflows/TestFirefox.yml
+++ b/.github/workflows/TestFirefox.yml
@@ -28,9 +28,9 @@ jobs:
       - uses: actions/checkout@v4
 
       # Makes thes `julia` command available
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
-            version: "1.6" # our lowest supported version
+            version: "1.10" # our lowest supported version
             arch: x64
 
       - name: Install Pluto.jl packages

--- a/Project.toml
+++ b/Project.toml
@@ -65,7 +65,7 @@ TOML = "1"
 Tables = "1"
 URIs = "1.3"
 UUIDs = "1"
-julia = "^1.6"
+julia = "^1.10"
 
 [extras]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -402,16 +402,11 @@ end
 
 function _convert_to_flags(options::CompilerOptions)::Vector{String}
     option_list = String[]
-    exclude_list = String[]
-
-    if VERSION < v"1.9"
-      push!(exclude_list, "--heap-size-hint")
-    end
 
     for name in fieldnames(CompilerOptions)
         flagname = string("--", replace(String(name), "_" => "-"))
         value = getfield(options, name)
-        if value !== nothing && flagname ∉ exclude_list
+        if value !== nothing
             push!(option_list, string(flagname, "=", value))
         end
     end

--- a/src/packages/IOListener.jl
+++ b/src/packages/IOListener.jl
@@ -50,10 +50,7 @@ function stoplistening(listener::IOListener)
     end
 end
 
-freeze_loading_spinners(s::AbstractString) = _replaceall(s, '◑' => '◐', '◒' => '◐', '◓' => '◐')
-
-_replaceall(s, p) = replace(s, p)
-_replaceall(s, p, ps...) = @static VERSION >= v"1.7" ? replace(s, p, ps...) : _replaceall(replace(s, p), ps...)
+freeze_loading_spinners(s::AbstractString) = replace(s, '◑' => '◐', '◒' => '◐', '◓' => '◐')
 
 phasemessage(iolistener, phase::String) = phasemessage(iolistener.buffer, phase)
 function phasemessage(io::IO, phase::String)

--- a/src/packages/Packages.jl
+++ b/src/packages/Packages.jl
@@ -7,7 +7,7 @@ import LoggingExtras
 import .Configuration: CompilerOptions, _merge_notebook_compiler_options, _convert_to_flags
 
 const tiers = unique((
-    PkgCompat.PRESERVE_ALL_INSTALLED,
+    Pkg.PRESERVE_ALL_INSTALLED,
 	Pkg.PRESERVE_ALL,
 	Pkg.PRESERVE_DIRECT,
 	Pkg.PRESERVE_SEMVER,
@@ -289,7 +289,7 @@ function sync_nbpkg_core(
                         # changed_versions=Dict{String,Pair}(),
                         restart_recommended=👺 || (
                             (!isempty(to_remove) && old_manifest_keys != new_manifest_keys) ||
-                            used_tier ∉ (Pkg.PRESERVE_ALL, PkgCompat.PRESERVE_ALL_INSTALLED)
+                            used_tier ∉ (Pkg.PRESERVE_ALL, Pkg.PRESERVE_ALL_INSTALLED)
                         ),
                         restart_required=👺 || (
                             used_tier ∈ (Pkg.PRESERVE_SEMVER, Pkg.PRESERVE_NONE)
@@ -303,7 +303,7 @@ function sync_nbpkg_core(
 
     return (
         did_something=👺 || (use_plutopkg_old != use_plutopkg_new),
-        used_tier=PkgCompat.PRESERVE_ALL_INSTALLED,
+        used_tier=Pkg.PRESERVE_ALL_INSTALLED,
         # changed_versions=Dict{String,Pair}(),
         restart_recommended=👺 || false,
         restart_required=👺 || false,

--- a/src/packages/PkgCompat.jl
+++ b/src/packages/PkgCompat.jl
@@ -472,7 +472,7 @@ end
 # ✅ Internal API with fallback
 "Update the project hash in the manifest file (https://github.com/JuliaLang/Pkg.jl/pull/2815)"
 function _update_project_hash!(ctx::PkgContext)
-	VERSION >= v"1.8.0" && isfile(manifest_file(ctx)) && try
+	isfile(manifest_file(ctx)) && try
 		Pkg.Operations.record_project_hash(ctx.env)
 		Pkg.Types.write_manifest(ctx.env)
 	catch e

--- a/src/packages/PkgCompat.jl
+++ b/src/packages/PkgCompat.jl
@@ -8,9 +8,6 @@ import Pkg.Types: VersionRange
 import RegistryInstances
 import ..Pluto
 
-const PRESERVE_ALL_INSTALLED = isdefined(Pkg, :PRESERVE_ALL_INSTALLED) ? Pkg.PRESERVE_ALL_INSTALLED : Pkg.PRESERVE_ALL
-
-
 @static if isdefined(Pkg,:REPLMode) && isdefined(Pkg.REPLMode,:complete_remote_package)
     const REPLMode = Pkg.REPLMode
 else
@@ -60,9 +57,7 @@ I tried to only use public API, except:
 ###
 
 
-const PkgContext = if isdefined(Pkg, :Context)
-	Pkg.Context
-elseif isdefined(Pkg, :Types) && isdefined(Pkg.Types, :Context)
+const PkgContext = if isdefined(Pkg, :Types) && isdefined(Pkg.Types, :Context)
 	Pkg.Types.Context
 elseif isdefined(Pkg, :API) && isdefined(Pkg.API, :Context)
 	Pkg.API.Context
@@ -341,7 +336,7 @@ end
 # (🐸 "Public API", but using PkgContext)
 function _package_versions_from_path(registry_entry_fullpath::AbstractString)::Vector{VersionNumber}
 	# compat
-    vd = @static if isdefined(Pkg, :Operations) && isdefined(Pkg.Operations, :load_versions) && hasmethod(Pkg.Operations.load_versions, (String,))
+    vd = @static if hasmethod(Pkg.Operations.load_versions, (String,))
         Pkg.Operations.load_versions(registry_entry_fullpath)
     else
         Pkg.Operations.load_versions(PkgContext(), registry_entry_fullpath)

--- a/src/packages/PkgCompat.jl
+++ b/src/packages/PkgCompat.jl
@@ -333,17 +333,6 @@ function _registry_entries(package_name::AbstractString, registries::Vector=_par
 	end
 end
 
-# (🐸 "Public API", but using PkgContext)
-function _package_versions_from_path(registry_entry_fullpath::AbstractString)::Vector{VersionNumber}
-	# compat
-    vd = @static if hasmethod(Pkg.Operations.load_versions, (String,))
-        Pkg.Operations.load_versions(registry_entry_fullpath)
-    else
-        Pkg.Operations.load_versions(PkgContext(), registry_entry_fullpath)
-    end
-	vd |> keys |> collect
-end
-
 # ✅ "Public" API using RegistryInstances
 """
 Return all registered versions of the given package. Returns `["stdlib"]` for standard libraries, a `Vector{VersionNumber}` for registered packages, or `["latest"]` if it crashed.

--- a/src/packages/precompile_isolated.jl
+++ b/src/packages/precompile_isolated.jl
@@ -18,11 +18,7 @@ function precompile_isolated(
     end
     
     Pkg.activate($(repr(environment)); io=out_stream)
-    if VERSION >= v"1.8.0" # https://github.com/JuliaLang/Pkg.jl/pull/2816
-        Pkg.precompile(; already_instantiated=true, io=out_stream)
-    else
-        Pkg.precompile(; io=out_stream)
-    end
+    Pkg.precompile(; already_instantiated=true, io=out_stream)
     """
 
     cmd = `$(Base.julia_cmd()[1]) $(flags) -e $(code)`

--- a/src/runner/PlutoRunner/src/display/Exception.jl
+++ b/src/runner/PlutoRunner/src/display/Exception.jl
@@ -34,7 +34,7 @@ end
 source_package(::Any) = nothing
 
 function format_output(val::CapturedException; context=default_iocontext)
-    if has_julia_syntax && val.ex isa PrettySyntaxError
+    if val.ex isa PrettySyntaxError
         dict = convert_parse_error_to_dict(val.ex.ex.detail)
         return dict, MIME"application/vnd.pluto.parseerror+object"()
     end

--- a/src/runner/PlutoRunner/src/display/Exception.jl
+++ b/src/runner/PlutoRunner/src/display/Exception.jl
@@ -28,10 +28,8 @@ frame_url(m::Method) = Base.url(m)
 frame_url(::Any) = nothing
 
 function source_package(m::Union{Method,Module})
-    @static if VERSION >= v"1.9"
-        next = parentmodule(m)
-        next === m ? m : source_package(next)
-    end
+    next = parentmodule(m)
+    next === m ? m : source_package(next)
 end
 source_package(::Any) = nothing
 
@@ -63,7 +61,7 @@ function format_output(val::CapturedException; context=default_iocontext)
             func = s.func === nothing ? nothing : s.func isa Symbol ? String(s.func) : repr(s.func)
             method = method_from_frame(s)
             sp = source_package(method)
-            pm = VERSION >= v"1.9" && method isa Method ? parentmodule(method) : nothing
+            pm = method isa Method ? parentmodule(method) : nothing
             call = replace(pretty_stackcall(s, s.linfo), r"Main\.var\"workspace#\d+\"\." => "")
 
             Dict(

--- a/src/runner/PlutoRunner/src/display/syntax error.jl
+++ b/src/runner/PlutoRunner/src/display/syntax error.jl
@@ -1,7 +1,4 @@
 
-const has_julia_syntax = isdefined(Base, :JuliaSyntax) && fieldcount(Base.Meta.ParseError) == 2
-
-
 # @codemirror/lint has only three levels
 function convert_julia_syntax_level(level)
     level == :error   ? "error" :
@@ -171,7 +168,7 @@ function throw_syntax_error(@nospecialize(syntax_err))
     syntax_err isa String && (syntax_err = "syntax: $syntax_err")
     syntax_err isa Exception || (syntax_err = ErrorException(syntax_err))
 
-    if has_julia_syntax && syntax_err isa Base.Meta.ParseError && syntax_err.detail isa Base.JuliaSyntax.ParseError
+    if syntax_err isa Base.Meta.ParseError && syntax_err.detail isa Base.JuliaSyntax.ParseError
         syntax_err = PrettySyntaxError(syntax_err)
     end
 

--- a/src/runner/PlutoRunner/src/evaluation/deleting globals.jl
+++ b/src/runner/PlutoRunner/src/evaluation/deleting globals.jl
@@ -128,12 +128,6 @@ function delete_method_doc(m::Method)
 end
 
 
-if VERSION < v"1.7.0-0"
-    @eval macro atomic(ex)
-        esc(ex)
-    end
-end
-
 """
 Delete all methods of `f` that were defined in this notebook, and leave the ones defined in other packages, base, etc. ✂
 

--- a/test/MacroAnalysis.jl
+++ b/test/MacroAnalysis.jl
@@ -311,7 +311,7 @@ import Memoize: @memoize
         @test notebook.cells[begin] |> noerror
         @test notebook.cells[end].errored
 
-        @test expecterror(UndefVarError(Symbol("@m")), notebook.cells[end]; strict=VERSION >= v"1.7")
+        @test expecterror(UndefVarError(Symbol("@m")), notebook.cells[end]; strict=true)
         cleanup(🍭, notebook)
     end
 
@@ -633,7 +633,7 @@ import Memoize: @memoize
         update_run!(🍭, notebook, cell(2))
 
         @test cell(2).errored == true
-        @test expecterror(UndefVarError(Symbol("@dateformat_str")), cell(2); strict=VERSION >= v"1.7")
+        @test expecterror(UndefVarError(Symbol("@dateformat_str")), cell(2); strict=true)
 
         update_run!(🍭, notebook, notebook.cells)
 

--- a/test/React.jl
+++ b/test/React.jl
@@ -1029,29 +1029,20 @@ import Pluto.Configuration: Options, EvaluationOptions
         update_run!(🍭, notebook, notebook.cells)
         @test Pluto.is_just_text(notebook.topology, notebook.cells[1])
         @test Pluto.is_just_text(notebook.topology, notebook.cells[2])
-        @static if VERSION >= v"1.10.0-DEV.1548" # ~JuliaSyntax PR Pluto.jl#2526 julia#46372
-            @test notebook.cells[1].errored
-            @test notebook.cells[2].errored
-            @test notebook.cells[3].errored
+        @test notebook.cells[1].errored
+        @test notebook.cells[2].errored
+        @test notebook.cells[3].errored
 
-            @test haskey(notebook.cells[1].output.body, :source)
-            @test haskey(notebook.cells[1].output.body, :diagnostics)
+        @test haskey(notebook.cells[1].output.body, :source)
+        @test haskey(notebook.cells[1].output.body, :diagnostics)
 
-            @test haskey(notebook.cells[2].output.body, :source)
-            @test haskey(notebook.cells[2].output.body, :diagnostics)
+        @test haskey(notebook.cells[2].output.body, :source)
+        @test haskey(notebook.cells[2].output.body, :diagnostics)
 
-            # not literal syntax error
-            @test haskey(notebook.cells[3].output.body, :msg)
-            @test !haskey(notebook.cells[3].output.body, :source)
-            @test !haskey(notebook.cells[3].output.body, :diagnostics)
-        else
-            @test !occursinerror("(incomplete ", notebook.cells[1])
-            @test !occursinerror("(incomplete ", notebook.cells[2])
-
-            @show notebook.cells[1].output.body
-            @test startswith(notebook.cells[1].output.body[:msg], "syntax:")
-            @test startswith(notebook.cells[2].output.body[:msg], "syntax:")
-        end
+        # not literal syntax error
+        @test haskey(notebook.cells[3].output.body, :msg)
+        @test !haskey(notebook.cells[3].output.body, :source)
+        @test !haskey(notebook.cells[3].output.body, :diagnostics)
     end
 
     @testset "using .LocalModule" begin

--- a/test/helpers.jl
+++ b/test/helpers.jl
@@ -51,7 +51,7 @@ function expecterror(err, cell; strict=true)
     msg = sprint(showerror, err)
 
     # UndefVarError(:x, #undef)
-    if err isa UndefVarError && !isdefined(err, :scope) && VERSION > v"1.10"
+    if err isa UndefVarError && !isdefined(err, :scope) && VERSION >= v"1.11"
         strict = false
         msg = first(split(msg, '\n'; limit=2))
     end

--- a/test/packages/Basic.jl
+++ b/test/packages/Basic.jl
@@ -715,9 +715,7 @@ import Malt
                 # │   cache file:      use_pkgimages = true, debug_level = 1, check_bounds = 1, inline = true, opt_level = 2
                 # └ @ Base loading.jl:2668
                 flip = !match
-                if VERSION >= v"1.9.0-aaa"
-                    🍭.options.compiler.pkgimages = (flip ⊻ Base.JLOptions().use_pkgimages == 1) ? "yes" : "no"
-                end
+                🍭.options.compiler.pkgimages = (flip ⊻ Base.JLOptions().use_pkgimages == 1) ? "yes" : "no"
                 🍭.options.compiler.check_bounds = (flip ⊻ Base.JLOptions().check_bounds == 1) ? "yes" : "no"
                 🍭.options.compiler.inline = (flip ⊻ Base.JLOptions().can_inline == 1) ? "yes" : "no"
                 🍭.options.compiler.optimize = match ? Base.JLOptions().opt_level : 3 - Base.JLOptions().opt_level
@@ -739,11 +737,8 @@ import Malt
             # syncing should have called Pkg.precompile(), which should have generated new precompile caches. 
             # If `match == false`, then this is the second run, and the precompile caches should be different. 
             # These new caches use the same filename (weird...), EXCEPT when the pkgimages flag changed, then you get a new filename.
-            if match == true || VERSION >= v"1.9.0-aaa"
-                @test before_sync != after_sync
-                @test length(before_sync) < length(after_sync)
-            end
-            
+            @test before_sync != after_sync
+            @test length(before_sync) < length(after_sync)
             
             
             # Now actually run the import.
@@ -763,7 +758,7 @@ import Malt
             full_logs = join([log["msg"][1] for log in notebook.cells[1].logs], "\n")
 
             # There should be a log message about loading the cache.
-            VERSION >= v"1.9.0-aaa" && @test occursin(r"Loading.*cache"i, full_logs)
+            @test occursin(r"Loading.*cache"i, full_logs)
             # There should NOT be a log message about rejecting the cache.
             @test !occursin(r"reject.*cache"i, full_logs)
             


### PR DESCRIPTION
Yay!

We should merge and release https://github.com/fonsp/Pluto.jl/pull/3049 first, so that people with Julia 1.6 can get one last Pluto update that includes this warning message.

We also need to fix https://github.com/fonsp/Pluto.jl/pull/2626#issuecomment-1671244510


## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/fonsp/Pluto.jl", rev="remove-1.6-code")
julia> using Pluto
```
