### PR TITLE
Center pasted cells in viewport

### DIFF
--- a/frontend/components/DropRuler.js
+++ b/frontend/components/DropRuler.js
@@ -181,3 +181,34 @@ const argmin = (x) => {
 }
 
 const last = (x) => x[x.length - 1]
+
+export const get_drop_index_for_paste = (/** @type {HTMLElement} */ pluto_editor_element) => {
+    /** @type {HTMLElement[]} */
+    const cell_nodes = Array.from(pluto_editor_element.querySelectorAll(":scope > main > pluto-notebook > pluto-cell"))
+
+    if (cell_nodes.length === 0) {
+        return 0
+    }
+
+    const last_cell = cell_nodes[cell_nodes.length - 1]
+    const cell_edges = cell_nodes.map((el) => el.offsetTop)
+    cell_edges.push(last_cell.offsetTop + last_cell.scrollHeight)
+
+    const main_element = pluto_editor_element.querySelector("main") ?? pluto_editor_element
+    const main_top = main_element.getBoundingClientRect().top + document.documentElement.scrollTop
+    const viewport_height = window.innerHeight ?? document.documentElement.clientHeight ?? 0
+    const middle_of_viewport = document.documentElement.scrollTop + viewport_height / 2
+    const editorY = middle_of_viewport - main_top
+
+    let best_index = 0
+    let best_distance = Infinity
+    for (let i = 0; i < cell_edges.length; i++) {
+        const distance = Math.abs(cell_edges[i] - editorY - 8)
+        if (distance < best_distance) {
+            best_distance = distance
+            best_index = i
+        }
+    }
+
+    return best_index
+}

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -382,6 +382,38 @@ export class Editor extends Component {
 
         this.setStatePromise = (fn) => new Promise((r) => this.setState(fn, r))
 
+        this.get_drop_index_for_paste = () => {
+            const cell_nodes = Array.from(
+                this.props.pluto_editor_element.querySelectorAll(":scope > main > pluto-notebook > pluto-cell")
+            )
+
+            if (cell_nodes.length === 0) {
+                return 0
+            }
+
+            const last_cell = cell_nodes[cell_nodes.length - 1]
+            const cell_edges = cell_nodes.map((el) => el.offsetTop)
+            cell_edges.push(last_cell.offsetTop + last_cell.scrollHeight)
+
+            const main_element = this.props.pluto_editor_element.querySelector("main") ?? this.props.pluto_editor_element
+            const main_top = main_element.getBoundingClientRect().top + document.documentElement.scrollTop
+            const viewport_height = window.innerHeight ?? document.documentElement.clientHeight ?? 0
+            const middle_of_viewport = document.documentElement.scrollTop + viewport_height / 2
+            const editorY = middle_of_viewport - main_top
+
+            let best_index = 0
+            let best_distance = Infinity
+            for (let i = 0; i < cell_edges.length; i++) {
+                const distance = Math.abs(cell_edges[i] - editorY - 8)
+                if (distance < best_distance) {
+                    best_distance = distance
+                    best_index = i
+                }
+            }
+
+            return best_index
+        }
+
         // these are things that can be done to the local notebook
         this.real_actions = {
             get_notebook: () => this?.state?.notebook ?? {},
@@ -1434,7 +1466,8 @@ ${t("t_key_autosave_description")}`
             if (topaste) {
                 const deserializer = detect_deserializer(topaste)
                 if (deserializer != null) {
-                    this.actions.add_deserialized_cells(topaste, -1, deserializer)
+                    const drop_index = this.get_drop_index_for_paste()
+                    this.actions.add_deserialized_cells(topaste, drop_index, deserializer)
                     e.preventDefault()
                 }
             }


### PR DESCRIPTION
## Summary
- calculate the drop index for paste operations based on the visible cell edges
- insert pasted cells at the computed index so they appear near the middle of the viewport

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3aaec8e78832f878237da3616594b

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/fonsp/Pluto.jl", rev="codex/fix-issue-3357-in-pluto.jl")
julia> using Pluto
```
