### PR TITLE
Auto detect language

### DIFF
--- a/frontend/common/lang.js
+++ b/frontend/common/lang.js
@@ -23,15 +23,11 @@ i18next.use(LanguageDetector).init({
             translation: ellinika,
         },
     },
-    // supportedLngs: ["en", "nl", "el"],
     detection: {
-        // Disabled autodetection for now because we don't have enough translations yet.
-        // order: ["localStorage", "navigator"],
-        order: ["localStorage"],
+        order: ["localStorage", "navigator"],
         caches: ["localStorage"],
         lookupLocalStorage: "i18nextLng",
     },
-    // lng: "nl",
 })
 
 export const t = i18next.t


### PR DESCRIPTION
Automatically detect the user language based on the navigator info and use the closest matching language.

See also #3307  #3324 #3325 #3308 #3311 

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/fonsp/Pluto.jl", rev="Auto-detect-lang")
julia> using Pluto
```
