### PR TITLE
docs: use JuliaMono

### DIFF
--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -2551,7 +2551,8 @@ body > pluto-helpbox > header > button:is(.helpbox-close, .helpbox-popout) {
 .helpbox-docs code,
 .helpbox-docs .cm-line {
     /* from https://docs.julialang.org/en/v1/assets/themes/documenter-light.css */
-    font-family: "Roboto Mono", "SFMono-Regular", "Menlo", "Consolas", "Liberation Mono", "DejaVu Sans Mono", monospace;
+    font-family: "JuliaMono", "SFMono-Regular", "Menlo", "Consolas", "Liberation Mono", "DejaVu Sans Mono", monospace;
+    font-variant-ligatures: none;
     font-size: 0.95em;
     line-height: initial;
 }

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -2551,7 +2551,7 @@ body > pluto-helpbox > header > button:is(.helpbox-close, .helpbox-popout) {
 .helpbox-docs code,
 .helpbox-docs .cm-line {
     /* from https://docs.julialang.org/en/v1/assets/themes/documenter-light.css */
-    font-family: "JuliaMono", "SFMono-Regular", "Menlo", "Consolas", "Liberation Mono", "DejaVu Sans Mono", monospace;
+    font-family: var(--julia-mono-font-stack);
     font-variant-ligatures: none;
     font-size: 0.95em;
     line-height: initial;


### PR DESCRIPTION
documenter has since switch to JuliaMono for code blocks.

https://github.com/JuliaDocs/Documenter.jl/blob/a0257f939c2be20c7a68ecc02c4ada8210f29495/assets/html/scss/documenter-dark.scss#L18
## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/fonsp/Pluto.jl", rev="docs-julia-mono")
julia> using Pluto
```
