### PR TITLE
Autocomplete: avoid with empty search string

### DIFF
--- a/frontend/components/CellInput/pluto_autocomplete.js
+++ b/frontend/components/CellInput/pluto_autocomplete.js
@@ -159,7 +159,7 @@ const validFor = (/** @type {string} */ text) => {
 
 const not_explicit_and_too_boring = (/** @type {autocomplete.CompletionContext} */ ctx, allow_strings = false) => {
     if (ctx.explicit) return false
-    if (ctx.matchBefore(/[ =)+-/,*:'"]$/)) return true
+    if (ctx.matchBefore(/[\s=\)+-/,*:'\(;\[\]\{\}"]$/)) return true
     if (ctx.tokenBefore(["IntegerLiteral", "FloatLiteral", "LineComment", "BlockComment", "Symbol"]) != null) return true
     if (!allow_strings) {
         if (ctx.tokenBefore([...STRING_NODE_NAMES]) != null) {


### PR DESCRIPTION
Fix #3375
fix #3276
fix #3251

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/fonsp/Pluto.jl", rev="autocomplete-more-ignore-chars")
julia> using Pluto
```
