### PR TITLE
Complete package names from list

### DIFF
--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -679,6 +679,7 @@ export const CellInput = ({
                                 too_long: message.too_long,
                             }
                         },
+                        request_packages: () => pluto_actions.send("all_registered_package_names").then(({ message }) => message.results),
                         request_special_symbols: () => pluto_actions.send("complete_symbols").then(({ message }) => message),
                         on_update_doc_query: on_update_doc_query,
                         request_unsubmitted_global_definitions: () => pluto_actions.get_unsubmitted_global_definitions(),

--- a/frontend/components/CellInput/pkg_bubble_plugin.js
+++ b/frontend/components/CellInput/pkg_bubble_plugin.js
@@ -80,9 +80,11 @@ function find_import_statements({ state, from, to }) {
             }
 
             if (node.name === "ImportPath") {
+                const package_name = doc.sliceString(node.from, node.to).split(".")[0]
+                if (package_name === "") return false
                 const item = {
                     type: "package",
-                    name: doc.sliceString(node.from, node.to).split(".")[0],
+                    name: package_name,
                     from: node.from,
                     to: node.to,
                 }

--- a/src/webserver/Dynamic.jl
+++ b/src/webserver/Dynamic.jl
@@ -566,8 +566,8 @@ responses[:nbpkg_available_versions] = function response_nbpkg_available_version
     ), nothing, nothing, 🙋.initiator))
 end
 
-responses[:package_completions] = function response_package_completions(🙋::ClientRequest)
-    results = PkgCompat.package_completions(🙋.body["query"])
+responses[:all_registered_package_names] = function response_all_registered_package_names(🙋::ClientRequest)
+    results = PkgCompat.registered_package_names()
     putclientupdates!(🙋.session, 🙋.initiator, UpdateMessage(:🍳, Dict(
         :results => results,
     ), nothing, nothing, 🙋.initiator))

--- a/test/packages/PkgCompat.jl
+++ b/test/packages/PkgCompat.jl
@@ -84,16 +84,11 @@ import Pkg
     end
 
     @testset "Completions" begin
-        cs = PkgCompat.package_completions("Hyper")
+        cs = PkgCompat.registered_package_names()
         @test "HypertextLiteral" ∈ cs
         @test "Hyperscript" ∈ cs
 
-        cs = PkgCompat.package_completions("Date")
         @test "Dates" ∈ cs
-
-        cs = PkgCompat.package_completions("Dateskjashdfkjahsdfkjh")
-
-        @test isempty(cs)
     end
 
     @testset "Compat manipulation" begin


### PR DESCRIPTION
When typing `import Plu` it now completes on the JS side using the full package list, removing a lot of risky julia code.