### PR TITLE
Don't override Pkg error message when using Pkg.activate

### DIFF
--- a/frontend/components/ErrorMessage.js
+++ b/frontend/components/ErrorMessage.js
@@ -446,6 +446,8 @@ export const ErrorMessage = ({ msg, stacktrace, cell_id }) => {
         {
             pattern: /^ArgumentError: Package (.*) not found in current path/,
             display: (/** @type{string} */ x) => {
+                if (pluto_actions.get_notebook().nbpkg?.enabled === false) return default_rewriter.display(x)
+
                 const match = x.match(/^ArgumentError: Package (.*) not found in current path/)
                 const package_name = (match?.[1] ?? "").replaceAll("`", "")
 
@@ -458,8 +460,10 @@ export const ErrorMessage = ({ msg, stacktrace, cell_id }) => {
                         <li>Try a different Julia version.</li>
                         <li>Contact the developers of ${package_name}.jl about this error.</li>
                     </ul>
-                    <p>You might find useful information in the package installation log:</p>
-                    <${PkgTerminalView} value=${pkg_terminal_value} />`
+                    ${pkg_terminal_value == null
+                        ? null
+                        : html` <p>You might find useful information in the package installation log:</p>
+                              <${PkgTerminalView} value=${pkg_terminal_value} />`} `
             },
             show_stacktrace: () => false,
         },


### PR DESCRIPTION
Without Pkg activate (as before)

![Scherm­afbeelding 2025-04-17 om 16 34 22](https://github.com/user-attachments/assets/390a7f95-11b3-4511-ae7a-3d1f98ec9d1e)


With Pkg activate, the oroginal julia message:

![Scherm­afbeelding 2025-04-17 om 16 35 04](https://github.com/user-attachments/assets/6be53124-1507-4afb-8b3f-13d31fb929db)


thx @bvdmitri 