### PR TITLE
fix display of Vector{Dict} and KeyedArray

### DIFF
--- a/src/runner/PlutoRunner/src/integrations.jl
+++ b/src/runner/PlutoRunner/src/integrations.jl
@@ -134,7 +134,7 @@ const integrations = Integration[
             pluto_showable(::MIME"application/vnd.pluto.table+object", x::Any) = try Tables.rowaccess(x)::Bool catch; false end
             pluto_showable(::MIME"application/vnd.pluto.table+object", t::Type) = false
             pluto_showable(::MIME"application/vnd.pluto.table+object", t::AbstractVector{<:NamedTuple}) = false
-            pluto_showable(::MIME"application/vnd.pluto.table+object", t::AbstractVector{<:Dict{Symbol,<:Any}}) = false
+            pluto_showable(::MIME"application/vnd.pluto.table+object", t::AbstractVector{<:AbstractDict}) = false
             pluto_showable(::MIME"application/vnd.pluto.table+object", t::AbstractVector{Union{}}) = false
 
         end,
@@ -169,6 +169,13 @@ const integrations = Integration[
         id = Base.PkgId(UUID("4e3cecfd-b093-5904-9786-8bbb286a6a31"), "ImageShow"),
         code = quote
             pluto_showable(::MIME"text/html", ::AbstractMatrix{<:ImageShow.Colorant}) = false
+        end,
+    ),
+    Integration(
+        id = Base.PkgId(UUID("94b1ba4f-4ee9-5380-92f1-94cde586c3c5"), "AxisKeys"),
+        code = quote
+            pluto_showable(::MIME"application/vnd.pluto.tree+object", ::AxisKeys.KeyedArray) = false
+            pluto_showable(::MIME"application/vnd.pluto.table+object", ::AxisKeys.KeyedArray) = false
         end,
     ),
 ]


### PR DESCRIPTION
Fixes https://github.com/fonsp/Pluto.jl/issues/2417 + more.

Before:
<img width="904" height="1070" alt="image" src="https://github.com/user-attachments/assets/dab2be75-ca5e-438f-87f7-67a7ca483e08" />
After:
<img width="904" height="652" alt="image" src="https://github.com/user-attachments/assets/9685bb2d-c0e6-47c0-9264-a98b85d1c157" />



## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/aplavin/Pluto.jl", rev="patch-1")
julia> using Pluto
```
