### PR TITLE
Add support for TestEnv.activate()

### DIFF
--- a/frontend/components/CellInput/pkg_bubble_plugin.js
+++ b/frontend/components/CellInput/pkg_bubble_plugin.js
@@ -18,6 +18,7 @@ export const pkg_disablers = [
     "Pkg.API.develop",
     "Pkg.add",
     "Pkg.API.add",
+    "TestEnv.activate",
     // https://juliadynamics.github.io/DrWatson.jl/dev/project/#DrWatson.quickactivate
     "quickactivate",
     "@quickactivate",

--- a/src/packages/Packages.jl
+++ b/src/packages/Packages.jl
@@ -27,6 +27,7 @@ function use_plutopkg(topology::NotebookTopology)
         Symbol("Pkg.API.develop") ∈ node.references ||
         Symbol("Pkg.add") ∈ node.references ||
         Symbol("Pkg.API.add") ∈ node.references ||
+        Symbol("TestEnv.activate") ∈ node.references ||
         # https://juliadynamics.github.io/DrWatson.jl/dev/project/#DrWatson.quickactivate
         Symbol("quickactivate") ∈ node.references ||
         Symbol("@quickactivate") ∈ node.references ||


### PR DESCRIPTION
Closes #2775 (if it had not been closed already)

How do I test this properly? Ideally, I would have wanted to check for the output of the `haskey(...)` cell to be `true`. I was inspired by the "DrWatson cell" test (does that test even need the `🍭`?), but that doesn't actually run the notebook, IIUC.
## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/jonas-schulze/Pluto.jl", rev="testenv")
julia> using Pluto
```
