### PR TITLE
Fix Pluto dev detection

### DIFF
--- a/src/webserver/Static.jl
+++ b/src/webserver/Static.jl
@@ -72,12 +72,12 @@ function notebook_response(notebook; home_url="./", as_redirect=true)
     end
 end
 
-const found_is_pluto_dev = Ref{Bool}()
+const found_is_pluto_dev = Ref{Union{Bool, Nothing}}()
 """
 Is the Pluto package `dev`ed? Returns `false` for normal Pluto installation from the registry.
 """
 function is_pluto_dev()
-    if isassigned(found_is_pluto_dev)
+    if found_is_pluto_dev[] !== nothing
         return found_is_pluto_dev[]
     end
 


### PR DESCRIPTION
In https://github.com/fonsp/Pluto.jl/commit/29a204e422420ee2e5e6df358d58c7c0a8f3ae83 I misunderstood how `isassigned` works with `Ref` and accidentally broke the Pluto dev detection because of it
This PR fixes it

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/fonsp/Pluto.jl", rev="Fix-offline-support")
julia> using Pluto
```
