### PR TITLE
Make fake_bind compatible to runic.

### DIFF
--- a/src/runner/PlutoRunner/src/bonds.jl
+++ b/src/runner/PlutoRunner/src/bonds.jl
@@ -133,16 +133,16 @@ end
 
 """
 Will be inserted in saved notebooks that use the @bind macro, make sure that they still contain legal syntax when executed as a vanilla Julia script. Overloading `Base.get` for custom UI objects gives bound variables a sensible value.
-Also turns off JuliaFormatter formatting to avoid issues with the formatter trying to change code that the user does not control. See https://domluna.github.io/JuliaFormatter.jl/stable/#Turn-off/on-formatting
+Also turns off Runic and JuliaFormatter formatting to avoid issues with the formatter trying to change code that the user does not control. See https://domluna.github.io/JuliaFormatter.jl/stable/#Turn-off/on-formatting or https://github.com/fredrikekre/Runic.jl?tab=readme-ov-file#toggle-formatting
 """
-const fake_bind = """macro bind(def, element)
-    #! format: off
+const fake_bind = """#! format: off
+macro bind(def, element)
     quote
         local iv = try Base.loaded_modules[Base.PkgId(Base.UUID("6e696c72-6542-2067-7265-42206c756150"), "AbstractPlutoDingetjes")].Bonds.initial_value catch; b -> missing; end
         local el = \$(esc(element))
         global \$(esc(def)) = Core.applicable(Base.get, el) ? Base.get(el) : iv(el)
         el
     end
-    #! format: on
-end"""
+end
+#! format: on"""
 

--- a/src/runner/PlutoRunner/src/bonds.jl
+++ b/src/runner/PlutoRunner/src/bonds.jl
@@ -135,14 +135,16 @@ end
 Will be inserted in saved notebooks that use the @bind macro, make sure that they still contain legal syntax when executed as a vanilla Julia script. Overloading `Base.get` for custom UI objects gives bound variables a sensible value.
 Also turns off Runic and JuliaFormatter formatting to avoid issues with the formatter trying to change code that the user does not control. See https://domluna.github.io/JuliaFormatter.jl/stable/#Turn-off/on-formatting or https://github.com/fredrikekre/Runic.jl?tab=readme-ov-file#toggle-formatting
 """
-const fake_bind = """#! format: off
+const fake_bind = """
 macro bind(def, element)
-    quote
+    #! format: off
+    return quote
         local iv = try Base.loaded_modules[Base.PkgId(Base.UUID("6e696c72-6542-2067-7265-42206c756150"), "AbstractPlutoDingetjes")].Bonds.initial_value catch; b -> missing; end
         local el = \$(esc(element))
         global \$(esc(def)) = Core.applicable(Base.get, el) ? Base.get(el) : iv(el)
         el
     end
+    #! format: on
 end
-#! format: on"""
+"""
 

--- a/src/runner/PlutoRunner/src/bonds.jl
+++ b/src/runner/PlutoRunner/src/bonds.jl
@@ -145,6 +145,5 @@ macro bind(def, element)
         el
     end
     #! format: on
-end
-"""
+end"""
 


### PR DESCRIPTION
[Runic](https://github.com/fredrikekre/Runic.jl) is a new "runic" formatter  for Julia code.
Due to peculiarities of implementation, format toggling is better handeled by wrapping around whole functions or macros, see  

See https://github.com/fredrikekre/Runic.jl/issues/107#issuecomment-2498098108

So in order to make Pluto notebooks invariant under runic formatting I propose to modify `fake_bind` accordingly. 

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/j-fu/Pluto.jl", rev="runic_fake_bind")
julia> using Pluto
```
