### PR TITLE
Prevent layout shift on load by mounting codemirror styles earlier

### DIFF
--- a/frontend/components/Cell.js
+++ b/frontend/components/Cell.js
@@ -335,6 +335,7 @@ export const Cell = ({
                 cm_forced_focus=${cm_forced_focus}
                 set_cm_forced_focus=${set_cm_forced_focus}
                 show_input=${show_input}
+                skip_static_fake=${is_first_cell}
                 on_submit=${on_submit}
                 on_delete=${on_delete}
                 on_add_after=${on_add_after}


### PR DESCRIPTION
https://github.com/fonsp/Pluto.jl/pull/2885 introduced a layout shift on load, fixed in this PR

I did not notice the issue in https://github.com/fonsp/Pluto.jl/pull/2885 because the file picker at the top of the notebook (codemirror) triggered the styles to mount. But when notebooks are viewed on the web, the styles are not mounted, and the ssr fake had no default cm styling.