### PR TITLE
New API: Pluto.is_single_expression

### DIFF
--- a/src/analysis/Parse.jl
+++ b/src/analysis/Parse.jl
@@ -119,6 +119,24 @@ end
 preprocess_expr(val::Any) = val
 
 
+"""
+Does this `String` contain a single expression? If this function returns `false`, then Pluto will show a "multiple expressions in one cell" error in the editor.
+
+!!! compat "Pluto 0.20.5"
+    This function is new in Pluto 0.20.5.
+
+"""
+function is_single_expression(s::String)
+    n = Pluto.Notebook([Pluto.Cell(s)])
+    e = parse_custom(n, n.cells[1])
+    bad = Meta.isexpr(e, :toplevel, 2) && Meta.isexpr(e.args[2], :call, 2) && e.args[2].args[1] == :(PlutoRunner.throw_syntax_error) && e.args[2].args[2] isa String && startswith(e.args[2].args[2], "extra token after end of expression")
+    
+    
+    return !bad
+end
+
+
+
 function updated_topology(old_topology::NotebookTopology{Cell}, notebook::Notebook, updated_cells)
     get_code_str(cell::Cell) = cell.code
     get_code_expr(cell::Cell) = parse_custom(notebook, cell)

--- a/test/misc API.jl
+++ b/test/misc API.jl
@@ -1,0 +1,43 @@
+@testset "Misc API" begin
+    
+    
+    @testset "is_single_expression" begin
+        
+        @test Pluto.is_single_expression("")
+        @test Pluto.is_single_expression("a")
+        @test Pluto.is_single_expression("a + 1")
+        @test Pluto.is_single_expression("a; a + 1")
+        @test !Pluto.is_single_expression("""
+            a = 1
+            a + 1
+        """)
+        
+        @test Pluto.is_single_expression("""
+            "yooo"
+            function f(x)
+                X   
+                C \\ c
+            end
+        """)
+        
+        
+        @test Pluto.is_single_expression("""
+            # asdf
+            
+            "yooo"
+            function f(x)
+                X   
+                C \\ c
+            end; # aasasdf
+        """)
+        
+        
+        
+        @test Pluto.is_single_expression("""
+            a a a a a // / // / 123 1 21 1313
+        """)
+        
+        
+        
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,6 +46,7 @@ verify_no_running_processes()
 @timeit_include("DependencyCache.jl")
 @timeit_include("Throttled.jl")
 @timeit_include("cell_disabling.jl")
+@timeit_include("misc API.jl")
 
 verify_no_running_processes()
 


### PR DESCRIPTION
To check if a `String` contains a single expression.

If this function returns `false`, then Pluto will show a "multiple expressions in one cell" error in the editor.

See tests in the PR files
## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/fonsp/Pluto.jl", rev="is_single_expression")
julia> using Pluto
```
