### PR TITLE
avoid accessing removed `deleted_world` property for julia 1.12

### DIFF
--- a/src/runner/PlutoRunner/src/evaluation/deleting globals.jl
+++ b/src/runner/PlutoRunner/src/evaluation/deleting globals.jl
@@ -208,7 +208,7 @@ is_method_deleted(method::Method) = @static if VERSION < v"1.12.0-beta4"
     method.deleted_world !== alive_world_val
 else
     # The dispatch status is set to 0 when a method is deleted. See the file `src/gc.f` changes in PR https://github.com/JuliaLang/julia/pull/58291 for more details.
-    method.dispatch_status === 0x0
+    method.dispatch_status == 0
 end
 
 

--- a/src/runner/PlutoRunner/src/evaluation/deleting globals.jl
+++ b/src/runner/PlutoRunner/src/evaluation/deleting globals.jl
@@ -200,7 +200,16 @@ function try_delete_toplevel_methods(workspace::Module, (cell_id, name_parts)::T
     end
 end
 
-const alive_world_val = methods(Base.sqrt).ms[1].deleted_world # typemax(UInt) in Julia v1.3, Int(-1) in Julia 1.0
+const alive_world_val = typemax(UInt) # This is true at least for julia 1.10 and 1.11, and it's not applicable for julia 1.12. See issue https://github.com/fonsp/Pluto.jl/issues/3259 for more details.
+
+
+# Check if a method has already been deleted/disabled
+is_method_deleted(method::Method) = @static if VERSION < v"1.12.0-beta4"
+    method.deleted_world !== alive_world_val
+else
+    # The dispatch status is set to 0 when a method is deleted. See the file `src/gc.f` changes in PR https://github.com/JuliaLang/julia/pull/58291 for more details.
+    method.dispatch_status === 0x0
+end
 
 
 

--- a/src/runner/PlutoRunner/src/evaluation/deleting globals.jl
+++ b/src/runner/PlutoRunner/src/evaluation/deleting globals.jl
@@ -139,7 +139,7 @@ function delete_toplevel_methods(f::Function, cell_id::UUID)::Bool
     methods_table = typeof(f).name.mt
     deleted_sigs = Set{Type}()
     Base.visit(methods_table) do method # iterates through all methods of `f`, including overridden ones
-        if isfromcell(method, cell_id) && method.deleted_world == alive_world_val
+        if isfromcell(method, cell_id) && !is_method_deleted(method)
             Base.delete_method(method)
             delete_method_doc(method)
             push!(deleted_sigs, method.sig)

--- a/src/runner/PlutoRunner/src/evaluation/deleting globals.jl
+++ b/src/runner/PlutoRunner/src/evaluation/deleting globals.jl
@@ -200,7 +200,7 @@ function try_delete_toplevel_methods(workspace::Module, (cell_id, name_parts)::T
     end
 end
 
-const alive_world_val = typemax(UInt) # This is true at least for julia 1.10 and 1.11, and it's not applicable for julia 1.12. See issue https://github.com/fonsp/Pluto.jl/issues/3259 for more details.
+const alive_world_val = typemax(UInt) # This is true at least for julia 1.10 and 1.11, and it's not applicable for julia 1.12. See issue https://github.com/fonsp/Pluto.jl/issues/3259 for more details. # UInt and not UInt64 because of https://github.com/JuliaLang/julia/pull/58291/files#diff-882927c6e612596e22406ae0d06adcee88a9ec05e8b61ad81b48942e2cb266e9 and https://github.com/JuliaLang/julia/blob/422d05d1f8c185ad636deb0ab181aa41e3d424ea/src/jltypes.c#L3237
 
 
 # Check if a method has already been deleted/disabled


### PR DESCRIPTION
This PR tries to fix #3259 by avoiding access to the removed property `deleted_world` from methods.

Based on the c function actually disabling methods here (modified as part of https://github.com/JuliaLang/julia/pull/58291):
https://github.com/JuliaLang/julia/blob/6cc1ae88078a9126ab28d743d80d484f9b58f2e6/src/gf.c#L2239-L2261
And more specifically on line 2251

It appears that the new `dispatch_status` is set to 0 when a method is disabled
