### PR TITLE
Fix lodash in userland JS

### DIFF
--- a/frontend/components/CellOutput.js
+++ b/frontend/components/CellOutput.js
@@ -28,6 +28,7 @@ import hljs from "../imports/highlightjs.js"
 import { julia_mixed } from "./CellInput/mixedParsers.js"
 import { julia } from "../imports/CodemirrorPlutoSetup.js"
 import { SafePreviewSanitizeMessage } from "./SafePreviewUI.js"
+import lodashLibrary from "../imports/lodash.js"
 
 const prettyAssignee = (assignee) =>
     assignee && assignee.startsWith("const ") ? html`<span style="color: var(--cm-color-keyword)">const</span> ${assignee.slice(6)}` : assignee
@@ -444,6 +445,7 @@ const execute_scripttags = async ({ root_node, script_nodes, previous_results_ma
                                       }),
 
                                 ...observablehq_for_cells,
+                                _: lodashLibrary,
                             },
                             code,
                         })


### PR DESCRIPTION
This brings back lodash with `_` in user-written `<script>`s. This was accidentally removed in #3237 

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/fonsp/Pluto.jl", rev="lodash-in-userland-js-fix")
julia> using Pluto
```
