### PR TITLE
Strip ANSI escape codes from copied output

### DIFF
--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -950,6 +950,9 @@ const InputContextMenu = ({
         )
     }
 
+    const strip_ansi_codes = (s) =>
+        typeof s === "string" ? s.replace(/\x1b\[[0-9;]*m/g, "") : s
+
     const copy_output = () => {
         let notebook = /** @type{import("./Editor.js").NotebookData?} */ (pluto_actions.get_notebook())
         let cell_result = notebook?.cell_results?.[cell_id]
@@ -962,7 +965,7 @@ const InputContextMenu = ({
                   cell_result.output.body.plain_error
 
         if (cell_output != null)
-            navigator.clipboard.writeText(cell_output).catch(() => {
+            navigator.clipboard.writeText(strip_ansi_codes(cell_output)).catch(() => {
                 alert(`Error copying cell output`)
             })
     }


### PR DESCRIPTION
## Summary
- sanitize output for the copy-output menu item, fix #3258 

https://chatgpt.com/codex/tasks/task_e_685a9dcd22e0832fa1099a9e3d5f2f6b

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/fonsp/Pluto.jl", rev="codex/fix-pluto.jl-issue-3258")
julia> using Pluto
```
