### PR TITLE
Add `app` functionality

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -82,3 +82,6 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [targets]
 test = ["DataFrames", "OffsetArrays", "Sockets", "Test", "TimerOutputs", "Memoize"]
+
+[apps]
+pluto = {submodule="PlutoApp"}

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.20.21"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+Comonicon = "863f3e99-da2a-4334-8734-de3dacbe5542"
 Configurations = "5218b696-f38b-4ac9-8b61-a12ec717816d"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
@@ -40,6 +41,7 @@ UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
 Base64 = "1"
+Comonicon = "1"
 Configurations = "0.15, 0.16, 0.17"
 Dates = "0, 1"
 Downloads = "1"
@@ -72,6 +74,9 @@ URIs = "1.3"
 UUIDs = "1"
 julia = "^1.10"
 
+[apps.pluto]
+submodule = "PlutoApp"
+
 [extras]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Memoize = "c03570c3-d221-55d1-a50c-7939bbd78826"
@@ -82,6 +87,3 @@ TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [targets]
 test = ["DataFrames", "OffsetArrays", "Sockets", "Test", "TimerOutputs", "Memoize"]
-
-[apps]
-pluto = {submodule="PlutoApp"}

--- a/src/Pluto.jl
+++ b/src/Pluto.jl
@@ -86,7 +86,9 @@ include("./webserver/Dynamic.jl")
 include("./webserver/REPLTools.jl")
 include("./webserver/WebServer.jl")
 
-include("PlutoApp.jl")
+@static if VERSION >= v"1.11"
+    include("PlutoApp.jl")
+end
 
 const reset_notebook_environment = PkgUtils.reset_notebook_environment
 const update_notebook_environment = PkgUtils.update_notebook_environment

--- a/src/Pluto.jl
+++ b/src/Pluto.jl
@@ -86,6 +86,8 @@ include("./webserver/Dynamic.jl")
 include("./webserver/REPLTools.jl")
 include("./webserver/WebServer.jl")
 
+include("PlutoApp.jl")
+
 const reset_notebook_environment = PkgUtils.reset_notebook_environment
 const update_notebook_environment = PkgUtils.update_notebook_environment
 const activate_notebook_environment = PkgUtils.activate_notebook_environment

--- a/src/PlutoApp.jl
+++ b/src/PlutoApp.jl
@@ -1,17 +1,17 @@
 module PlutoApp
+
 using Pluto
 import Comonicon
 
