### PR TITLE
PlutoPkg: include former stdlibs in logic

### DIFF
--- a/src/packages/Packages.jl
+++ b/src/packages/Packages.jl
@@ -184,6 +184,8 @@ function sync_nbpkg_core(
                         Status.report_business!(pkg_status, :resolve) do
                             with_auto_fixes(notebook) do
                                 _resolve(notebook, iolistener)
+                                # this call should work
+                                PkgCompat.dependencies(notebook.nbpkg_ctx; throw=true)
                             end
                         end
                     end

--- a/src/packages/Packages.jl
+++ b/src/packages/Packages.jl
@@ -184,8 +184,6 @@ function sync_nbpkg_core(
                         Status.report_business!(pkg_status, :resolve) do
                             with_auto_fixes(notebook) do
                                 _resolve(notebook, iolistener)
-                                # this call should work
-                                PkgCompat.dependencies(notebook.nbpkg_ctx; throw=true)
                             end
                         end
                     end


### PR DESCRIPTION
Include future and former stdlibs in the logic used by PlutoPkg. 

This mostly affects UI ("this is a stdlib") and whether we automatically set a compat entry.

TODO
- [ ] Use GracefulPkg.jl for the stdlib list? Can be a separate PR