### PR TITLE
Transfer to JuliaPluto org

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,7 +1,7 @@
 # This GitHub action checks whether a new version of this package
 # has been registred in the official registry.
 # If so, it creates a new _release_:
-# https://github.com/fonsp/Pluto.jl/releases
+# https://github.com/JuliaPluto/Pluto.jl/releases
 
 name: TagBot
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
-# Posting an issue? [Read this first!](https://github.com/fonsp/Pluto.jl/issues/182)
+# Posting an issue? [Read this first!](https://github.com/JuliaPluto/Pluto.jl/issues/182)
 
 Interested in contributing to Pluto's development? [Take a look at our developer instructions](https://github.com/fonsp/pluto-developer-instructions)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 
 
-<h1><img alt="Pluto.jl" src="https://raw.githubusercontent.com/fonsp/Pluto.jl/dd0ead4caa2d29a3a2cfa1196d31e3114782d363/frontend/img/logo_white_contour.svg" width=300 height=74 ></h1>
+<h1><img alt="Pluto.jl" src="https://raw.githubusercontent.com/JuliaPluto/Pluto.jl/dd0ead4caa2d29a3a2cfa1196d31e3114782d363/frontend/img/logo_white_contour.svg" width=300 height=74 ></h1>
 
 _Writing a notebook is not just about writing the final document — Pluto empowers the experiments and discoveries that are essential to getting there._
 
@@ -31,7 +31,7 @@ _Writing a notebook is not just about writing the final document — Pluto empow
 <p align="center"><a href="https://binder.plutojl.org/">🎈 <b>Pluto demo</b> inside your browser 🎈</a></p>
 
 
-<img alt="reactivity screencap" src="https://raw.githubusercontent.com/fonsp/Pluto.jl/580ab811f13d565cc81ebfa70ed36c84b125f55d/demo/plutodemo.gif" >
+<img alt="reactivity screencap" src="https://raw.githubusercontent.com/JuliaPluto/Pluto.jl/580ab811f13d565cc81ebfa70ed36c84b125f55d/demo/plutodemo.gif" >
 
 
 
@@ -45,7 +45,7 @@ Cells can contain _arbitrary_ Julia code, and you can use external libraries. Th
 
 ### Output
 
