### PR TITLE
Julia 1.13: Fix use of CapturedException and stacktrace

### DIFF
--- a/src/runner/PlutoRunner/src/display/format_output.jl
+++ b/src/runner/PlutoRunner/src/display/format_output.jl
@@ -93,7 +93,7 @@ function format_output_default(@nospecialize(val), @nospecialize(context=default
         end
     catch ex
         title = ErrorException("Failed to show value: \n" * sprint(try_showerror, ex))
-        bt = stacktrace(catch_backtrace())
+        bt = catch_backtrace()
         format_output(CapturedException(title, bt))
     end
 end

--- a/src/runner/PlutoRunner/src/evaluation/run_expression.jl
+++ b/src/runner/PlutoRunner/src/evaluation/run_expression.jl
@@ -125,7 +125,7 @@ function run_inside_trycatch(m::Module, f::Union{Expr,Function})::Tuple{Any,Unio
             f()
         end
     catch ex
-        bt = stacktrace(catch_backtrace())
+        bt = catch_backtrace()
         (CapturedException(ex, bt), nothing)
     end
 end
@@ -198,7 +198,7 @@ function run_expression(
         try
             try_macroexpand(m, notebook_id, cell_id, expr; capture_stdout)
         catch e
-            result = CapturedException(e, stacktrace(catch_backtrace()))
+            result = CapturedException(e, catch_backtrace())
             cell_results[cell_id], cell_runtimes[cell_id] = (result, nothing)
             return (result, nothing)
         end


### PR DESCRIPTION
Fix https://github.com/JuliaPluto/PlutoDependencyExplorer.jl/issues/18

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/fonsp/Pluto.jl", rev="CapturedException-stacktrace")
julia> using Pluto
```
