### PR TITLE
downstream_recursive and upstream_recursive: don't include initial cells in output

### DIFF
--- a/src/analysis/MoreAnalysis.jl
+++ b/src/analysis/MoreAnalysis.jl
@@ -51,7 +51,7 @@ function downstream_recursive(
     topology::NotebookTopology,
     from::Union{Vector{Cell},Set{Cell}},
 )::Set{Cell}
-    found = Set{Cell}(copy(from))
+    found = Set{Cell}(empty(from))
     _downstream_recursive!(found, notebook, topology, from)
     found
 end
@@ -82,7 +82,7 @@ function upstream_recursive(
     topology::NotebookTopology,
     from::Union{Vector{Cell},Set{Cell}},
 )::Set{Cell}
-    found = Set{Cell}(copy(from))
+    found = Set{Cell}(empty(from))
     _upstream_recursive!(found, notebook, topology, from)
     found
 end
@@ -110,9 +110,9 @@ function codependents(notebook::Notebook, topology::NotebookTopology, var::Symbo
         var ∈ topology.nodes[cell].definitions
     end
     
-    downstream = collect(downstream_recursive(notebook, topology, assigned_in))
+    downstream = collect(union!(downstream_recursive(notebook, topology, assigned_in), assigned_in))
 
-    downupstream = upstream_recursive(notebook, topology, downstream)
+    downupstream = union!(upstream_recursive(notebook, topology, downstream), assigned_in)
 end
 
 "Return a `Dict{Symbol,Vector{Symbol}}` where the _keys_ are the bound variables of the notebook.

--- a/test/MoreAnalysis.jl
+++ b/test/MoreAnalysis.jl
@@ -21,24 +21,30 @@ using Test
     
     @testset "Recursive stuff" begin
         
-        @test cell_indices(MoreAnalysis.downstream_recursive(notebook, notebook.topology, notebook.cells[1:1])) == [1,3,4,5,6,7]
-        @test cell_indices(MoreAnalysis.upstream_recursive(notebook, notebook.topology, notebook.cells[1:1])) == [1]
+        @test cell_indices(MoreAnalysis.downstream_recursive(notebook, notebook.topology, notebook.cells[1:1])) == 3:7
+        @test cell_indices(MoreAnalysis.upstream_recursive(notebook, notebook.topology, notebook.cells[1:1])) == []
         
-        @test cell_indices(MoreAnalysis.downstream_recursive(notebook, notebook.topology, notebook.cells[6:6])) == [6,7]
-        @test cell_indices(MoreAnalysis.upstream_recursive(notebook, notebook.topology, notebook.cells[6:6])) == [1,2,3,4,6]
+        @test cell_indices(MoreAnalysis.downstream_recursive(notebook, notebook.topology, notebook.cells[6:6])) == [7]
+        @test cell_indices(MoreAnalysis.upstream_recursive(notebook, notebook.topology, notebook.cells[6:6])) == [1,2,3,4]
         
-        @test cell_indices(MoreAnalysis.downstream_recursive(notebook, notebook.topology, notebook.cells[7:7])) == [7]
-        @test cell_indices(MoreAnalysis.upstream_recursive(notebook, notebook.topology, notebook.cells[7:7])) == 1:7
+        @test cell_indices(MoreAnalysis.downstream_recursive(notebook, notebook.topology, notebook.cells[7:7])) == []
+        @test cell_indices(MoreAnalysis.upstream_recursive(notebook, notebook.topology, notebook.cells[7:7])) == 1:6
         
-        @test cell_indices(MoreAnalysis.downstream_recursive(notebook, notebook.topology, notebook.cells[4:5])) == 4:7
-        @test cell_indices(MoreAnalysis.upstream_recursive(notebook, notebook.topology, notebook.cells[4:5])) == 1:5
+        @test cell_indices(MoreAnalysis.downstream_recursive(notebook, notebook.topology, notebook.cells[4:5])) == 6:7
+        @test cell_indices(MoreAnalysis.upstream_recursive(notebook, notebook.topology, notebook.cells[4:5])) == 1:3
         
-        @test cell_indices(MoreAnalysis.downstream_recursive(notebook, notebook.topology, notebook.cells[1:2])) == 1:7
-        @test cell_indices(MoreAnalysis.upstream_recursive(notebook, notebook.topology, notebook.cells[1:7])) == 1:7
+        @test cell_indices(MoreAnalysis.downstream_recursive(notebook, notebook.topology, notebook.cells[1:2])) == 3:7
+        @test cell_indices(MoreAnalysis.upstream_recursive(notebook, notebook.topology, notebook.cells[1:2])) == []
+        
+        @test cell_indices(MoreAnalysis.downstream_recursive(notebook, notebook.topology, notebook.cells[1:7])) == 3:7
+        @test cell_indices(MoreAnalysis.upstream_recursive(notebook, notebook.topology, notebook.cells[1:7])) == 1:6
+        
+        
+        @test cell_indices(MoreAnalysis.downstream_recursive(notebook, notebook.topology, notebook.cells[[1,3]])) == 3:7
+        @test cell_indices(MoreAnalysis.upstream_recursive(notebook, notebook.topology, notebook.cells[[1,3]])) == [1]
         
         @test MoreAnalysis.upstream_recursive(notebook, notebook.topology, Cell[]) == Set{Cell}()
         @test MoreAnalysis.downstream_recursive(notebook, notebook.topology, Cell[]) == Set{Cell}()
-        
     end
     
     @testset "Bond connections" begin
@@ -47,10 +53,7 @@ using Test
         #     MoreAnalysis.find_bound_variables(cell.parsedcode)
         # end)
 
-        # @show bound_variables
-
         connections = MoreAnalysis.bound_variable_connections_graph(notebook)
-        # @show connections
 
         @test !isempty(connections)
         wanted_connections = Dict(


### PR DESCRIPTION
Technically breaking but I dont think anyone including PSS uses this function.
## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/fonsp/Pluto.jl", rev="moreanalysis-recursive-exclude-starts")
julia> using Pluto
```
