### PR TITLE
Improve machine translatability of Pluto documents

### DIFF
--- a/frontend/common/lang.js
+++ b/frontend/common/lang.js
@@ -69,6 +69,8 @@ export const getCurrentLanguage = () => {
     return i18next.language
 }
 
+document.documentElement.lang = getCurrentLanguage()
+
 /**
  * Like t, but you can interpolate Preact elements.
  * @param {string} key

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -47,7 +47,7 @@ import { SafePreviewUI } from "./SafePreviewUI.js"
 import { open_pluto_popup } from "../common/open_pluto_popup.js"
 import { get_included_external_source } from "../common/external_source.js"
 import { LanguagePicker } from "./LanguagePicker.js"
-import { t, th } from "../common/lang.js"
+import { getCurrentLanguage, t, th } from "../common/lang.js"
 
 // This is imported asynchronously - uncomment for development
 // import environment from "../common/Environment.js"
@@ -97,11 +97,14 @@ const statusmap = (/** @type {EditorState} */ state, /** @type {LaunchParameters
     static_preview: state.static_preview,
     inspecting_hidden_code: state.inspecting_hidden_code,
     bonds_disabled: !(
-        state.initializing ||
-        // connected to regular pluto server
-        state.connected ||
-        // connected to slider server
-        (launch_params.slider_server_url != null && (state.slider_server?.connecting || state.slider_server?.interactive))
+        // initializing, no answer yet
+        (
+            state.initializing ||
+            // connected to regular pluto server
+            state.connected ||
+            // connected to slider server
+            (launch_params.slider_server_url != null && (state.slider_server?.connecting || state.slider_server?.interactive))
+        )
     ),
     offer_binder: state.backend_launch_phase === BackendLaunchPhase.wait_for_user && launch_params.binder_url != null,
     offer_local: state.backend_launch_phase === BackendLaunchPhase.wait_for_user && launch_params.pluto_server_url != null,

--- a/frontend/components/ErrorMessage.js
+++ b/frontend/components/ErrorMessage.js
@@ -518,7 +518,7 @@ export const ErrorMessage = ({ msg, stacktrace, plain_error, cell_id }) => {
             <!-- <p>This message was included with the error:</p> -->
         </div>
 
-        <header>${matched_rewriter.display(msg)}</header>
+        <header translate="yes">${matched_rewriter.display(msg)}</header>
         ${stacktrace.length == 0 || !(matched_rewriter.show_stacktrace?.() ?? true)
             ? null
             : stacktrace_waiting_to_view

--- a/frontend/components/SafePreviewUI.js
+++ b/frontend/components/SafePreviewUI.js
@@ -36,7 +36,7 @@ export const SafePreviewUI = ({ process_waiting_for_permission, risky_file_sourc
                                           </p>
                                           ${warn_about_untrusted_code
                                               ? html`
-                                                    <pluto-output class="rich_output"
+                                                    <pluto-output translate="yes" class="rich_output"
                                                         ><div class="markdown">
                                                             <div class="admonition warning">
                                                                 <p class="admonition-title">Warning</p>

--- a/frontend/editor.html
+++ b/frontend/editor.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
 
 <head>
     <meta name="viewport" content="width=device-width" />
@@ -48,7 +48,7 @@
 
 <body class="no-MαθJax">
     <div style="display: flex; min-height: 100vh;">
-        <pluto-editor class="loading fullscreen">
+        <pluto-editor class="loading fullscreen" translate="no">
             <progress style="filter: grayscale(1)" class="statefile-fetch-progress delete-me-when-live" max="100"></progress>
         </pluto-editor>
     </div>


### PR DESCRIPTION
This changes our use of the `lang` and `translate` attributes:
- `lang="en"` is removed from the `<html>` tag by default. It will now be set to the interface language dynamically on load (#3307)
- `translate` is set to `"no"` globally, and to `"yes"` locally on cell output and docs pages. This means that UI will not be translated.


I used the Chrome Translate feature on a static HTML export and a live editing session, and it works really well!

It looks like Chrome Translate will auto-detect language anyways, so if the global `lang` attribute does not match content language, it's not a problem.

But it would be nice to set language as frontmatter.

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/fonsp/Pluto.jl", rev="lang-and-translate-attributes")
julia> using Pluto
```
