### PR TITLE
avoid access to internal `MethodList` field removed in 1.12.

### DIFF
--- a/src/runner/PlutoRunner/src/evaluation/run_expression.jl
+++ b/src/runner/PlutoRunner/src/evaluation/run_expression.jl
@@ -38,7 +38,12 @@ end
 function delete_computer!(computers::Dict{UUID,Computer}, cell_id::UUID)
     computer = pop!(computers, cell_id)
     UseEffectCleanups.trigger_cleanup(cell_id)
-    Base.delete_method(methods(computer.f) |> only) # Make the computer function uncallable
+    # Make the computer function uncallable
+    if VERSION < v"1.12.0-0"
+        Base.visit(Base.delete_method, methods(computer.f).mt)
+    else
+        foreach(Base.delete_method, methods(computer.f))
+    end
 end
 
 parse_cell_id(filename::Symbol) = filename |> string |> parse_cell_id


### PR DESCRIPTION
I was playing with internals and found out that this `delete_computer` method errors due to direct access to an internal field of `MethodList` which was removed in https://github.com/JuliaLang/julia/pull/58131

I am not sure what was the original logic, and why this does not simply delete the single methods of the computer function (which should be unique as it's created everytime with a `gensym` name).

I added a `only` here to simplify catching issues where multiple methods might be returned for a specific computer function.

It is strange that this has not popped up on running Pluto notebooks in the wild. I wonder whether this path is actually not hit anymore in latest pluto versions, but couldn't find any obvious pointer to this in the code so far.

@Pangoraw maybe you know why this was done with `Base.visit` instead of directly using `Base.delete_method`? 

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/disberd/Pluto.jl", rev="update_delete_computer")
julia> using Pluto
```
