### PR TITLE
Fix copy output button in embed_display trees

### DIFF
--- a/frontend/components/CellOutput.js
+++ b/frontend/components/CellOutput.js
@@ -789,10 +789,11 @@ function apply_enhanced_markup_features(container, pluto_actions) {
         if (container.firstElementChild?.matches("div.markdown")) {
             container.querySelectorAll("pre > code").forEach((code_element) => {
                 const pre = code_element.parentElement
+                if (pre.closest("table, pluto-display, bond, pluto-tree")) return
                 generateCopyCodeButton(pre)
             })
             container.querySelectorAll("h1, h2, h3, h4, h5, h6").forEach((header_element) => {
-                if (header_element.closest("table, pluto-display, bond")) return
+                if (header_element.closest("table, pluto-display, bond, pluto-tree")) return
                 generateCopyHeaderIdButton(/** @type {HTMLHeadingElement} */ (header_element), pluto_actions)
             })
         }


### PR DESCRIPTION
<img width="730" height="486" alt="Scherm­afbeelding 2025-08-12 om 12 37 04" src="https://github.com/user-attachments/assets/dcc7c281-24b6-4a88-a4d3-f455e51a5fcf" />


## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/fonsp/Pluto.jl", rev="fix-copy-output-button-embed-display")
julia> using Pluto
```
