### PR TITLE
generate_html: add kwargs for recording_url_js and recording_audio_url_js

### DIFF
--- a/src/notebook/Export.jl
+++ b/src/notebook/Export.jl
@@ -20,7 +20,7 @@ function cdnified_html(filename::AbstractString;
     )
     should_use_bundled_cdn = version ∈ (nothing, PLUTO_VERSION) && pluto_cdn_root === nothing
     
-    something(
+    @something(
         if should_use_bundled_cdn
             try
                 original = read(project_relative_path("frontend-dist", filename), String)
@@ -108,6 +108,9 @@ function generate_html(;
         slider_server_url_js::AbstractString="undefined", 
         binder_url_js::AbstractString=repr(default_binder_url),
         
+        recording_url_js::AbstractString="undefined",
+        recording_audio_url_js::AbstractString="undefined",
+
         disable_ui::Bool=true, 
         preamble_html_js::AbstractString="undefined",
         notebook_id_js::AbstractString="undefined", 
@@ -118,7 +121,7 @@ function generate_html(;
 
     cdnified = cdnified_editor_html(; version, pluto_cdn_root)
     
-    length(statefile_js) > 32000000 && @error "Statefile embedded in HTML is very large. The file can be opened with Chrome and Safari, but probably not with Firefox. If you are using PlutoSliderServer to generate this file, then we recommend the setting `baked_statefile=false`. If you are not using PlutoSliderServer, then consider reducing the size of figures and output in the notebook." length(statefile_js)
+    (length(statefile_js) > 32000000 || length(recording_url_js) > 32000000 || length(recording_audio_url_js) > 32000000) && @error "Statefile or recording URL embedded in HTML is very large. The file can be opened with Chrome and Safari, but probably not with Firefox. If you are using PlutoSliderServer to generate this file, then we recommend the setting `baked_statefile=false`. If you are not using PlutoSliderServer, then consider reducing the size of figures and output in the notebook." length(statefile_js) length(recording_url_js) length(recording_audio_url_js)
     
     parameters = """
     <script data-pluto-file="launch-parameters">
@@ -130,6 +133,8 @@ function generate_html(;
     window.pluto_binder_url = $(binder_url_js);
     window.pluto_statefile = $(statefile_js);
     window.pluto_preamble_html = $(preamble_html_js);
+    window.pluto_recording_url = $(recording_url_js);
+    window.pluto_recording_audio_url = $(recording_audio_url_js);
     </script>
     """
     


### PR DESCRIPTION


## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/fonsp/Pluto.jl", rev="generate_html-recording")
julia> using Pluto
```
