### PR TITLE
Avoid calling `cd` during notebook init

### DIFF
--- a/src/evaluation/Run.jl
+++ b/src/evaluation/Run.jl
@@ -414,7 +414,6 @@ function update_save_run!(
 		# this code block will run cells that only contain text offline, i.e. on the server process, before doing anything else
 		# this makes the notebook load a lot faster - the front-end does not have to wait for each output, and perform costly reflows whenever one updates
 		# "A Workspace on the main process, used to prerender markdown before starting a notebook process for speedy UI."
-		original_pwd = try pwd(); catch; end
 		offline_session = ServerSession()
 		offline_workspace = WorkspaceManager.make_workspace(
 			(
@@ -429,7 +428,6 @@ function update_save_run!(
 			run_single!(offline_workspace, cell, new.nodes[cell], new.codes[cell])
 		end
 
-		isnothing(original_pwd) || cd(original_pwd)
 		to_run_online = setdiff(cells, to_run_offline)
 		
 		clear_not_prerenderable_cells && foreach(clear_output!, to_run_online)

--- a/src/evaluation/WorkspaceManager.jl
+++ b/src/evaluation/WorkspaceManager.jl
@@ -114,7 +114,7 @@ function make_workspace((session, notebook)::SN; is_offline_renderer::Bool=false
 
         @async start_relaying_logs((session, notebook), remote_log_channel)
         @async start_relaying_self_updates((session, notebook), run_channel)
-        cd_workspace(workspace, notebook.path)
+        is_offline_renderer || cd_workspace(workspace, notebook.path)
         
         Status.report_business_finished!(init_status, Symbol(2))
         Status.report_business_started!(init_status, Symbol(3))


### PR DESCRIPTION
There was an issue with https://github.com/JuliaPluto/PlutoSliderServer.jl/pull/169 where multiple parallel notebooks runs could change the final `pwd`. This happened because of thread unsafe code around the `cd` system of the offline prerenderer.

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/fonsp/Pluto.jl", rev="dont-cd-for-offline-renderer")
julia> using Pluto
```
