### PR TITLE
Remove `FileEditEvent` and add `StateChangeEvent` in its place

### DIFF
--- a/src/notebook/Events.jl
+++ b/src/notebook/Events.jl
@@ -69,6 +69,7 @@ end
 
 # Triggered when the local code has changed (user typed something),
 # but the code hasn't run yet. 
+# TODO: Remove me after 0.20 @deprecate 
 struct FileEditEvent <: PlutoEvent
     notebook::Notebook
     file_contents::String
@@ -76,13 +77,16 @@ struct FileEditEvent <: PlutoEvent
 end
 
 FileEditEvent(notebook::Notebook) = begin
-    file_contents = sprint() do io
-        # TODO: https://github.com/fonsp/Pluto.jl/pull/1729: serialize_temp flag
-        # to only get local changes; the workspace edit of the notebook!
-        save_notebook(io, notebook #=; serialize_temp=true =#)
-    end
-    FileEditEvent(notebook, file_contents, notebook.path)
+    FileEditEvent(notebook, "BROKEN", notebook.path)
 end
+
+"""
+Triggered when the notebook state changes (e.g. code changes, output changes, a log message appears, etc)
+"""
+struct StateChangeEvent <: PlutoEvent
+    notebook::Notebook
+end
+
 
 # Triggered when we create a new notebook
 struct NewNotebookEvent <: PlutoEvent

--- a/src/webserver/Dynamic.jl
+++ b/src/webserver/Dynamic.jl
@@ -203,7 +203,7 @@ function send_notebook_changes!(🙋::ClientRequest; commentary::Any=nothing)
         for (client, msg) in outbox
             putclientupdates!(client, msg)
         end
-        try_event_call(🙋.session, FileEditEvent(🙋.notebook))
+        try_event_call(🙋.session, StateChangeEvent(🙋.notebook))
     end
 end
 


### PR DESCRIPTION
`FileEditEvent` creates a performance issue, about 10% of cpu time in bond setting if the profiling result is to be trusted
## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/fonsp/Pluto.jl", rev="remove-FileEditEvent")
julia> using Pluto
```
