### PR TITLE
📋 "Copy output" for error messages

### DIFF
--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -913,14 +913,27 @@ const InputContextMenu = ({ on_delete, cell_id, run_cell, skip_as_script, runnin
     const is_copy_output_supported = () => {
         let notebook = /** @type{import("./Editor.js").NotebookData?} */ (pluto_actions.get_notebook())
         let cell_result = notebook?.cell_results?.[cell_id]
-        return !!cell_result && !cell_result.errored && !cell_result.queued && cell_result.output.mime === "text/plain" && cell_result.output.body
+        if (cell_result == null) return false
+
+        return (
+            (!cell_result.errored && cell_result.output.mime === "text/plain" && cell_result.output.body != null) ||
+            (cell_result.errored && cell_result.output.mime === "application/vnd.pluto.stacktrace+object")
+        )
     }
 
     const copy_output = () => {
         let notebook = /** @type{import("./Editor.js").NotebookData?} */ (pluto_actions.get_notebook())
-        let cell_output = notebook?.cell_results?.[cell_id]?.output.body ?? ""
-        cell_output &&
-            navigator.clipboard.writeText(cell_output).catch((err) => {
+        let cell_result = notebook?.cell_results?.[cell_id]
+        if (cell_result == null) return
+
+        let cell_output =
+            cell_result.output.mime === "text/plain"
+                ? cell_result.output.body
+                : // @ts-ignore
+                  cell_result.output.body.plain_error
+
+        if (cell_output != null)
+            navigator.clipboard.writeText(cell_output).catch(() => {
                 alert(`Error copying cell output`)
             })
     }

--- a/frontend/components/ErrorMessage.js
+++ b/frontend/components/ErrorMessage.js
@@ -305,7 +305,7 @@ const AnsiUpLine = (/** @type {{value: string}} */ { value }) => {
     return value === "" ? html`<p><br /></p>` : html`<p ref=${node_ref}>${did_ansi_up.current ? null : without_ansi_chars}</p>`
 }
 
-export const ErrorMessage = ({ msg, stacktrace, cell_id }) => {
+export const ErrorMessage = ({ msg, stacktrace, plain_error, cell_id }) => {
     let pluto_actions = useContext(PlutoActionsContext)
 
     const default_rewriter = {

--- a/src/runner/PlutoRunner/src/display/Exception.jl
+++ b/src/runner/PlutoRunner/src/display/Exception.jl
@@ -83,7 +83,16 @@ function format_output(val::CapturedException; context=default_iocontext)
         val
     end
 
-    Dict{Symbol,Any}(:msg => sprint(try_showerror, val.ex), :stacktrace => stacktrace), MIME"application/vnd.pluto.stacktrace+object"()
+    (
+        Dict{Symbol,Any}(
+            :msg => sprint(try_showerror, val.ex),
+            :stacktrace => stacktrace,
+            :plain_error => sprint() do io
+                try_showerror(io, val.ex, val.processed_bt[1:something(limit, end)]; color=false)
+            end,
+        ),
+        MIME"application/vnd.pluto.stacktrace+object"()
+    )
 end
 
 
@@ -136,9 +145,9 @@ end
 
 
 "Because even showerror can error... 👀"
-function try_showerror(io::IO, e, args...)
+function try_showerror(io::IO, e, args...; color::Bool=true)
     try
-        showerror(IOContext(io, :color => true), e, args...)
+        showerror(IOContext(io, :color => color), e, args...)
     catch show_ex
         print(io, "\nFailed to show error:\n\n")
         try_showerror(io, show_ex, stacktrace(catch_backtrace()))

--- a/test/RichOutput.jl
+++ b/test/RichOutput.jl
@@ -414,6 +414,7 @@ import Pluto: update_run!, WorkspaceManager, ClientSession, ServerSession, Noteb
             @test_nowarn update_run!(🍭, notebook, notebook.cells[1:5])
 
             @test occursinerror("DomainError", notebook.cells[1])
+            @test occursin("DomainError", notebook.cells[1].output.body[:plain_error])
             let
                 st = notebook.cells[1].output.body
                 @test length(st[:stacktrace]) == 4 # check in REPL


### PR DESCRIPTION
You can now use "Copy output" on errored cells, to get the complete error message and stack trace in the REPL format. This should make it easier to share errors online

https://github.com/user-attachments/assets/dc6b6c6e-cf03-4bb9-ab42-e9c631e3caf6



## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/fonsp/Pluto.jl", rev="📋-Copy-output-for-error-messages")
julia> using Pluto
```
