### PR TITLE
Fix Julia 1.11.2 WorkspaceManager race condition

### DIFF
--- a/src/evaluation/WorkspaceManager.jl
+++ b/src/evaluation/WorkspaceManager.jl
@@ -334,12 +334,12 @@ function get_workspace(session_notebook::SN; allow_creation::Bool=true)::Union{N
         get(active_workspaces, notebook.notebook_id, nothing)
     else
         get!(active_workspaces, notebook.notebook_id) do
-            Task(() -> make_workspace(session_notebook))
+            🌸 = Pluto.@asynclog make_workspace(session_notebook)
+            yield(); 🌸
         end
     end
 
     isnothing(task) && return nothing
-    istaskstarted(task) || schedule(task)
     fetch(task)
 end
 get_workspace(workspace::Workspace; kwargs...)::Workspace = workspace


### PR DESCRIPTION
This should fix https://github.com/fonsp/Pluto.jl/issues/3114, not yet tested

I believe the issue was caused by a race condition calling `schedule` twice on the same task, fixed by adding `yield`


## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/fonsp/Pluto.jl", rev="fix-workspacemanager-task-starting-race-condition")
julia> using Pluto
```
