### PR TITLE
"Refactor: Consolidate CSS imports using @import in all-styles.css for cleaner editor.html" to issue #3240

### DIFF
--- a/frontend/all-styles.css
+++ b/frontend/all-styles.css
@@ -1,0 +1,12 @@
+/* 
+ * all-styles.css
+ * This file consolidates multiple CSS files via @import.
+ * It helps keep HTML cleaner and centralizes CSS dependencies.
+ * NOTE: @import must be at the top of the file before any other rules.
+ */
+
+
+@import url("./editor.css");
+@import url("./binder.css");
+@import url("./treeview.css");
+@import url("./highlightjs.css");

--- a/frontend/all-styles.css
+++ b/frontend/all-styles.css
@@ -1,11 +1,3 @@
-/* 
- * all-styles.css
- * This file consolidates multiple CSS files via @import.
- * It helps keep HTML cleaner and centralizes CSS dependencies.
- * NOTE: @import must be at the top of the file before any other rules.
- */
-
-
 @import url("./editor.css");
 @import url("./binder.css");
 @import url("./treeview.css");

--- a/frontend/editor.html
+++ b/frontend/editor.html
@@ -34,8 +34,6 @@
     <!-- This doesn't do anything unless activated, and it makes sure parcel bundles this -->
     <script id="iframe-resizer-content-window-script" src="https://cdn.jsdelivr.net/npm/iframe-resizer@4.3.11/js/iframeResizer.contentWindow.min.js" crossorigin="anonymous" defer></script>
 
-    <!-- Consolidated stylesheet import for cleaner HTML and easier maintenance -->
-    <!-- all-styles.css uses @import to include editor.css, binder.css, treeview.css, and highlightjs.css -->
     <link rel="stylesheet" href="./all-styles.css" type="text/css" />
 
     <meta name="pluto-insertion-spot-parameters">

--- a/frontend/editor.html
+++ b/frontend/editor.html
@@ -34,10 +34,9 @@
     <!-- This doesn't do anything unless activated, and it makes sure parcel bundles this -->
     <script id="iframe-resizer-content-window-script" src="https://cdn.jsdelivr.net/npm/iframe-resizer@4.3.11/js/iframeResizer.contentWindow.min.js" crossorigin="anonymous" defer></script>
 
-    <link rel="stylesheet" href="./editor.css" type="text/css" />
-    <link rel="stylesheet" href="./binder.css" type="text/css" />
-    <link rel="stylesheet" href="./treeview.css" type="text/css" />
-    <link rel="stylesheet" href="./highlightjs.css" type="text/css">
+    <!-- Consolidated stylesheet import for cleaner HTML and easier maintenance -->
+    <!-- all-styles.css uses @import to include editor.css, binder.css, treeview.css, and highlightjs.css -->
+    <link rel="stylesheet" href="./all-styles.css" type="text/css" />
 
     <meta name="pluto-insertion-spot-parameters">
     <script src="./editor.js" type="module" defer></script>


### PR DESCRIPTION
Changes Made

Created all-styles.css with @import statements for:
- editor.css
- binder.css
- treeview.css
- highlightjs.css

Updated editor.html to reference all-styles.css via a single <link> tag.

Added inline comments for clarity and future maintainers.



## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/Anirban-001/Pluto.jl", rev="main")
julia> using Pluto
```
