### PR TITLE
Handle i18next plural forms in language updater

### DIFF
--- a/frontend/lang/update_languages.jl
+++ b/frontend/lang/update_languages.jl
@@ -26,28 +26,54 @@ end
 
 const english = load_json("english.json")
 
+const plural_suffixes = ["zero", "one", "two", "few", "many", "other"]
+const plural_regex = Regex("^(.*)_(" * join(plural_suffixes, "|") * ")\$")
+
+# Return the base key if it ends with an i18next plural suffix.
+# For example "t_time_minutes_other" -> "t_time_minutes".
+base_plural(key) = begin
+    m = match(plural_regex, key)
+    m === nothing ? nothing : m.captures[1]
+end
+
+# Keep a list of pluralized keys in the English file so we can
+# retain additional plural forms in other languages.
+const english_plural_bases = Set(filter(!isnothing, base_plural.(keys(english))))
+
 
 for lang_file in not_english
     @info "🔄 Updating" lang_file
     json = load_json(lang_file)
     
-    # Error about keys that should not be there, and remove them
+    # Warn about keys that should not be there
     for key in keys(json)
-        if !haskey(english, key)
+        if !(haskey(english, key) || (base_plural(key) !== nothing && base_plural(key) in english_plural_bases))
             @warn "🗑️ Key $key found in $lang_file but not in english.json. Removing..." old_value=json[key]
         end
     end
-    
+
     for key in keys(english)
         if !haskey(json, key)
             @info "🆕 Adding key: $key"
         end
     end
-    
-    new_data = OrderedDict(
-        key => haskey(json, key) ? json[key] : ""
-        for key in keys(english)
-    )
+
+    new_data = OrderedDict{String,Any}()
+    for key in keys(english)
+        # copy the English key or initialize with an empty string
+        new_data[key] = haskey(json, key) ? json[key] : ""
+        base = base_plural(key)
+        if base !== nothing
+            # if the English file defines one plural form, copy any
+            # additional forms present in the translation file
+            for suffix in plural_suffixes
+                candidate = string(base, "_", suffix)
+                if !haskey(english, candidate) && haskey(json, candidate)
+                    new_data[candidate] = json[candidate]
+                end
+            end
+        end
+    end
     
     write_json(lang_file, new_data)   
     


### PR DESCRIPTION
## Summary
- Preserve i18next pluralization keys like `_few` and `_many` when syncing translation files
- Group extra plural forms with their base key during language updates
- Add comments explaining plural detection and copying logic

## Testing
- `./julia-1.12.0-rc1/bin/julia frontend/lang/update_languages.jl`


------
https://chatgpt.com/codex/tasks/task_e_689f18c9c15c832fa94b19f4bd0fbc7a