### PR TITLE
Load observablehq stdlib using jsdelivr ESM

### DIFF
--- a/frontend/common/SetupCellEnvironment.js
+++ b/frontend/common/SetupCellEnvironment.js
@@ -1,8 +1,9 @@
-// import Library from "https://unpkg.com/@observablehq/stdlib@3.3.1/src/library.js?module"
+// @ts-ignore
+import { Library } from "https://cdn.jsdelivr.net/npm/@observablehq/stdlib@3.3.1/+esm"
 
 export let make_library = () => {
     // @ts-ignore
-    let library = new window.observablehq.Library()
+    let library = new Library()
     return {
         DOM: library.DOM,
         Files: library.Files,

--- a/frontend/common/SetupCellEnvironment.js
+++ b/frontend/common/SetupCellEnvironment.js
@@ -1,9 +1,9 @@
 // @ts-ignore
 import { Library } from "https://cdn.jsdelivr.net/npm/@observablehq/stdlib@3.3.1/+esm"
 
-export let make_library = () => {
+export const make_library = () => {
     // @ts-ignore
-    let library = new Library()
+    const library = new Library()
     return {
         DOM: library.DOM,
         Files: library.Files,
@@ -28,11 +28,11 @@ const observablehq_for_myself = make_library()
 export const observablehq_for_cells = make_library()
 export { observablehq_for_myself as default }
 
-export let DOM = observablehq_for_myself.DOM
-export let Files = observablehq_for_myself.Files
-export let Generators = observablehq_for_myself.Generators
-export let Promises = observablehq_for_myself.Promises
-export let now = observablehq_for_myself.now
-export let svg = observablehq_for_myself.svg
-export let html = observablehq_for_myself.html
-export let require = observablehq_for_myself.require
+export const DOM = observablehq_for_myself.DOM
+export const Files = observablehq_for_myself.Files
+export const Generators = observablehq_for_myself.Generators
+export const Promises = observablehq_for_myself.Promises
+export const now = observablehq_for_myself.now
+export const svg = observablehq_for_myself.svg
+export const html = observablehq_for_myself.html
+export const require = observablehq_for_myself.require

--- a/frontend/editor.html
+++ b/frontend/editor.html
@@ -24,7 +24,6 @@
     </script>
 
     <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js" defer></script>
-    <script src="https://cdn.jsdelivr.net/npm/@observablehq/stdlib@3.3.1/dist/stdlib.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/iframe-resizer@4.3.11/js/iframeResizer.min.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/ansi_up@5.1.0/ansi_up.min.js" defer></script>
 

--- a/frontend/editor.html
+++ b/frontend/editor.html
@@ -23,9 +23,7 @@
         )
     </script>
 
-    <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/iframe-resizer@4.3.11/js/iframeResizer.min.js" defer></script>
-    <script src="https://cdn.jsdelivr.net/npm/ansi_up@5.1.0/ansi_up.min.js" defer></script>
 
     <link rel="pluto-external-source" id="vmsg-wasm" href="https://unpkg.com/vmsg@0.4.0/vmsg.wasm">
     <link rel="pluto-external-source" id="arrow_up_circle_icon" href="https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/arrow-up-circle-outline.svg">

--- a/frontend/imports/AnsiUp.js
+++ b/frontend/imports/AnsiUp.js
@@ -1,2 +1,5 @@
 // @ts-ignore
-export default AnsiUp = window.AnsiUp
+import AnsiUpPackage from "https://cdn.jsdelivr.net/npm/ansi_up@5.1.0/+esm"
+// needs .default a second time, weird
+const AnsiUp = AnsiUpPackage.default
+export default AnsiUp

--- a/frontend/imports/lodash.d.ts
+++ b/frontend/imports/lodash.d.ts
@@ -1,2 +1,4 @@
 import * as _ from "lodash-es"
 export default _
+
+// Note: run `npm install` if you want to get types in your editor

--- a/frontend/imports/lodash.d.ts
+++ b/frontend/imports/lodash.d.ts
@@ -1,2 +1,2 @@
-import _ from "lodash-es"
+import * as _ from "lodash-es"
 export default _

--- a/frontend/imports/lodash.js
+++ b/frontend/imports/lodash.js
@@ -1,2 +1,2 @@
-// @ts-ignore
-export default window._
+import _ from "https://cdn.jsdelivr.net/npm/lodash-es@4.17.21/+esm"
+export default _

--- a/frontend/imports/lodash.js
+++ b/frontend/imports/lodash.js
@@ -1,2 +1,3 @@
+// @ts-ignore
 import _ from "https://cdn.jsdelivr.net/npm/lodash-es@4.17.21/+esm"
 export default _

--- a/frontend/imports/lodash.js
+++ b/frontend/imports/lodash.js
@@ -1,3 +1,5 @@
 // @ts-ignore
 import _ from "https://cdn.jsdelivr.net/npm/lodash-es@4.17.21/+esm"
 export default _
+
+// Note: run `npm install` if you want to get types in your editor

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -22,8 +22,6 @@
     <link rel="pluto-logo-small" href="./img/favicon_unsaturated.svg" />
 
     <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js" defer></script>
-    <script src="https://cdn.jsdelivr.net/npm/@observablehq/stdlib@3.3.1/dist/stdlib.js" defer></script>
-
 
     <link rel="stylesheet" href="welcome.css">
     <link rel="stylesheet" href="index.css">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -21,8 +21,6 @@
     <link rel="pluto-logo-big" href="./img/logo.svg" />
     <link rel="pluto-logo-small" href="./img/favicon_unsaturated.svg" />
 
-    <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.21/lodash.min.js" defer></script>
-
     <link rel="stylesheet" href="welcome.css">
     <link rel="stylesheet" href="index.css">
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,5 @@
 {
   "devDependencies": {
-    "@types/lodash": "^4.14.182",
     "@types/lodash-es": "^4.17.6"
   }
 }


### PR DESCRIPTION
Instead of a global script.

This should remove some loading issue when embedding Pluto in places that use RequireJS like Documenter.jl