+# Note we need the `# Intro` header for Comonicon to pick up this docstring.
 """
 # Intro
 The `pluto` executable exposes a simple CLI interface for the `Pluto.run(; ...)` function.
-It is supposed to be used via Julia ["apps"](https://pkgdocs.julialang.org/v1/apps/) from Julia 1.11+
-and typically lives in your `\$PATH`.
-It can be installed via `julia -e "import Pkg; Pkg.Apps.add("Pluto")"`.
+It is supposed to be used via Julia ["apps"](https://pkgdocs.julialang.org/v1/apps/) from Julia 1.11+ and typically lives in your `\$PATH`.
+It can be installed via `julia -e "import Pkg; Pkg.Apps.add(\"Pluto\")"`.
 """
 Comonicon.@main function pluto(notebooks::String...;
-    # Comonicon flags must default to false
-    dont_launch_browser::Bool=false,
+    dont_launch_browser::Bool=false, # Comonicon flags must default to false
     port::Int=-1,  # Union{Nothing, Int} not supported by Comonicon
     host::String="127.0.0.1",
     auto_reload_from_file::Bool=false
@@ -24,8 +24,7 @@ Comonicon.@main function pluto(notebooks::String...;
 end
 function (Base.@main)(ARGS::Vector{String})
     # this function is generated into the current module by Comonicon
-    # and will ultimately call the function above annotated by
-    # `Comonicon.@main`
+    # and will ultimately call the function above annotated by `Comonicon.@main`
     return command_main(ARGS)
 end
 

--- a/src/PlutoApp.jl
+++ b/src/PlutoApp.jl
@@ -2,6 +2,13 @@ module PlutoApp
 using Pluto
 import Comonicon
 
+"""
+# Intro
+The `pluto` executable exposes a simple CLI interface for the `Pluto.run(; ...)` function.
+It is supposed to be used via Julia ["apps"](https://pkgdocs.julialang.org/v1/apps/) from Julia 1.11+
+and typically lives in your `\$PATH`.
+It can be installed via `julia -e "import Pkg; Pkg.Apps.add("Pluto")"`.
+"""
 Comonicon.@main function pluto(notebooks::String...;
     # Comonicon flags must default to false
     dont_launch_browser::Bool=false,

--- a/src/PlutoApp.jl
+++ b/src/PlutoApp.jl
@@ -1,0 +1,10 @@
+module PlutoApp
+using Pluto
+
+function (@main)(ARGS)
+    Pluto.run()
+    return
+end
+
+
+end

--- a/src/PlutoApp.jl
+++ b/src/PlutoApp.jl
@@ -1,10 +1,25 @@
 module PlutoApp
 using Pluto
+import Comonicon
 
-function (@main)(ARGS)
-    Pluto.run()
+Comonicon.@main function pluto(notebooks::String...;
+    # Comonicon flags must default to false
+    dont_launch_browser::Bool=false,
+    port::Int=-1,  # Union{Nothing, Int} not supported by Comonicon
+    host::String="127.0.0.1",
+    auto_reload_from_file::Bool=false
+)
+    notebook = (isempty(notebooks) ? nothing : collect(notebooks))
+    port = (port == -1 ? nothing : port)
+    launch_browser = !dont_launch_browser
+    Pluto.run(; notebook, launch_browser, port, host, auto_reload_from_file)
     return
 end
-
+function (Base.@main)(ARGS::Vector{String})
+    # this function is generated into the current module by Comonicon
+    # and will ultimately call the function above annotated by
+    # `Comonicon.@main`
+    return command_main(ARGS)
+end
 
 end


### PR DESCRIPTION
This PR may relate to or close https://github.com/Roger-luo/Configurations.jl/issues/100.

## Summary
This PR implements a simple CLI interface to launch Pluto using Julia 1.11 ["apps"](https://pkgdocs.julialang.org/v1/apps/).

Using this PR allows a user to run 

``` sh
pluto mynotebook.jl
pluto --port=1235 --dont-launch-browser
# etc
```
Currently only a small subset of `Pluto.run(; ...)` flags are supported - in particular those which are documented under `?Pluto.run` (see PlutoApp.jl in this PR.)
For more complex use cases a user can just launch Pluto from a Julia REPL as before.

## Motivation
A minor issue that we keep running into is that students are confused exactly how Pluto relies to a "package" they are developing (typically bundling some research code etc).
They end up installing Pluto into their package (adding it as a dependency) and are confused why their package is not available from inside Pluto.
I think this is because the mental model that Pluto launches new Julia workers is not obvious.

With the app workflow I hope that users have a new mental model that you launch Pluto from "anywhere" as an app and then activate their own project from inside Pluto.

## Choice of CLI Parser library
I have chosen [Comonicon.jl](https://github.com/comonicon/Comonicon.jl). Alternatives include
- ad hoc parser
- [`ArgParse.jl`](https://github.com/carlobaldassi/ArgParse.jl)
- [`SimpleArgParse.jl`](https://github.com/admercs/SimpleArgParse.jl)
- [`Fire.jl`](https://github.com/ylxdzsw/Fire.jl)
- [`TrimableCLIParser.jl`](https://github.com/RomeoV/TrimmableCLIParser.jl)

I have chosen because it is relatively widely used, let's us write a quite concise interface, Pluto already uses [Configurations.jl](https://github.com/Roger-luo/Configurations.jl) from the same ecosystem (i.e., author), and I was the most familiar with it.

Happy to get feedback whether this feature is wanted and reasonable in this current form.

## Run the app code
You can either do something like

``` julia
julia --project -m Pluto.PlutoApp --help
```
or

``` julia
]app dev .
;pluto --help
```

For the prior, you may want to consider commenting out the precompile when playing around with the CLI interface (to accelerate your CLI interface feedback loop) by commenting out `include("./precompile.jl")` in `src/Pluto.jl`.

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/RomeoV/Pluto.jl", rev="add-app")
julia> using Pluto
```