### PR TITLE
Disable "more" tree viewer button when not possible

### DIFF
--- a/frontend/common/SliderServerClient.js
+++ b/frontend/common/SliderServerClient.js
@@ -35,6 +35,17 @@ const recursive_dependencies = (/** @type {import("../components/Editor.js").Cel
 
 const disjoint = (a, b) => !_.some([...a], (x) => b.has(x))
 
+export const is_noop_action = (action) => action?.__is_noop_action === true
+
+const create_noop_action = (name) => {
+    const fn = (...args) => {
+        console.info("Ignoring action", name, { args })
+    }
+
+    fn.__is_noop_action = true
+    return fn
+}
+
 export const nothing_actions = ({ actions }) =>
     Object.fromEntries(
         Object.entries(actions).map(([k, v]) => [
@@ -43,9 +54,7 @@ export const nothing_actions = ({ actions }) =>
                 ? // the original action
                   v
                 : // a no-op action
-                  (...args) => {
-                      console.info("Ignoring action", k, { args })
-                  },
+                  create_noop_action(k),
         ])
     )
 

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -681,7 +681,7 @@ export class Editor extends Component {
                     notebook.bonds[name] = new_bond
                 })
             },
-            reshow_cell: (cell_id, objectid, dim) => {
+            reshow_cell: (cell_id, objectid, dim) =>
                 this.client.send(
                     "reshow_cell",
                     {
@@ -691,8 +691,7 @@ export class Editor extends Component {
                     },
                     { notebook_id: this.state.notebook.notebook_id },
                     false
-                )
-            },
+                ),
             request_js_link_response: (cell_id, link_id, input) => {
                 return this.client
                     .send(

--- a/frontend/components/Logs.js
+++ b/frontend/components/Logs.js
@@ -125,7 +125,7 @@ const Dot = ({ set_cm_highlighted_line, msg, kwargs, y, level, sanitize_html }) 
     }
 
     const mimepair_output = (pair) =>
-        html`<${SimpleOutputBody} cell_id=${"adsf"} mime=${pair[1]} body=${pair[0]} persist_js_state=${false} sanitize_html=${sanitize_html} />`
+        html`<${SimpleOutputBody} cell_id=${"cell_id_not_known"} mime=${pair[1]} body=${pair[0]} persist_js_state=${false} sanitize_html=${sanitize_html} />`
 
     useEffect(() => {
         return () => set_cm_highlighted_line(null)

--- a/frontend/treeview.css
+++ b/frontend/treeview.css
@@ -177,6 +177,10 @@ pluto-tree-more {
     white-space: nowrap;
 }
 
+pluto-tree-more.disabled {
+    cursor: not-allowed;
+}
+
 pluto-tree-more::before {
     margin-left: 0.2em;
     margin-right: 0.5em;


### PR DESCRIPTION
You can't click "more" on a long vector display when:
- inside logs
- when viewing notebooks online (HTML export)

This PR makes the button not clickable to make this clear
## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/fonsp/Pluto.jl", rev="disable-more-tree-viewer-button-when-impossible")
julia> using Pluto
```
