### PR TITLE
autocomplete: handle definitions from other cells

### DIFF
--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -547,6 +547,17 @@ export const CellInput = ({
             }
         })
 
+        const unsubmitted_globals_updater = EditorView.updateListener.of((update) => {
+            if (update.docChanged) {
+                const before = [...update.startState.field(ScopeStateField).definitions.keys()]
+                const after = [...update.state.field(ScopeStateField).definitions.keys()]
+
+                if (!_.isEqual(before, after)) {
+                    pluto_actions.set_unsubmitted_global_definitions(cell_id, after)
+                }
+            }
+        })
+
         const usesDarkTheme = window.matchMedia("(prefers-color-scheme: dark)").matches
         const newcm = (newcm_ref.current = new EditorView({
             state: EditorState.create({
@@ -597,6 +608,7 @@ export const CellInput = ({
                     highlightSelectionMatches({ minSelectionLength: 2, wholeWords: true }),
                     bracketMatching(),
                     docs_updater,
+                    unsubmitted_globals_updater,
                     tab_help_plugin,
                     // Remove selection on blur
                     EditorView.domEventHandlers({
@@ -668,6 +680,8 @@ export const CellInput = ({
                         },
                         request_special_symbols: () => pluto_actions.send("complete_symbols").then(({ message }) => message),
                         on_update_doc_query: on_update_doc_query,
+                        request_unsubmitted_global_definitions: () => pluto_actions.get_unsubmitted_global_definitions(),
+                        cell_id,
                     }),
 
                     // I put plutoKeyMaps separately because I want make sure we have

--- a/frontend/components/CellInput/go_to_definition_plugin.js
+++ b/frontend/components/CellInput/go_to_definition_plugin.js
@@ -67,6 +67,7 @@ let get_variable_marks = (state, { scopestate, global_definitions }) => {
 const filter_non_null = (xs) => /** @type {Array<T>} */ (xs.filter((x) => x != null))
 
 /**
+ * Key: variable name, value: cell id.
  * @type {Facet<{ [variable_name: string]: string }, { [variable_name: string]: string }>}
  */
 export const GlobalDefinitionsFacet = Facet.define({


### PR DESCRIPTION
Autocomplete now includes globals that are defined in other cells, but not yet submitted (with Ctrl+S or the run button). Fix https://github.com/fonsp/Pluto.jl/issues/2991



<img width="280" alt="image" src="https://github.com/user-attachments/assets/b9807b5e-eb84-4a47-b61f-bee291204429">


https://github.com/user-attachments/assets/847337f2-bbea-436f-b411-e1dd7fcf600e


## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/fonsp/Pluto.jl", rev="autocomplete-handle-definitions-from-other-cells")
julia> using Pluto
```
