### PR TITLE
Make JuliaFormatter ignore bind macro in notebook file

### DIFF
--- a/src/notebook/saving and loading.jl
+++ b/src/notebook/saving and loading.jl
@@ -50,10 +50,8 @@ function save_notebook(io::IO, notebook::Notebook)
     # Super Advanced Code Analysis™ to add the @bind macro to the saved file if it's used somewhere.
     if any(!must_be_commented_in_file(c) && occursin("@bind", c.code) for c in notebook.cells)
         println(io, "")
-        println(io, "#! format: off") # Turn off formatting. See https://domluna.github.io/JuliaFormatter.jl/stable/#Turn-off/on-formatting
         println(io, "# This Pluto notebook uses @bind for interactivity. When running this notebook outside of Pluto, the following 'mock version' of @bind gives bound variables a default value (instead of an error).")
         println(io, PlutoRunner.fake_bind)
-        println(io, "#! format: on") # Turn formatting back on.
     end
     println(io)
 
@@ -93,6 +91,7 @@ function save_notebook(io::IO, notebook::Notebook)
         end
     end
 
+    println(io, "#! format: off") # Turn off formatting for the rest of the document.
 
     using_plutopkg = notebook.nbpkg_ctx !== nothing
 

--- a/src/notebook/saving and loading.jl
+++ b/src/notebook/saving and loading.jl
@@ -32,7 +32,7 @@ Have a look at our [JuliaCon 2020 presentation](https://youtu.be/IAF8DjrQSSk?t=1
 function save_notebook(io::IO, notebook::Notebook)
     println(io, _notebook_header)
     println(io, "# ", PLUTO_VERSION_STR)
-    
+
     # Notebook metadata
     let nb_metadata_toml = strip(sprint(TOML.print, get_metadata_no_default(notebook)))
         if !isempty(nb_metadata_toml)
@@ -58,7 +58,7 @@ function save_notebook(io::IO, notebook::Notebook)
     println(io)
 
     cells_ordered = collect(topological_order(notebook))
-    
+
     # NOTE: the notebook topological is cached on every update_dependency! call
     # ....  so it is possible that a cell was added/removed since this last update.
     # ....  in this case, it will not contain that cell since it is build from its
@@ -93,13 +93,13 @@ function save_notebook(io::IO, notebook::Notebook)
         end
     end
 
-    
+
     using_plutopkg = notebook.nbpkg_ctx !== nothing
-    
+
     write_package = if using_plutopkg
         ptoml_contents = PkgCompat.read_project_file(notebook)
         mtoml_contents = PkgCompat.read_manifest_file(notebook)
-        
+
         !isempty(strip(ptoml_contents))
     else
         false
@@ -111,14 +111,14 @@ function save_notebook(io::IO, notebook::Notebook)
         write(io, ptoml_contents)
         print(io, "\"\"\"")
         print(io, _cell_suffix)
-        
+
         println(io, _cell_id_delimiter, string(_mtoml_cell_id))
         print(io, "PLUTO_MANIFEST_TOML_CONTENTS = \"\"\"\n")
         write(io, mtoml_contents)
         print(io, "\"\"\"")
         print(io, _cell_suffix)
     end
-    
+
 
     println(io, _cell_id_delimiter, "Cell order:")
     for c in notebook.cells
@@ -139,7 +139,7 @@ function write_buffered(fn::Function, path)
     file_content = sprint(fn)
     write(path, file_content)
 end
-    
+
 function save_notebook(notebook::Notebook, path::String)
     # @warn "Saving to file!!" exception=(ErrorException(""), backtrace())
     notebook.last_save_time = time()

--- a/src/notebook/saving and loading.jl
+++ b/src/notebook/saving and loading.jl
@@ -50,10 +50,10 @@ function save_notebook(io::IO, notebook::Notebook)
     # Super Advanced Code Analysis™ to add the @bind macro to the saved file if it's used somewhere.
     if any(!must_be_commented_in_file(c) && occursin("@bind", c.code) for c in notebook.cells)
         println(io, "")
-        println(io, "#! format: off")
+        println(io, "#! format: off") # Turn off formatting. See https://domluna.github.io/JuliaFormatter.jl/stable/#Turn-off/on-formatting
         println(io, "# This Pluto notebook uses @bind for interactivity. When running this notebook outside of Pluto, the following 'mock version' of @bind gives bound variables a default value (instead of an error).")
         println(io, PlutoRunner.fake_bind)
-        println(io, "#! format: on")
+        println(io, "#! format: on") # Turn formatting back on.
     end
     println(io)
 

--- a/src/notebook/saving and loading.jl
+++ b/src/notebook/saving and loading.jl
@@ -91,7 +91,6 @@ function save_notebook(io::IO, notebook::Notebook)
         end
     end
 
-    println(io, "#! format: off") # Turn off formatting for the rest of the document.
 
     using_plutopkg = notebook.nbpkg_ctx !== nothing
 

--- a/src/notebook/saving and loading.jl
+++ b/src/notebook/saving and loading.jl
@@ -50,8 +50,10 @@ function save_notebook(io::IO, notebook::Notebook)
     # Super Advanced Code Analysis™ to add the @bind macro to the saved file if it's used somewhere.
     if any(!must_be_commented_in_file(c) && occursin("@bind", c.code) for c in notebook.cells)
         println(io, "")
+        println(io, "#! format: off")
         println(io, "# This Pluto notebook uses @bind for interactivity. When running this notebook outside of Pluto, the following 'mock version' of @bind gives bound variables a default value (instead of an error).")
         println(io, PlutoRunner.fake_bind)
+        println(io, "#! format: on")
     end
     println(io)
 

--- a/src/runner/PlutoRunner/src/bonds.jl
+++ b/src/runner/PlutoRunner/src/bonds.jl
@@ -133,7 +133,7 @@ end
 
 """
 Will be inserted in saved notebooks that use the @bind macro, make sure that they still contain legal syntax when executed as a vanilla Julia script. Overloading `Base.get` for custom UI objects gives bound variables a sensible value.
-Also turns off JuliaFormatter formatting to avoid issueswith the formatter trying to change code that the user does not control. See https://domluna.github.io/JuliaFormatter.jl/stable/#Turn-off/on-formatting
+Also turns off JuliaFormatter formatting to avoid issues with the formatter trying to change code that the user does not control. See https://domluna.github.io/JuliaFormatter.jl/stable/#Turn-off/on-formatting
 """
 const fake_bind = """macro bind(def, element)
     #! format: off

--- a/src/runner/PlutoRunner/src/bonds.jl
+++ b/src/runner/PlutoRunner/src/bonds.jl
@@ -10,7 +10,7 @@ function transform_bond_value(s::Symbol, value_from_js)
     catch e
         @error "🚨 AbstractPlutoDingetjes: Bond value transformation errored." exception=(e, catch_backtrace())
         (;
-            message=Text("🚨 AbstractPlutoDingetjes: Bond value transformation errored."), 
+            message=Text("🚨 AbstractPlutoDingetjes: Bond value transformation errored."),
             exception=Text(
                 sprint(showerror, e, stacktrace(catch_backtrace()))
             ),
@@ -35,16 +35,16 @@ function possible_bond_values(s::Symbol; get_length::Bool=false)
         :InfinitePossibilities
     elseif (possible_values isa AbstractPlutoDingetjes.Bonds.NotGiven)
         # error("Bond \"$s\" did not specify its possible values with `AbstractPlutoDingetjes.Bond.possible_values()`. Try using PlutoUI for the `@bind` values.")
-        
+
         # If you change this, change it everywhere in this file.
         :NotGiven
     else
-        get_length ? 
+        get_length ?
             try
                 length(possible_values)
             catch
                 length(make_serializable(possible_values))
-            end : 
+            end :
             make_serializable(possible_values)
     end
 end
@@ -118,7 +118,7 @@ x^2
 The first cell will show a slider as the cell's output, ranging from 0 until 100.
 The second cell will show the square of `x`, and is updated in real-time as the slider is moved.
 """
-macro bind(def, element)    
+macro bind(def, element)
 	if def isa Symbol
 		quote
 			$(load_integrations_if_needed)()
@@ -135,11 +135,13 @@ end
 Will be inserted in saved notebooks that use the @bind macro, make sure that they still contain legal syntax when executed as a vanilla Julia script. Overloading `Base.get` for custom UI objects gives bound variables a sensible value.
 """
 const fake_bind = """macro bind(def, element)
+    #! format: off # Turn off formatting. See https://domluna.github.io/JuliaFormatter.jl/stable/#Turn-off/on-formatting
     quote
         local iv = try Base.loaded_modules[Base.PkgId(Base.UUID("6e696c72-6542-2067-7265-42206c756150"), "AbstractPlutoDingetjes")].Bonds.initial_value catch; b -> missing; end
         local el = \$(esc(element))
         global \$(esc(def)) = Core.applicable(Base.get, el) ? Base.get(el) : iv(el)
         el
     end
+    #! format: on # Turn formatting back on.
 end"""
 

--- a/src/runner/PlutoRunner/src/bonds.jl
+++ b/src/runner/PlutoRunner/src/bonds.jl
@@ -133,15 +133,16 @@ end
 
 """
 Will be inserted in saved notebooks that use the @bind macro, make sure that they still contain legal syntax when executed as a vanilla Julia script. Overloading `Base.get` for custom UI objects gives bound variables a sensible value.
+Also turns off JuliaFormatter formatting to avoid issueswith the formatter trying to change code that the user does not control. See https://domluna.github.io/JuliaFormatter.jl/stable/#Turn-off/on-formatting
 """
 const fake_bind = """macro bind(def, element)
-    #! format: off # Turn off formatting. See https://domluna.github.io/JuliaFormatter.jl/stable/#Turn-off/on-formatting
+    #! format: off
     quote
         local iv = try Base.loaded_modules[Base.PkgId(Base.UUID("6e696c72-6542-2067-7265-42206c756150"), "AbstractPlutoDingetjes")].Bonds.initial_value catch; b -> missing; end
         local el = \$(esc(element))
         global \$(esc(def)) = Core.applicable(Base.get, el) ? Base.get(el) : iv(el)
         el
     end
-    #! format: on # Turn formatting back on.
+    #! format: on
 end"""
 


### PR DESCRIPTION
This is regularly the only change when I format my code/notebooks, and it gets reset whenever the notebook is saved. By telling JuliaFormatter to ignore it, it reduces noise in commits (if accidentally committed) and means I don't have to worry about formatting code I didn't write nor will I ever see.

I believe this is a good solution to #2623 as it solves the issue of files being constantly reformatted for those who use JuliaFormatter, and it does not affect those who do not. (Other than 2 extra lines in the notebook)

Closes #2623

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/christiangnrd/Pluto.jl", rev="patch-2")
julia> using Pluto
```