### PR TITLE
Fix completion exported on Julia 1.12

### DIFF
--- a/src/runner/PlutoRunner/src/ide features/completions.jl
+++ b/src/runner/PlutoRunner/src/ide features/completions.jl
@@ -31,7 +31,7 @@ function source_module(c::ModuleCompletion)
     end
 end
 
-completion_str_to_symbol(c::String) = endswith(s, "\"") ? Symbol("@$(s[begin:end-1])_str") : Symbol(s)
+completion_str_to_symbol(s::String) = endswith(s, "\"") ? Symbol("@$(s[begin:end-1])_str") : Symbol(s)
 
 completion_value_type(c::ModuleCompletion) = try
     completion_value_type_inner(getfield(c.parent, completion_str_to_symbol(c.mod)))::Symbol


### PR DESCRIPTION


## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/fonsp/Pluto.jl", rev="autocomplete-exported-julia-1.12")
julia> using Pluto
```