-Your notebooks are **saved as pure Julia files** ([sample](https://github.com/fonsp/Pluto.jl/blob/main/sample/Basic.jl)), which you can then import as if you had been programming in a regular editor all along. You can also export your notebook with cell outputs as attractive HTML and PDF documents. By reordering cells and hiding code, you have full control over how you tell your story.
+Your notebooks are **saved as pure Julia files** ([sample](https://github.com/JuliaPluto/Pluto.jl/blob/main/sample/Basic.jl)), which you can then import as if you had been programming in a regular editor all along. You can also export your notebook with cell outputs as attractive HTML and PDF documents. By reordering cells and hiding code, you have full control over how you tell your story.
 
 <br >
 
@@ -126,7 +126,7 @@ See [plutojl.org/#install](https://plutojl.org/#install) for an easy guide to in
 
 ## Questions and Help
 
-Questions? Have a look at the [FAQ](https://github.com/fonsp/Pluto.jl/wiki) and the [documentation](https://plutojl.org).
+Questions? Have a look at the [FAQ](https://github.com/JuliaPluto/Pluto.jl/wiki) and the [documentation](https://plutojl.org).
 <br>
 <br>
 <br>
@@ -139,13 +139,13 @@ Questions? Have a look at the [FAQ](https://github.com/fonsp/Pluto.jl/wiki) and 
 
 ## Contribute to Pluto
 
-Follow [these instructions](https://github.com/fonsp/Pluto.jl/blob/main/CONTRIBUTING.md) to start working on the package.
+Follow [these instructions](https://github.com/JuliaPluto/Pluto.jl/blob/main/CONTRIBUTING.md) to start working on the package.
 
 <img src="https://raw.githubusercontent.com/gist/fonsp/9a36c183e2cad7c8fc30290ec95eb104/raw/ca3a38a61f95cd58d79d00b663a3c114d21e284e/cute.svg">
 
 ## License
 
-Pluto.jl is open source! Specifically, it is [MIT Licensed](https://github.com/fonsp/Pluto.jl/blob/main/LICENSE). Pluto.jl is built by gluing together open source software:
+Pluto.jl is open source! Specifically, it is [MIT Licensed](https://github.com/JuliaPluto/Pluto.jl/blob/main/LICENSE). Pluto.jl is built by gluing together open source software:
 
 -   `Julia` - [license](https://github.com/JuliaLang/julia/blob/master/LICENSE.md)
 -   `CodeMirror` - [license](https://github.com/codemirror/codemirror.next/blob/master/LICENSE-MIT)
@@ -161,7 +161,7 @@ If you want to reference Pluto.jl in scientific writing, you can use our DOI: [!
 
 ### Featured notebooks
 
-Unless otherwise specified, the included featured notebooks have a more permissive license: the [Unlicense](https://github.com/fonsp/Pluto.jl/blob/main/sample/LICENSE). This means that you can use them however you like - you do not need to credit us! 
+Unless otherwise specified, the included featured notebooks have a more permissive license: the [Unlicense](https://github.com/JuliaPluto/Pluto.jl/blob/main/sample/LICENSE). This means that you can use them however you like - you do not need to credit us! 
 
 Your notebook files are _yours_, you also do not need to credit us. Have fun!
 
@@ -172,12 +172,12 @@ The Pluto project is an ambition to [_rethink what a programming environment sho
 ### You can chat with us
 
 -   talk with fellow Pluto users in the **[Zulip chat room](https://gist.github.com/fonsp/db7d00fd3fe5bc0b379b4af9ec6674b6)** (_search for the `pluto.jl` stream_)
--   use Pluto's **[built-in feedback system:](https://github.com/fonsp/Pluto.jl/issues/182#issue-637726414)**
+-   use Pluto's **[built-in feedback system:](https://github.com/JuliaPluto/Pluto.jl/issues/182#issue-637726414)**
 -   contact fons **[via email](mailto:fons@plutojl.org)**
 
 <img alt="feedback screencap" src="https://user-images.githubusercontent.com/6933510/84502876-6f08db00-acb9-11ea-84c3-f5daaba29273.png" width="100%">
 
-Questions? Have a look at the [FAQ](https://github.com/fonsp/Pluto.jl/wiki).
+Questions? Have a look at the [FAQ](https://github.com/JuliaPluto/Pluto.jl/wiki).
 
 ## Sponsors
 

--- a/frontend/common/Feedback.js
+++ b/frontend/common/Feedback.js
@@ -72,7 +72,7 @@ export const init_feedback = async () => {
                     feedbackform.querySelector("#opinion").value = ""
                 } catch (error) {
                     let message =
-                        "Whoops, failed to send feedback 😢\nWe would really like to hear from you! Please got to https://github.com/fonsp/Pluto.jl/issues to report this failure:\n\n"
+                        "Whoops, failed to send feedback 😢\nWe would really like to hear from you! Please got to https://github.com/JuliaPluto/Pluto.jl/issues to report this failure:\n\n"
                     console.error(message)
                     console.error(error)
                     alert(message + error)

--- a/frontend/common/NewUpdateMessage.js
+++ b/frontend/common/NewUpdateMessage.js
@@ -28,7 +28,7 @@ export const new_update_message = (client) =>
         })
 
 const fetch_pluto_releases = async () => {
-    let response = await fetch("https://api.github.com/repos/fonsp/Pluto.jl/releases", {
+    let response = await fetch("https://api.github.com/repos/JuliaPluto/Pluto.jl/releases", {
         method: "GET",
         mode: "cors",
         cache: "no-cache",

--- a/frontend/common/PlutoConnection.js
+++ b/frontend/common/PlutoConnection.js
@@ -129,13 +129,13 @@ const create_ws_connection = (address, { on_message, on_socket_close }, timeout_
                     } catch (process_err) {
                         console.error("Failed to process message from websocket", process_err, { message })
                         // prettier-ignore
-                        alert(`Something went wrong! You might need to refresh the page.\n\nPlease open an issue on https://github.com/fonsp/Pluto.jl with this info:\n\nFailed to process update\n${process_err.message}\n\n${JSON.stringify(event)}`)
+                        alert(`Something went wrong! You might need to refresh the page.\n\nPlease open an issue on https://github.com/JuliaPluto/Pluto.jl with this info:\n\nFailed to process update\n${process_err.message}\n\n${JSON.stringify(event)}`)
                     }
                 } catch (unpack_err) {
                     console.error("Failed to unpack message from websocket", unpack_err, { event })
 
                     // prettier-ignore
-                    alert(`Something went wrong! You might need to refresh the page.\n\nPlease open an issue on https://github.com/fonsp/Pluto.jl with this info:\n\nFailed to unpack message\n${unpack_err}\n\n${JSON.stringify(event)}`)
+                    alert(`Something went wrong! You might need to refresh the page.\n\nPlease open an issue on https://github.com/JuliaPluto/Pluto.jl with this info:\n\nFailed to unpack message\n${unpack_err}\n\n${JSON.stringify(event)}`)
                 }
             })
         }

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -738,7 +738,7 @@ export const CellInput = ({
                         set_error(exception)
                         console.error("EditorView exception!", exception)
                         // alert(
-                        //     `We ran into an issue! We have lost your cursor 😞😓😿\n If this appears again, please press F12, then click the "Console" tab,  eport an issue at https://github.com/fonsp/Pluto.jl/issues`
+                        //     `We ran into an issue! We have lost your cursor 😞😓😿\n If this appears again, please press F12, then click the "Console" tab,  eport an issue at https://github.com/JuliaPluto/Pluto.jl/issues`
                         // )
                     }),
                 ],

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -762,7 +762,7 @@ export class Editor extends Component {
                                 ;(ignore ? console.log : console.error)(
                                     `#######################**************************########################
 PlutoError: StateOutOfSync: Failed to apply patches.
-Please report this: https://github.com/fonsp/Pluto.jl/issues adding the info below:
+Please report this: https://github.com/JuliaPluto/Pluto.jl/issues adding the info below:
 failing path: ${failing_path}
 notebook previous value: ${path_value}
 patch: ${JSON.stringify(
@@ -1824,7 +1824,7 @@ ${t("t_key_autosave_description")}`
                     <footer>
                         <div id="info">
                             <${LanguagePicker} />
-                            <a href="https://github.com/fonsp/Pluto.jl/wiki" target="_blank">${t("t_FAQ")}</a>
+                            <a href="https://github.com/JuliaPluto/Pluto.jl/wiki" target="_blank">${t("t_FAQ")}</a>
                             <span style="flex: 1 1 0%; min-width: 5ch;"></span>
                             <form id="feedback" action="#" method="post">
                                 <label for="opinion">${th("t_how_can_we_improve", {

--- a/frontend/components/ErrorMessage.js
+++ b/frontend/components/ErrorMessage.js
@@ -403,7 +403,7 @@ export const ErrorMessage = ({ msg, stacktrace, plain_error, cell_id }) => {
                 html`<p>Tried to reevaluate an <code>include</code> call, this is not supported. You might need to restart this notebook from the main menu.</p>
                     <p>
                         For a workaround, use the alternative version of <code>include</code> described here:
-                        <a target="_blank" href="https://github.com/fonsp/Pluto.jl/issues/115#issuecomment-661722426">GH issue 115</a>
+                        <a target="_blank" href="https://github.com/JuliaPluto/Pluto.jl/issues/115#issuecomment-661722426">GH issue 115</a>
                     </p>
                     <p>In the future, <code>include</code> will be deprecated, and this will be the default.</p>`,
         },

--- a/frontend/components/LanguagePicker.js
+++ b/frontend/components/LanguagePicker.js
@@ -11,7 +11,7 @@ export const LanguagePicker = () => {
 
     const handleLanguageChange = async (event) => {
         if (event.target.value === "contribute") {
-            window.open("https://github.com/fonsp/Pluto.jl/tree/main/frontend/lang", "_blank")
+            window.open("https://github.com/JuliaPluto/Pluto.jl/tree/main/frontend/lang", "_blank")
             return
         }
 

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -464,7 +464,7 @@ kbd {
     font-weight: 600;
 }
 
-/* Avoid scrollbar in in-line latex with markdown, see https://github.com/fonsp/Pluto.jl/issues/1309 */
+/* Avoid scrollbar in in-line latex with markdown, see https://github.com/JuliaPluto/Pluto.jl/issues/1309 */
 pluto-output mjx-assistive-mml {
     height: 1px;
 }

--- a/frontend/lang/README.md
+++ b/frontend/lang/README.md
@@ -12,7 +12,7 @@ Localizing Pluto is a great way to help the Julia community, because it makes Ju
 
 We also want to break the tradition that "programming is in English". Programming is for everyone, and we hope that computers can be used regardless of language and culture.
 
-Your work is also an **open source** contribution! Because you contribute localizations via git and github, you will be listed in the Pluto contributors list (https://github.com/fonsp/Pluto.jl), and in the Pluto release notes (https://github.com/fonsp/Pluto.jl/releases).
+Your work is also an **open source** contribution! Because you contribute localizations via git and github, you will be listed in the Pluto contributors list (https://github.com/JuliaPluto/Pluto.jl), and in the Pluto release notes (https://github.com/JuliaPluto/Pluto.jl/releases).
 
 
 
@@ -87,7 +87,7 @@ You use the `_one`, `_other`, `_zero`, `_two`, `_few`, `_many`, and `_other` suf
 
 ## How to contribute
 
-Before you start, take a look at [the Issues and PRs labeled "language"](https://github.com/fonsp/Pluto.jl/issues?q=label%3Alanguage). Someone else might already be working on this language, and you could collaborate!
+Before you start, take a look at [the Issues and PRs labeled "language"](https://github.com/JuliaPluto/Pluto.jl/issues?q=label%3Alanguage). Someone else might already be working on this language, and you could collaborate!
 
 
 ### Initial setup:

--- a/src/notebook/Export.jl
+++ b/src/notebook/Export.jl
@@ -25,7 +25,7 @@ function cdnified_html(filename::AbstractString;
             try
                 original = read(project_relative_path("frontend-dist", filename), String)
                 
-                cdn_root = "https://cdn.jsdelivr.net/gh/fonsp/Pluto.jl@$(string(PLUTO_VERSION))/frontend-dist/"
+                cdn_root = "https://cdn.jsdelivr.net/gh/JuliaPluto/Pluto.jl@$(string(PLUTO_VERSION))/frontend-dist/"
 
                 @debug "Using CDN for Pluto assets:" cdn_root
 
@@ -43,7 +43,7 @@ function cdnified_html(filename::AbstractString;
         let
             original = read(project_relative_path("frontend", filename), String)
 
-            cdn_root = something(pluto_cdn_root, "https://cdn.jsdelivr.net/gh/fonsp/Pluto.jl@$(something(cdn_version_override, string(something(version, PLUTO_VERSION))))/frontend/")
+            cdn_root = something(pluto_cdn_root, "https://cdn.jsdelivr.net/gh/JuliaPluto/Pluto.jl@$(something(cdn_version_override, string(something(version, PLUTO_VERSION))))/frontend/")
 
             @debug "Using CDN for Pluto assets:" cdn_root
     

--- a/src/packages/PkgCompat.jl
+++ b/src/packages/PkgCompat.jl
@@ -418,7 +418,7 @@ function dependencies(ctx)
 
 			to reset this notebook's environment.
 
-			Before doing so, consider sending your notebook file to https://github.com/fonsp/Pluto.jl/issues together with the following info:
+			Before doing so, consider sending your notebook file to https://github.com/JuliaPluto/Pluto.jl/issues together with the following info:
 			""" Pluto.PLUTO_VERSION VERSION exception=(e,catch_backtrace())
 		end
 

--- a/src/webserver/Router.jl
+++ b/src/webserver/Router.jl
@@ -56,7 +56,7 @@ function http_router_for(session::ServerSession)
                         as_sample, 
                         risky_file_source=nothing,
                         title="Failed to load notebook", 
-                        advice="The file <code>$(htmlesc(path))</code> could not be loaded. Please <a href='https://github.com/fonsp/Pluto.jl/issues'>report this error</a>!",
+                        advice="The file <code>$(htmlesc(path))</code> could not be loaded. Please <a href='https://github.com/JuliaPluto/Pluto.jl/issues'>report this error</a>!",
                     )
                 else
                     return error_response(404, "Can't find a file here", "Please check whether <code>$(htmlesc(path))</code> exists.")
@@ -70,7 +70,7 @@ function http_router_for(session::ServerSession)
                     as_sample, 
                     risky_file_source=url,
                     title="Failed to load notebook", 
-                    advice="The notebook from <code>$(htmlesc(url))</code> could not be loaded. Please <a href='https://github.com/fonsp/Pluto.jl/issues'>report this error</a>!"
+                    advice="The notebook from <code>$(htmlesc(url))</code> could not be loaded. Please <a href='https://github.com/JuliaPluto/Pluto.jl/issues'>report this error</a>!"
                 )
             else
                 # You can ask Pluto to handle CustomLaunch events
@@ -83,7 +83,7 @@ function http_router_for(session::ServerSession)
                 return maybe_notebook_response
             end
         catch e
-            return error_response(400, "Bad query", "Please <a href='https://github.com/fonsp/Pluto.jl/issues'>report this error</a>!", sprint(showerror, e, stacktrace(catch_backtrace())))
+            return error_response(400, "Bad query", "Please <a href='https://github.com/JuliaPluto/Pluto.jl/issues'>report this error</a>!", sprint(showerror, e, stacktrace(catch_backtrace())))
         end
     end
 
@@ -115,7 +115,7 @@ function http_router_for(session::ServerSession)
             SessionActions.move(session, notebook, newpath)
             HTTP.Response(200, notebook.path)
         catch e
-            error_response(400, "Bad query", "Please <a href='https://github.com/fonsp/Pluto.jl/issues'>report this error</a>!", sprint(showerror, e, stacktrace(catch_backtrace())))
+            error_response(400, "Bad query", "Please <a href='https://github.com/JuliaPluto/Pluto.jl/issues'>report this error</a>!", sprint(showerror, e, stacktrace(catch_backtrace())))
         end
     end
 
@@ -141,7 +141,7 @@ function http_router_for(session::ServerSession)
             home_url="../", 
             as_sample=true, 
             title="Failed to load sample", 
-            advice="Please <a href='https://github.com/fonsp/Pluto.jl/issues'>report this error</a>!"
+            advice="Please <a href='https://github.com/JuliaPluto/Pluto.jl/issues'>report this error</a>!"
         )
     end
     HTTP.register!(router, "GET", "/sample/*", serve_sample)
@@ -161,7 +161,7 @@ function http_router_for(session::ServerSession)
             HTTP.setheader(response, "Content-Disposition" => "inline; filename=\"$(basename(notebook.path))\"")
             response
         catch e
-            return error_response(400, "Bad query", "Please <a href='https://github.com/fonsp/Pluto.jl/issues'>report this error</a>!", sprint(showerror, e, stacktrace(catch_backtrace())))
+            return error_response(400, "Bad query", "Please <a href='https://github.com/JuliaPluto/Pluto.jl/issues'>report this error</a>!", sprint(showerror, e, stacktrace(catch_backtrace())))
         end
     end
     HTTP.register!(router, "GET", "/notebookfile", serve_notebookfile)
@@ -174,7 +174,7 @@ function http_router_for(session::ServerSession)
             HTTP.setheader(response, "Content-Disposition" => "attachment; filename=\"$(without_pluto_file_extension(basename(notebook.path))).plutostate\"")
             response
         catch e
-            return error_response(400, "Bad query", "Please <a href='https://github.com/fonsp/Pluto.jl/issues'>report this error</a>!", sprint(showerror, e, stacktrace(catch_backtrace())))
+            return error_response(400, "Bad query", "Please <a href='https://github.com/JuliaPluto/Pluto.jl/issues'>report this error</a>!", sprint(showerror, e, stacktrace(catch_backtrace())))
         end
     end
     HTTP.register!(router, "GET", "/statefile", serve_statefile)
@@ -187,7 +187,7 @@ function http_router_for(session::ServerSession)
             HTTP.setheader(response, "Content-Disposition" => "attachment; filename=\"$(without_pluto_file_extension(basename(notebook.path))).html\"")
             response
         catch e
-            return error_response(400, "Bad query", "Please <a href='https://github.com/fonsp/Pluto.jl/issues'>report this error</a>!", sprint(showerror, e, stacktrace(catch_backtrace())))
+            return error_response(400, "Bad query", "Please <a href='https://github.com/JuliaPluto/Pluto.jl/issues'>report this error</a>!", sprint(showerror, e, stacktrace(catch_backtrace())))
         end
     end
     HTTP.register!(router, "GET", "/notebookexport", serve_notebookexport)
@@ -206,7 +206,7 @@ function http_router_for(session::ServerSession)
             execution_allowed=haskey(query, "execution_allowed"),
             clear_frontmatter=haskey(query, "clear_frontmatter"),
             title="Failed to load notebook",
-            advice="The contents could not be read as a Pluto notebook file. When copying contents from somewhere else, make sure that you copy the entire notebook file.  You can also <a href='https://github.com/fonsp/Pluto.jl/issues'>report this error</a>!"
+            advice="The contents could not be read as a Pluto notebook file. When copying contents from somewhere else, make sure that you copy the entire notebook file.  You can also <a href='https://github.com/JuliaPluto/Pluto.jl/issues'>report this error</a>!"
         )
     end
     HTTP.register!(router, "POST", "/notebookupload", serve_notebookupload)


### PR DESCRIPTION
I transfered the repository from github.com/fonsp to github.com/JuliaPluto. Updating some URLs

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/JuliaPluto/Pluto.jl", rev="transfer-to-JuliaPluto-org")
julia> using Pluto
```
