### PR TITLE
Fix for clipped LaTeX in markdown

### DIFF
--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -464,9 +464,12 @@ pluto-output mjx-assistive-mml {
     height: 1px;
 }
 
-/* Avoid scrollbar in cells that contain just a h3 element, like the h3 headers in https://computationalthinking.mit.edu/Fall22/images_abstractions/transformations_and_autodiff/ */
+/* Allow horizontal scrolling of wide markdown content (e.g. long MathJax
+   expressions) while keeping vertical overflow hidden. This still prevents
+   scrollbars for simple headers but avoids clipping.  */
 .raw-html-wrapper > div.markdown {
-    overflow: hidden;
+    overflow-x: auto;
+    overflow-y: hidden;
 }
 
 pluto-output details {


### PR DESCRIPTION
## Summary
- allow horizontal scrolling for markdown so wide LaTeX isn't clipped

## Testing
- `apt-get update` *(fails: Invalid response from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688c781558dc832fa5a3a83018600fc0

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/fonsp/Pluto.jl", rev="codex/add-horizontal-scrolling-to-mathjax-output")
julia> using Pluto
```
