### PR TITLE
Added missing localization for delete cell action.

### DIFF
--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -1024,7 +1024,7 @@ const InputContextMenu = ({
         >
             ${open
                 ? html`<ul onMouseenter=${mouseenter}>
-                      <${InputContextMenuItem} tag="delete" contents="Delete cell" title="Delete cell" onClick=${on_delete} setOpen=${setOpen} />
+                      <${InputContextMenuItem} tag="delete" contents=${t("t_delete_cell_action")} title=${t("t_delete_cell_action")} onClick=${on_delete} setOpen=${setOpen} />
 
                       <${InputContextMenuItem}
                           title=${running_disabled ? t("t_enable_and_run_cell") : t("t_disable_this_cell_and_all_cells_that_depend_on_it")}


### PR DESCRIPTION
The "Delete cell" action from the cell's context menu didn't use translation. Since `t_delete_cell_action` wasn't actually use anywhere in the code base (besides source JSON files), I guess it should be it.

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/s-zymon/Pluto.jl", rev="missing_loc_delete_cell")
julia> using Pluto
```
