### PR TITLE
German lang: use neutral gendered forms

### DIFF
--- a/frontend/lang/deutsch.json
+++ b/frontend/lang/deutsch.json
@@ -89,7 +89,7 @@
         "Hab Geduld :)"
     ],
     "t_package_could_not_load": "<p>Das Paket <strong>{{package}}.jl</strong> konnte nicht geladen werden, da es nicht initialisiert werden konnte.</p><p>Das ist nicht schön! Was du versuchen könntest:</p>",
-    "t_package_could_not_load_things_you_could_try": "<ul><li>Das Notebook neu starten.</li><li>Eine andere Julia-Version ausprobieren.</li><li>Die Entwickler von {{package}}.jl bezüglich dieses Fehlers kontaktieren.</li></ul>",
+    "t_package_could_not_load_things_you_could_try": "<ul><li>Das Notebook neu starten.</li><li>Eine andere Julia-Version ausprobieren.</li><li>Die Entwickler:innen von {{package}}.jl bezüglich dieses Fehlers kontaktieren.</li></ul>",
     "t_might_find_info_in_pkg_log": "Du kannst nützliche Informationen im Paketinstallationsprotokoll finden:",
 
     "t_edit_frontmatter": "Frontmatter bearbeiten",
@@ -257,7 +257,7 @@
     "t_frontmatter_synchronized": "Frontmatter synchronisiert ✓\n\nDiese Parameter werden in zukünftigen Exporten verwendet.",
     "t_frontmatter_delete_field": "Feld löschen",
     "t_frontmatter_add_field": "Feld hinzufügen {{plus}}",
-    "t_frontmatter_add_author": "Autor hinzufügen {{plus}}",
+    "t_frontmatter_add_author": "Autor:in hinzufügen {{plus}}",
     "t_frontmatter_cancel": "Abbrechen",
     "t_frontmatter_save": "Speichern",
     "t_frontmatter_preview": "Vorschau",


### PR DESCRIPTION
Hey @kellertuer!

What do you think of this change? I want to use inclusive language :) This topic came up in the French localisation.

I wrote this myself using my mediocre german skills. I saw that there are also neutral forms without `:` like "Entwickelnde" but I like to show the inclusive language explicitly, since it fits Pluto's mission.


## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/fonsp/Pluto.jl", rev="german-neutral-gendered")
julia> using Pluto
```
