### PR TITLE
Update saving and loading.jl: e is not defined

### DIFF
--- a/src/notebook/saving and loading.jl
+++ b/src/notebook/saving and loading.jl
@@ -234,7 +234,7 @@ function _read_notebook_collected_cells!(@nospecialize(io::IO))
             # parse metadata
             metadata = try
                 create_cell_metadata(TOML.parse(join(metadata_toml_lines, "\n")))
-            catch
+            catch e
                 @error "Failed to parse embedded TOML content" cell_id exception=(e, catch_backtrace())
                 DEFAULT_CELL_METADATA
             end


### PR DESCRIPTION
fixes 

```
└ @ Pluto ~/.julia/packages/Pluto/qz8Mi/src/notebook/saving and loading.jl:238
┌ Error: Exception while generating log record in module Pluto at /home/pgeorgakopoulos/.julia/packages/Pluto/qz8Mi/src/notebook/saving and loading.jl:238
│   exception =
│    UndefVarError: `e` not defined in `Pluto`
│    Suggestion: check for spelling errors or missing imports.
│    Stacktrace:
│      [1] macro expansion
│        @ ./logging/logging.jl:386 [inlined]
│      [2] _read_notebook_collected_cells!(io::IO)
│        @ Pluto ~/.julia/packages/Pluto/qz8Mi/src/notebook/saving and loading.jl:238
│      [3] load_notebook_nobackup(io::IO, path::AbstractString; skip_nbpkg::Bool)
```

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/fonsp/Pluto.jl", rev="pankgeorg-patch-1")
julia> using Pluto
```
