### PR TITLE
Easter eggs are more fun when they're hidden 

### DIFF
--- a/frontend/components/ErrorMessage.js
+++ b/frontend/components/ErrorMessage.js
@@ -543,7 +543,7 @@ const get_first_package = (limited_stacktrace) => {
     }
 }
 
-const motivational_word_probability = 0.1
+const motivational_word_probability = 0.0
 const motivational_words = [
     //
     "Don't panic!",


### PR DESCRIPTION
This pull zeros out `motivational_word_probability` parameter, which effectively hides the motivational messages by default. 

The motivational messages add some levity to the development process and have received positive feedback from the community. On the other hand, at least some developers find them somewhat distracting. The random messages are bold and vivid, which can draw a user's attention unnecessarily. This potential issue can be compounded if the end user is a nondeveloper, since they might not be aware of the context and probably shouldn't be redirected to the Julia discourse home page.

This change would fix #3062


## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/AshlinHarris/Pluto.jl", rev="main")
julia> using Pluto
```
