### PR TITLE
Automatic `id` tags for Markdown headers

### DIFF
--- a/src/runner/PlutoRunner/src/PlutoRunner.jl
+++ b/src/runner/PlutoRunner/src/PlutoRunner.jl
@@ -64,6 +64,7 @@ include("./evaluation/deleting globals.jl")
 
 
 include("./display/LaTeX.jl")
+include("./display/HeaderID.jl")
 include("./display/format_output.jl")
 include("./display/IOContext.jl")
 include("./display/syntax error.jl")

--- a/src/runner/PlutoRunner/src/display/HeaderID.jl
+++ b/src/runner/PlutoRunner/src/display/HeaderID.jl
@@ -1,0 +1,30 @@
+import Markdown
+
+# We add a method for the Markdown -> HTML conversion that automatically adds an id to headers
+function Markdown.html(io::IO, header::Markdown.Header{l}) where l
+    id = text_to_id(stripped(header.text))
+    Markdown.withtag(io, "h$l", :id => id) do
+        Markdown.htmlinline(io, header.text)
+    end
+end
+
+# We actually don't need to encode this! Markdown stdlib will do it for us.
+text_to_id(text::String) = text
+
+# encodeURIComponent(s::String) = join(map(codeunits(s)) do b
+# 	c = Char(b)
+# 	if c ∈ 'a':'z' || c ∈ 'A':'Z' || c ∈ '0':'9' || c ∈ ('-','.','_','~')
+# 		c
+# 	else
+# 		"%$(uppercase(string(b, base=16, pad=2)))"
+# 	end
+# end)
+
+stripped(x::Vector) = join(Iterators.map(stripped, x))
+stripped(s::String) = s
+stripped(s::Union{Markdown.Italic,Markdown.Link,Markdown.Bold}) = stripped(s.text)
+stripped(s::Markdown.LaTeX) = stripped(s.formula)
+stripped(s::Markdown.Code) = stripped(s.code)
+stripped(s::Markdown.Image) = ""
+stripped(s) = ""
+


### PR DESCRIPTION
I was thinking of a couple ways to do this, but the simplest one turned out the best! I tried lowercasing, replacing ` ` with `-`, URI encoding, deaccenting, etc. But just using the header content as ID works great! You can just copy a header text, and use it as ID. And both id and anchor will use the same unicode->URI transformation, sick!


https://github.com/user-attachments/assets/7f57875d-2ca2-421e-bd54-1d93c9a6db56

