### PR TITLE
Fix execution of hidden scripts

### DIFF
--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -392,7 +392,6 @@ export const CellInput = ({
             const value = getValue6(cm)
             const trimmed = value.trim()
             const offset = value.length - value.trimStart().length
-            console.table({ value, trimmed, offset })
             if (trimmed.startsWith('md"') && trimmed.endsWith('"')) {
                 // Markdown cell, change to code
                 let start, end

--- a/frontend/components/CellOutput.js
+++ b/frontend/components/CellOutput.js
@@ -388,7 +388,7 @@ const execute_scripttags = async ({ root_node, script_nodes, previous_results_ma
         } else {
             // If there is no src="", we take the content and run it in an observablehq-like environment
             try {
-                let code = node.innerText
+                let code = node.textContent
                 let script_id = node.id
                 let old_result = script_id ? previous_results_map.get(script_id) : null
 

--- a/frontend/components/ErrorMessage.js
+++ b/frontend/components/ErrorMessage.js
@@ -188,7 +188,7 @@ const JuliaHighlightedLine = ({ code, frameLine, i }) => {
     const code_ref = useRef(/** @type {HTMLPreElement?} */ (null))
     useLayoutEffect(() => {
         if (code_ref.current) {
-            code_ref.current.innerText = code
+            code_ref.current.textContent = code
             delete code_ref.current.dataset.highlighted
             highlight(code_ref.current, "julia")
         }


### PR DESCRIPTION
This fixes a bug where a `<script>` element that is hidden (e.g. inside `<details>`) does not execute.

This should also improve performance a bit since `innerText` triggers reflow.

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/fonsp/Pluto.jl", rev="fix-execution-hidden-scripts")
julia> using Pluto
```
