### PR TITLE
Add stale cells (aka single-shot cells)

### DIFF
--- a/frontend/components/Cell.js
+++ b/frontend/components/Cell.js
@@ -105,7 +105,19 @@ const on_jump = (hasBarrier, pluto_actions, cell_id) => () => {
  * */
 export const Cell = ({
     cell_input: { cell_id, code, code_folded, metadata },
-    cell_result: { queued, running, runtime, errored, output, logs, published_object_keys, depends_on_disabled_cells, depends_on_skipped_cells },
+    cell_result: {
+        queued,
+        running,
+        runtime,
+        errored,
+        output,
+        logs,
+        published_object_keys,
+        depends_on_disabled_cells,
+        depends_on_skipped_cells,
+        stale,
+        depends_on_stale_cells,
+    },
     cell_dependencies,
     cell_input_local,
     notebook_id,
@@ -294,8 +306,10 @@ export const Cell = ({
                 code_folded,
                 skip_as_script,
                 running_disabled,
+                stale,
                 depends_on_disabled_cells,
                 depends_on_skipped_cells,
+                depends_on_stale_cells,
                 show_input,
                 shrunk: Object.values(logs).length > 0,
                 hooked_up: output?.has_pluto_hook_features ?? false,
@@ -315,9 +329,42 @@ export const Cell = ({
                 <span></span>
             </button>
             <pluto-shoulder draggable="true" title="Drag to move cell">
-                <button onClick=${on_code_fold} class="foldcode" title="Show/hide code">
-                    <span></span>
-                </button>
+                <div>
+                    <button onClick=${on_code_fold} class="foldcode" title="Show/hide code">
+                        <span></span>
+                    </button>
+                    ${stale
+                        ? html`<button
+                              class="stale_cell_marker"
+                              title=${`This cell’s output is stale. Click to know more!`}
+                              onClick=${(e) => {
+                                  open_pluto_popup({
+                                      type: "info",
+                                      source_element: e.target,
+                                      body: html`This cell’s outputs is wrapped in a PlutoRunner.Stale object. This freezes all the cells that depend on this
+                                      one.`,
+                                  })
+                              }}
+                          >
+                              <span></span>
+                          </button>`
+                        : depends_on_stale_cells
+                        ? html`<button
+                              class="depends_on_stale_cells_marker"
+                              title=${`This cell depends on stale cells. Click to know more!`}
+                              onClick=${(e) => {
+                                  open_pluto_popup({
+                                      type: "info",
+                                      source_element: e.target,
+                                      body: html`This cell depends on a cell whose outputs is wrapped in a PlutoRunner.Stale object. This freezes all the cells
+                                      that depend on it, including this one.`,
+                                  })
+                              }}
+                          >
+                              <span></span>
+                          </button>`
+                        : null}
+                </div>
             </pluto-shoulder>
             <pluto-trafficlight></pluto-trafficlight>
             ${code_not_trusted_yet

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -118,7 +118,7 @@ const first_true_key = (obj) => {
  * @type {{
  *    disabled: boolean,
  *    show_logs: boolean,
- *    skip_as_script: boolean
+ *    skip_as_script: boolean,
  *  }}
  *
  * @typedef CellInputData
@@ -160,12 +160,14 @@ const first_true_key = (obj) => {
  *  queued: boolean,
  *  running: boolean,
  *  errored: boolean,
+ *  stale: boolean,
  *  runtime: number?,
  *  downstream_cells_map: { string: [string]},
  *  upstream_cells_map: { string: [string]},
  *  precedence_heuristic: number?,
  *  depends_on_disabled_cells: boolean,
  *  depends_on_skipped_cells: boolean,
+ *  depends_on_stale_cells: boolean,
  *  output: {
  *      body: string,
  *      persist_js_state: boolean,

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -1253,6 +1253,11 @@ pluto-display > div {
     display: none;
 }
 
+/* STALE CELLS */
+pluto-cell.stale > pluto-output {
+    background: var(--pluto-stale-output-bg-color);
+}
+
 /* DISABLED CELLS */
 
 pluto-cell.depends_on_disabled_cells > pluto-output,
@@ -1390,7 +1395,7 @@ button.floating_back_button,
 pluto-cell > button,
 pluto-input > button,
 pluto-runarea > button,
-pluto-shoulder > button,
+pluto-shoulder > div > button,
 nav#slide_controls > button {
     position: absolute;
     margin: 0px;
@@ -1420,7 +1425,6 @@ pluto-shoulder {
     --invisible-border: calc(0.5 * var(--pluto-cell-spacing));
     --shoulder-width: calc(28px + var(--invisible-border));
     --border-radius: calc(5px + var(--invisible-border));
-
     left: calc(0px - var(--shoulder-width));
     width: var(--shoulder-width);
     border-radius: var(--border-radius) 0px 0px var(--border-radius);
@@ -1434,6 +1438,7 @@ pluto-shoulder {
     bottom: calc(0px - var(--invisible-border));
     border: var(--invisible-border) solid rgba(0, 0, 0, 0);
     border-right: none;
+    overflow: clip;
 }
 pluto-editor.fullscreen pluto-shoulder {
     --shoulder-width: 2000px;
@@ -1444,29 +1449,41 @@ pluto-shoulder:hover {
     background-clip: padding-box;
 }
 
-pluto-shoulder > button {
+pluto-shoulder > div {
     flex: 0 0 auto;
     position: sticky;
     top: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+pluto-shoulder > div > button {
+    position: static;
     padding: 4px 5px 4px 10px;
 }
 
-pluto-cell:focus-within > pluto-shoulder > button {
+pluto-cell:focus-within > pluto-shoulder > div > button {
     /* we use padding instead of 4px extra margin to move the eye to the left so that the hitbox becomes grows - you want to be able to double click the button */
     padding-right: 9px;
 }
 
-/* pluto-cell.code_folded.inline-output > pluto-shoulder > button {
+/* pluto-cell.code_folded.inline-output > pluto-shoulder > div > button {
     margin-top: 3px;
 } */
 
-pluto-shoulder > button > span::after {
+pluto-shoulder > div > button.foldcode > span::after {
     background-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/eye-outline.svg");
     filter: var(--image-filters);
 }
 
-pluto-cell.code_folded > pluto-shoulder > button > span::after {
+pluto-cell.code_folded > pluto-shoulder > div > button.foldcode > span::after {
     background-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/eye-off-outline.svg");
+    filter: var(--image-filters);
+}
+
+pluto-shoulder > div > button.stale_cell_marker > span::after,
+pluto-shoulder > div > button.depends_on_stale_cells_marker > span::after {
+    background-image: url("https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/warning-outline.svg");
     filter: var(--image-filters);
 }
 
@@ -1548,6 +1565,14 @@ body:not(.___) pluto-cell.errored > pluto-trafficlight {
     background-clip: padding-box;
 }
 
+/* stale cells */
+body:not(.___) pluto-cell.stale > pluto-trafficlight,
+body:not(.___) pluto-cell.depends_on_stale_cells > pluto-trafficlight {
+    background: var(--stale-cell-color);
+    border-left-color: var(--stale-cell-color);
+    background-clip: padding-box;
+}
+
 body:not(.___) pluto-cell.queued > pluto-trafficlight::after {
     background: repeating-linear-gradient(-45deg, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0) 8px, var(--normal-cell-color) 8px, var(--normal-cell-color) 16px);
     background-clip: padding-box;
@@ -1624,7 +1649,7 @@ pluto-input > button > span {
     pluto-cell > button,
     pluto-input > button,
     pluto-runarea > button,
-    pluto-shoulder > button,
+    pluto-shoulder > div > button,
     pluto-cell > pluto-runarea {
         opacity: 0;
         /* to make it feel smooth: */
@@ -1638,8 +1663,8 @@ pluto-input > button > span {
     pluto-cell:hover > pluto-input > button,
     pluto-cell:focus-within > pluto-input > button,
     pluto-cell > pluto-runarea > button,
-    pluto-cell:hover > pluto-shoulder > button,
-    pluto-cell:focus-within > pluto-shoulder > button {
+    pluto-cell:hover > pluto-shoulder > div > button,
+    pluto-cell:focus-within > pluto-shoulder > div > button {
         opacity: 0.6;
         transition: opacity 0.25s ease-in-out;
     }
@@ -1650,7 +1675,7 @@ pluto-input > button > span {
     pluto-cell > button:hover,
     pluto-cell > pluto-input > button:hover,
     pluto-cell > pluto-runarea > button:hover,
-    pluto-cell > pluto-shoulder > button:hover,
+    pluto-cell > pluto-shoulder > div > button:hover,
     pluto-cell:hover > pluto-runarea {
         opacity: 1;
         /* to make it feel snappy: */
@@ -1661,7 +1686,7 @@ pluto-input > button > span {
 @media screen and (pointer: coarse) {
     pluto-cell > button.add_cell,
     pluto-input > button,
-    pluto-shoulder > button {
+    pluto-shoulder > div > button {
         opacity: 0.25;
         transition: opacity 0.25s ease-in-out;
     }
@@ -1676,14 +1701,14 @@ pluto-input > button > span {
     pluto-cell:focus-within > button.add_cell,
     pluto-cell:focus-within > pluto-input > button,
     pluto-cell:focus-within > pluto-runarea,
-    pluto-cell:focus-within > pluto-shoulder > button {
+    pluto-cell:focus-within > pluto-shoulder > div > button {
         opacity: 0.6;
         transition: opacity 0.25s ease-in-out;
     }
     pluto-cell > pluto-input > button:focus-within,
     pluto-cell > button:focus-within,
     pluto-cell > pluto-input > button:focus-within pluto-cell > pluto-runarea > button:focus-within,
-    pluto-cell > pluto-shoulder > button:focus-within,
+    pluto-cell > pluto-shoulder > div > button:focus-within,
     pluto-cell > pluto-runarea {
         opacity: 1;
         /* to make it feel snappy: */
@@ -1694,7 +1719,7 @@ pluto-input > button > span {
 pluto-cell > button > span::after,
 pluto-input > button > span::after,
 pluto-runarea > button > span::after,
-pluto-shoulder > button > span::after {
+pluto-shoulder > div > button > span::after {
     display: block;
     content: " " !important;
     background-size: 17px 17px;

--- a/frontend/themes/dark.css
+++ b/frontend/themes/dark.css
@@ -23,6 +23,7 @@
         --error-cell-color: rgba(var(--error-color), 0.6);
         --bright-error-cell-color: rgba(var(--error-color), 0.9);
         --light-error-cell-color: rgba(var(--error-color), 0);
+        --stale-cell-color: #b86f00;
 
         /*Export styling*/
         --export-bg-color: hsl(225deg 17% 18%);
@@ -45,6 +46,7 @@
         --pluto-output-color: hsl(0deg 0% 77%);
         --pluto-output-h-color: hsl(0, 0%, 90%);
         --pluto-output-bg-color: var(--main-bg-color);
+        --pluto-stale-output-bg-color: #332300;
         --a-underline: #ffffff69;
         --blockquote-color: inherit;
         --blockquote-bg: #2e2e2e;

--- a/frontend/themes/light.css
+++ b/frontend/themes/light.css
@@ -23,6 +23,7 @@
         --error-cell-color: rgba(var(--error-color), 0.7);
         --bright-error-cell-color: rgb(var(--error-color));
         --light-error-cell-color: rgba(var(--error-color), 0.05);
+        --stale-cell-color: #ffba53;
 
         /*Export styling*/
         --export-bg-color: rgb(60, 67, 101);
@@ -45,6 +46,7 @@
         --pluto-output-color: hsl(0, 0%, 25%);
         --pluto-output-h-color: hsl(0, 0%, 12%);
         --pluto-output-bg-color: white;
+        --pluto-stale-output-bg-color: #ffeed5;
         --a-underline: #00000059;
         --blockquote-color: #555;
         --blockquote-bg: #f2f2f2;
@@ -191,36 +193,36 @@
 
         /* code highlighting */
         --cm-color-editor-text: #41323f;
-        --cm-color-comment:     #e96ba8;
-        --cm-color-atom:        #815ba4;
-        --cm-color-number:      #815ba4;
-        --cm-color-property:    #b67a48;
-        --cm-color-keyword:     #ef6155;
-        --cm-color-string:      #da5616;
-        --cm-color-var:         #5668a4;
-        --cm-color-var2:        #37768a;
-        --cm-color-macro:       #5c8c5f;
-        --cm-color-builtin:     #5e7ad3;
-        --cm-color-function:    #cc80ac;
-        --cm-color-type:        hsl(170deg 7% 56%);
-        --cm-color-bracket:     #41323f;
-        --cm-color-tag:         #ef6155;
-        --cm-color-link:        #815ba4;
-        --cm-color-error-bg:    #ef6155;
-        --cm-color-error:       #f7f7f7;
+        --cm-color-comment: #e96ba8;
+        --cm-color-atom: #815ba4;
+        --cm-color-number: #815ba4;
+        --cm-color-property: #b67a48;
+        --cm-color-keyword: #ef6155;
+        --cm-color-string: #da5616;
+        --cm-color-var: #5668a4;
+        --cm-color-var2: #37768a;
+        --cm-color-macro: #5c8c5f;
+        --cm-color-builtin: #5e7ad3;
+        --cm-color-function: #cc80ac;
+        --cm-color-type: hsl(170deg 7% 56%);
+        --cm-color-bracket: #41323f;
+        --cm-color-tag: #ef6155;
+        --cm-color-link: #815ba4;
+        --cm-color-error-bg: #ef6155;
+        --cm-color-error: #f7f7f7;
         --cm-color-matchingBracket: black;
         --cm-color-matchingBracket-bg: #1b4bbb21;
         --cm-color-placeholder-text: rgba(0, 0, 0, 0.2);
         --cm-color-clickable-underline: #ced2ef;
 
         /* Mixed parsers */
-        --cm-color-html:        #48b685;
+        --cm-color-html: #48b685;
         --cm-color-html-accent: #00ab85;
-        --cm-color-css:         #876800;
-        --cm-color-css-accent:  #696200;
+        --cm-color-css: #876800;
+        --cm-color-css-accent: #696200;
         --cm-css-why-doesnt-codemirror-highlight-all-the-text-aaa: #3b3700;
-        --cm-color-md:          #005a9b;
-        --cm-color-md-accent:   #00a9d1;
+        --cm-color-md: #005a9b;
+        --cm-color-md-accent: #00a9d1;
 
         /*autocomplete menu*/
         --autocomplete-menu-bg-color: white;

--- a/src/notebook/Cell.jl
+++ b/src/notebook/Cell.jl
@@ -43,6 +43,7 @@ Base.@kwdef mutable struct Cell <: PlutoDependencyExplorer.AbstractCell
     output::CellOutput=CellOutput()
     queued::Bool=false
     running::Bool=false
+    stale::Bool=false
 
     published_objects::Dict{String,Any}=Dict{String,Any}()
     
@@ -56,6 +57,7 @@ Base.@kwdef mutable struct Cell <: PlutoDependencyExplorer.AbstractCell
 
     depends_on_disabled_cells::Bool=false
     depends_on_skipped_cells::Bool=false
+    depends_on_stale_cells::Bool=false
 
     metadata::Dict{String,Any}=copy(DEFAULT_CELL_METADATA)
 end
@@ -84,3 +86,4 @@ end
 can_show_logs(c::Cell) = get(c.metadata, METADATA_SHOW_LOGS_KEY, DEFAULT_CELL_METADATA[METADATA_SHOW_LOGS_KEY])
 is_skipped_as_script(c::Cell) = get(c.metadata, METADATA_SKIP_AS_SCRIPT_KEY, DEFAULT_CELL_METADATA[METADATA_SKIP_AS_SCRIPT_KEY])
 must_be_commented_in_file(c::Cell) = is_disabled(c) || is_skipped_as_script(c) || c.depends_on_disabled_cells || c.depends_on_skipped_cells
+stale(c::Cell) = c.stale

--- a/src/runner/PlutoRunner/src/PlutoRunner.jl
+++ b/src/runner/PlutoRunner/src/PlutoRunner.jl
@@ -30,6 +30,9 @@ abstract type SpecialPlutoExprValue end
 struct GiveMeCellID <: SpecialPlutoExprValue end
 struct GiveMeRerunCellFunction <: SpecialPlutoExprValue end
 struct GiveMeRegisterCleanupFunction <: SpecialPlutoExprValue end
+struct Stale
+    out
+end
 
 
 # TODO: clear key when a cell is deleted furever

--- a/src/webserver/Dynamic.jl
+++ b/src/webserver/Dynamic.jl
@@ -124,9 +124,11 @@ function notebook_to_js(notebook::Notebook)
                 "queued" => cell.queued,
                 "running" => cell.running,
                 "errored" => cell.errored,
+                "stale" => cell.stale,
                 "runtime" => cell.runtime,
                 "logs" => FirebaseyUtils.AppendonlyMarker(cell.logs),
                 "depends_on_skipped_cells" => cell.depends_on_skipped_cells,
+                "depends_on_stale_cells" => cell.depends_on_stale_cells,
             )
         for (id, cell) in notebook.cells_dict),
         "cell_order" => notebook.cell_order,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -45,6 +45,7 @@ verify_no_running_processes()
 @timeit_include("DependencyCache.jl")
 @timeit_include("Throttled.jl")
 @timeit_include("cell_disabling.jl")
+@timeit_include("stale_cells.jl")
 
 verify_no_running_processes()
 

--- a/test/stale_cells.jl
+++ b/test/stale_cells.jl
@@ -1,0 +1,90 @@
+using Test
+using Pluto
+using Pluto: update_run!, ServerSession, Cell, Notebook, WorkspaceManager
+
+@testset "Stale cells" begin
+    🍭 = ServerSession()
+    🍭.options.evaluation.workspace_use_distributed = false
+
+    notebook = Notebook([
+        Cell("a = 1") # 1
+        Cell("b = a + 1") # 2
+
+        Cell("""
+        begin
+            c = b
+            push!(runs, a + 1)
+            b
+        end
+            """) # 3
+
+        Cell("a + 1") # 4
+
+        Cell("begin runs = [] end") # 5
+
+        Cell("length(runs)") # 6
+
+        Cell("c") # 7
+    ])
+    update_run!(🍭, notebook, notebook.cells)
+
+    id(i) = notebook.cells[i].cell_id
+    c(i) = notebook.cells[i]
+    get_depends_on_stale_cells(notebook::Notebook) = [i for (i, c) in pairs(notebook.cells) if c.depends_on_stale_cells]
+    get_stale_cells(notebook::Notebook) = [i for (i, c) in pairs(notebook.cells) if c.stale]
+
+    @test get_stale_cells(notebook) == []
+    @test get_depends_on_stale_cells(notebook) == []
+    @test all(noerror, notebook.cells)
+    @test c(6).output.body == "1"
+
+    # Cell metadata gets updated
+    setcode!(c(2), "begin b = a + 1; Main.PlutoRunner.Stale(Nothing) end")
+
+    update_run!(🍭, notebook, c(2))
+
+    @test get_stale_cells(notebook) == [2]
+    @test get_depends_on_stale_cells(notebook) == [3, 7]
+    @test all(noerror, notebook.cells)
+
+    # depends_on_stale_cells output does not change, but stale cells do
+    setcode!(c(2), "begin b = a + 2; Main.PlutoRunner.Stale(b) end")
+
+    update_run!(🍭, notebook, c(2))
+    update_run!(🍭, notebook, c(6))
+
+    @test get_stale_cells(notebook) == [2]
+    @test get_depends_on_stale_cells(notebook) == [3, 7]
+    @test c(3).output.body == "2"
+    @test c(2).output.body == "3"
+    @test all(noerror, notebook.cells)
+    @test c(6).output.body == "1"
+
+    setcode!(c(1), "a = 2")
+
+    update_run!(🍭, notebook, c(1))
+    update_run!(🍭, notebook, c(6))
+
+    @test get_stale_cells(notebook) == [2]
+    @test get_depends_on_stale_cells(notebook) == [3, 7]
+    @test c(3).output.body == "2"
+    @test c(2).output.body == "4"
+    @test c(7).output.body == "2"
+    @test all(noerror, notebook.cells)
+    @test c(6).output.body == "1"
+
+    # we can resume
+    setcode!(c(2), "begin b = a + 2; Nothing end")
+
+    update_run!(🍭, notebook, c(2))
+    update_run!(🍭, notebook, c(6))
+
+    @test get_stale_cells(notebook) == []
+    @test get_depends_on_stale_cells(notebook) == []
+    @test c(3).output.body == "4"
+    @test c(7).output.body == "4"
+    @test all(noerror, notebook.cells)
+    @test c(6).output.body == "2"
+
+    cleanup(🍭, notebook)
+end


### PR DESCRIPTION
As discussed in #2970 and previous discussions, having a way to temporarily block the execution of long-running cells would be beneficial.

This implementation goes for a very flexible solution: `Main.PlutoRunner.Stale`. When returned from a cell, this struct passes down its formatting to its single member `out`. However, the cell also gets marked as stale. This means that none of the cells that depend on it will be run. The stale cell, however, will still be run when its dependencies run, to see if its no longer stale.

On the frontend stale outputs are displayed on a light or dark orange background while stale cells and cells that depend on them get orange traffic lights.

When a cell is in one of those two states a warning sign with an explanatory popup is displayed below the "fold code" button.

(see picture below)

<img width="780" alt="Picture of frontend rendering" src="https://github.com/user-attachments/assets/b7ca7264-b555-4618-b0fd-4068e2d325a4">

## Small details
- We might want to change the frontend formatting a bit. Maybe dim the cells like when they are disabled.
- Implementation-wise, I decided not to touch the topology when running the cells, because of the dynamic nature of the stale state. I basically only check if a cell depends on stale ones before running it. We could pro-actively exclude all dependents of a cell that returns Stale.

## Future
We could add utility macros to PlutoHooks/PlutoLinks, something like `single-shot`. This would show how to use the marker.

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/SimonLafran/Pluto.jl", rev="stale-cells")
julia> using Pluto
```
