### PR TITLE
Add keyboard shortcuts to documentation

### DIFF
--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -1339,9 +1339,11 @@ Delete or Backspace:   delete empty cell
 
 PageUp or fn${and}↑:   jump to cell above
 PageDown or fn${and}↓:   jump to cell below
+${control_name}${and}click:   jump to definition
 ${alt_or_options_name}${and}↑:   move line/cell up
 ${alt_or_options_name}${and}↓:   move line/cell down
 
+${control_name}${and}/:   toggle comment
 ${control_name}${and}M:   toggle markdown
 ${fold_prefix}${and}[:   hide cell code
 ${fold_prefix}${and}]:   show cell code


### PR DESCRIPTION
Hello! I've added information on 2 keyboard shortcuts ("jump to definition" and "toggle comment") to the documentation. These changes are limited to Pluto.jl's JavaScript code, and I've tested them in Debian on the latest Firefox and Chrome.
## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/AshlinHarris/Pluto.jl", rev="main")
julia> using Pluto
```
