### PR TITLE
Performance: Skip unneeded updates

### DIFF
--- a/src/notebook/Events.jl
+++ b/src/notebook/Events.jl
@@ -79,7 +79,7 @@ FileEditEvent(notebook::Notebook) = begin
     file_contents = sprint() do io
         # TODO: https://github.com/fonsp/Pluto.jl/pull/1729: serialize_temp flag
         # to only get local changes; the workspace edit of the notebook!
-        save_notebook(io, notebook #=; serialize_temp=true =#)
+        # save_notebook(io, notebook #=; serialize_temp=true =#)
     end
     FileEditEvent(notebook, file_contents, notebook.path)
 end

--- a/src/webserver/Dynamic.jl
+++ b/src/webserver/Dynamic.jl
@@ -176,32 +176,35 @@ function send_notebook_changes!(🙋::ClientRequest; commentary::Any=nothing)
     outbox = Set{Tuple{ClientSession,UpdateMessage}}()
     
     lock(current_state_for_clients_lock) do
-        notebook_dict = notebook_to_js(🙋.notebook)
         counter = update_counter_for_debugging[] += 1
+        
+        if !isempty(🙋.session.connected_clients)
+            notebook_dict = notebook_to_js(🙋.notebook)
 
-        for (_, client) in 🙋.session.connected_clients
-            if client.connected_notebook !== nothing && client.connected_notebook.notebook_id == 🙋.notebook.notebook_id
-                current_dict = get(current_state_for_clients, client, :empty)
-                patches = Firebasey.diff(current_dict, notebook_dict)
-                patches_as_dicts = Firebasey._convert(Vector{Dict}, patches)
-                current_state_for_clients[client] = deep_enough_copy(notebook_dict)
+            for (_, client) in 🙋.session.connected_clients
+                if client.connected_notebook !== nothing && client.connected_notebook.notebook_id == 🙋.notebook.notebook_id
+                    current_dict = get(current_state_for_clients, client, :empty)
+                    patches = Firebasey.diff(current_dict, notebook_dict)
+                    patches_as_dicts = Firebasey._convert(Vector{Dict}, patches)
+                    current_state_for_clients[client] = deep_enough_copy(notebook_dict)
 
-                # Make sure we do send a confirmation to the client who made the request, even without changes
-                is_response = 🙋.initiator !== nothing && client == 🙋.initiator.client
+                    # Make sure we do send a confirmation to the client who made the request, even without changes
+                    is_response = 🙋.initiator !== nothing && client == 🙋.initiator.client
 
-                if !isempty(patches) || is_response
-                    response = Dict(
-                        :counter => counter,
-                        :patches => patches_as_dicts,
-                        :response => is_response ? commentary : nothing
-                    )
-                    push!(outbox, (client, UpdateMessage(:notebook_diff, response, 🙋.notebook, nothing, 🙋.initiator)))
+                    if !isempty(patches) || is_response
+                        response = Dict(
+                            :counter => counter,
+                            :patches => patches_as_dicts,
+                            :response => is_response ? commentary : nothing
+                        )
+                        push!(outbox, (client, UpdateMessage(:notebook_diff, response, 🙋.notebook, nothing, 🙋.initiator)))
+                    end
                 end
             end
-        end
 
-        for (client, msg) in outbox
-            putclientupdates!(client, msg)
+            for (client, msg) in outbox
+                putclientupdates!(client, msg)
+            end
         end
         try_event_call(🙋.session, FileEditEvent(🙋.notebook))
     end


### PR DESCRIPTION
Skip `notebook_to_js` if there are no websocket clients (like PlutoSliderServer) (5% of cpu time while running bonds)

Skip `save_notebook` in `FileEditEvent` which gets called a LOOOOT (10% of cpu time while running bonds).

Needs https://github.com/fonsp/Pluto.jl/pull/3166