### PR TITLE
Remove deprecations

### DIFF
--- a/src/Configuration.jl
+++ b/src/Configuration.jl
@@ -52,7 +52,6 @@ const AUTO_RELOAD_FROM_FILE_DEFAULT = false
 const AUTO_RELOAD_FROM_FILE_COOLDOWN_DEFAULT = 0.4
 const AUTO_RELOAD_FROM_FILE_IGNORE_PKG_DEFAULT = false
 const NOTEBOOK_DEFAULT = nothing
-const INIT_WITH_FILE_VIEWER_DEFAULT = false
 const SIMULATED_LAG_DEFAULT = 0.0
 const SIMULATED_PKG_LAG_DEFAULT = 0.0
 const INJECTED_JAVASCRIPT_DATA_URL_DEFAULT = "data:text/javascript;base64,"
@@ -77,7 +76,6 @@ The HTTP server options. See [`SecurityOptions`](@ref) for additional settings.
 - `auto_reload_from_file_cooldown::Real = $AUTO_RELOAD_FROM_FILE_COOLDOWN_DEFAULT` Experimental, will be removed
 - `auto_reload_from_file_ignore_pkg::Bool = $AUTO_RELOAD_FROM_FILE_IGNORE_PKG_DEFAULT` Experimental flag, will be removed
 - `notebook::Union{Nothing,String} = $NOTEBOOK_DEFAULT` Optional path of notebook to launch at start
-- `init_with_file_viewer::Bool = $INIT_WITH_FILE_VIEWER_DEFAULT`
 - `simulated_lag::Real=$SIMULATED_LAG_DEFAULT` (internal) Extra lag to add to our server responses. Will be multiplied by `0.5 + rand()`.
 - `simulated_pkg_lag::Real=$SIMULATED_PKG_LAG_DEFAULT` (internal) Extra lag to add to operations done by Pluto's package manager. Will be multiplied by `0.5 + rand()`.
 - `injected_javascript_data_url::String = "$INJECTED_JAVASCRIPT_DATA_URL_DEFAULT"` (internal) Optional javascript injectables to the front-end. Can be used to customize the editor, but this API is not meant for general use yet.
@@ -100,7 +98,6 @@ The HTTP server options. See [`SecurityOptions`](@ref) for additional settings.
     auto_reload_from_file_cooldown::Real = AUTO_RELOAD_FROM_FILE_COOLDOWN_DEFAULT
     auto_reload_from_file_ignore_pkg::Bool = AUTO_RELOAD_FROM_FILE_IGNORE_PKG_DEFAULT
     notebook::Union{Nothing,String,Vector{<:String}} = NOTEBOOK_DEFAULT
-    init_with_file_viewer::Bool = INIT_WITH_FILE_VIEWER_DEFAULT
     simulated_lag::Real = SIMULATED_LAG_DEFAULT
     simulated_pkg_lag::Real = SIMULATED_PKG_LAG_DEFAULT
     injected_javascript_data_url::String = INJECTED_JAVASCRIPT_DATA_URL_DEFAULT
@@ -293,7 +290,6 @@ function from_flat_kwargs(;
         auto_reload_from_file_cooldown::Real = AUTO_RELOAD_FROM_FILE_COOLDOWN_DEFAULT,
         auto_reload_from_file_ignore_pkg::Bool = AUTO_RELOAD_FROM_FILE_IGNORE_PKG_DEFAULT,
         notebook::Union{Nothing,String,Vector{<:String}} = NOTEBOOK_DEFAULT,
-        init_with_file_viewer::Bool = INIT_WITH_FILE_VIEWER_DEFAULT,
         simulated_lag::Real = SIMULATED_LAG_DEFAULT,
         simulated_pkg_lag::Real = SIMULATED_PKG_LAG_DEFAULT,
         injected_javascript_data_url::String = INJECTED_JAVASCRIPT_DATA_URL_DEFAULT,
@@ -342,7 +338,6 @@ function from_flat_kwargs(;
         auto_reload_from_file_cooldown,
         auto_reload_from_file_ignore_pkg,
         notebook,
-        init_with_file_viewer,
         simulated_lag,
         simulated_pkg_lag,
         injected_javascript_data_url,

--- a/src/analysis/DependencyCache.jl
+++ b/src/analysis/DependencyCache.jl
@@ -29,7 +29,6 @@ function upstream_cells_map(cell::Cell, topology::NotebookTopology)::Dict{Symbol
         for sym in referenced_symbols
     )
 end
-@deprecate upstream_cells_map(cell::Cell, notebook::Notebook) upstream_cells_map(cell, notebook.topology)
 
 "Fills cell dependency information for display in the GUI"
 function update_dependency_cache!(cell::Cell, topology::NotebookTopology)

--- a/src/analysis/DependencyCache.jl
+++ b/src/analysis/DependencyCache.jl
@@ -13,7 +13,6 @@ function downstream_cells_map(cell::Cell, topology::NotebookTopology)::Dict{Symb
         for sym in defined_symbols
     )
 end
-@deprecate downstream_cells_map(cell::Cell, notebook::Notebook) downstream_cells_map(cell, notebook.topology)
 
 _is_anon_function_name(s::Symbol) = startswith(String(s), "__ExprExpl_anon__")
 

--- a/src/evaluation/WorkspaceManager.jl
+++ b/src/evaluation/WorkspaceManager.jl
@@ -606,11 +606,6 @@ function move_vars(
     )
 end
 
-# TODO: delete me
-@deprecate(
-    delete_vars(args...; kwargs...),
-    move_vars(args...; kwargs...)
-)
 
 """
 ```julia

--- a/src/notebook/Notebook.jl
+++ b/src/notebook/Notebook.jl
@@ -129,17 +129,6 @@ function PlutoDependencyExplorer.topological_order(notebook::Notebook)
 	end
 end
 
-function PlutoDependencyExplorer.where_referenced(notebook::Notebook, topology::NotebookTopology, something)
-    # can't use @deprecate on an overload
-    @warn "Deprecated, drop the notebook argument"
-    PlutoDependencyExplorer.where_referenced(topology, something)
-end
-function PlutoDependencyExplorer.where_assigned(notebook::Notebook, topology::NotebookTopology, something)
-    # can't use @deprecate on an overload
-    @warn "Deprecated, drop the notebook argument"
-    PlutoDependencyExplorer.where_assigned(topology, something)
-end
-
 emptynotebook(args...) = Notebook([Cell()], args...)
 
 function sample_notebook(name::String)

--- a/src/webserver/SessionActions.jl
+++ b/src/webserver/SessionActions.jl
@@ -213,10 +213,6 @@ end
 
 "Create a new empty notebook inside `session::ServerSession`. Returns the `Notebook`."
 function new(session::ServerSession; run_async=true, notebook_id::UUID=uuid1())
-    if session.options.server.init_with_file_viewer
-        @error "DEPRECATED: init_with_file_viewer has been removed."
-    end
-    
     notebook = if session.options.compiler.sysimage === nothing
         emptynotebook()
     else


### PR DESCRIPTION
We are going to release 0.20.0 soon. That means we can remove some deprecations


- `init_with_file_viewer`
- `downstream_cells_map`
- `upstream_cells_map(cell::Cell, notebook::Notebook)`
- `delete_vars`
- `where_referenced(notebook::Notebook, topology::NotebookTopology, something)`
- `where_assigned(notebook::Notebook, topology::NotebookTopology, something)`

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/fonsp/Pluto.jl", rev="remove-deprecations")
julia> using Pluto
```
