### PR TITLE
Remove all Woff v1 imports for Alegreya

### DIFF
--- a/frontend/fonts/alegreya.css
+++ b/frontend/fonts/alegreya.css
@@ -5,8 +5,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 400;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-ext-400-normal.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-ext-400-normal.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-ext-400-normal.woff2) format("woff2");
     unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 
@@ -17,8 +16,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 400;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-400-normal.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-400-normal.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-400-normal.woff2) format("woff2");
     unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 
@@ -29,8 +27,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 400;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-ext-400-normal.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-ext-400-normal.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-ext-400-normal.woff2) format("woff2");
     unicode-range: U+1F00-1FFF;
 }
 
@@ -41,8 +38,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 400;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-400-normal.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-400-normal.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-400-normal.woff2) format("woff2");
     unicode-range: U+0370-0377, U+037A-037F, U+0384-038A, U+038C, U+038E-03A1, U+03A3-03FF;
 }
 
@@ -53,8 +49,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 400;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-vietnamese-400-normal.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-vietnamese-400-normal.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-vietnamese-400-normal.woff2) format("woff2");
     unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329,
         U+1EA0-1EF9, U+20AB;
 }
@@ -66,8 +61,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 400;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-ext-400-normal.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-ext-400-normal.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-ext-400-normal.woff2) format("woff2");
     unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -78,8 +72,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 400;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-400-normal.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-400-normal.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-400-normal.woff2) format("woff2");
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191,
         U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
@@ -91,8 +84,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 500;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-ext-500-normal.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-ext-500-normal.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-ext-500-normal.woff2) format("woff2");
     unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 
@@ -103,8 +95,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 500;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-500-normal.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-500-normal.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-500-normal.woff2) format("woff2");
     unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 
@@ -115,8 +106,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 500;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-ext-500-normal.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-ext-500-normal.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-ext-500-normal.woff2) format("woff2");
     unicode-range: U+1F00-1FFF;
 }
 
@@ -127,8 +117,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 500;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-500-normal.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-500-normal.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-500-normal.woff2) format("woff2");
     unicode-range: U+0370-0377, U+037A-037F, U+0384-038A, U+038C, U+038E-03A1, U+03A3-03FF;
 }
 
@@ -139,8 +128,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 500;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-vietnamese-500-normal.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-vietnamese-500-normal.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-vietnamese-500-normal.woff2) format("woff2");
     unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329,
         U+1EA0-1EF9, U+20AB;
 }
@@ -152,8 +140,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 500;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-ext-500-normal.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-ext-500-normal.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-ext-500-normal.woff2) format("woff2");
     unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -164,8 +151,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 500;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-500-normal.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-500-normal.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-500-normal.woff2) format("woff2");
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191,
         U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
@@ -177,8 +163,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 700;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-ext-700-normal.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-ext-700-normal.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-ext-700-normal.woff2) format("woff2");
     unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 
@@ -189,8 +174,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 700;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-700-normal.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-700-normal.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-700-normal.woff2) format("woff2");
     unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 
@@ -201,8 +185,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 700;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-ext-700-normal.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-ext-700-normal.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-ext-700-normal.woff2) format("woff2");
     unicode-range: U+1F00-1FFF;
 }
 
@@ -213,8 +196,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 700;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-700-normal.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-700-normal.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-700-normal.woff2) format("woff2");
     unicode-range: U+0370-0377, U+037A-037F, U+0384-038A, U+038C, U+038E-03A1, U+03A3-03FF;
 }
 
@@ -225,8 +207,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 700;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-vietnamese-700-normal.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-vietnamese-700-normal.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-vietnamese-700-normal.woff2) format("woff2");
     unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329,
         U+1EA0-1EF9, U+20AB;
 }
@@ -238,8 +219,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 700;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-ext-700-normal.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-ext-700-normal.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-ext-700-normal.woff2) format("woff2");
     unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -250,8 +230,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 700;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-700-normal.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-700-normal.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-700-normal.woff2) format("woff2");
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191,
         U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
@@ -263,8 +242,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 400;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-ext-400-italic.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-ext-400-italic.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-ext-400-italic.woff2) format("woff2");
     unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 
@@ -275,8 +253,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 400;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-400-italic.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-400-italic.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-400-italic.woff2) format("woff2");
     unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 
@@ -287,8 +264,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 400;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-ext-400-italic.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-ext-400-italic.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-ext-400-italic.woff2) format("woff2");
     unicode-range: U+1F00-1FFF;
 }
 
@@ -299,8 +275,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 400;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-400-italic.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-400-italic.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-400-italic.woff2) format("woff2");
     unicode-range: U+0370-0377, U+037A-037F, U+0384-038A, U+038C, U+038E-03A1, U+03A3-03FF;
 }
 
@@ -311,8 +286,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 400;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-vietnamese-400-italic.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-vietnamese-400-italic.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-vietnamese-400-italic.woff2) format("woff2");
     unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329,
         U+1EA0-1EF9, U+20AB;
 }
@@ -324,8 +298,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 400;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-ext-400-italic.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-ext-400-italic.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-ext-400-italic.woff2) format("woff2");
     unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -336,8 +309,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 400;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-400-italic.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-400-italic.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-400-italic.woff2) format("woff2");
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191,
         U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
@@ -349,8 +321,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 500;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-ext-500-italic.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-ext-500-italic.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-ext-500-italic.woff2) format("woff2");
     unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 
@@ -361,8 +332,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 500;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-500-italic.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-500-italic.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-500-italic.woff2) format("woff2");
     unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 
@@ -373,8 +343,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 500;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-ext-500-italic.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-ext-500-italic.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-ext-500-italic.woff2) format("woff2");
     unicode-range: U+1F00-1FFF;
 }
 
@@ -385,8 +354,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 500;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-500-italic.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-500-italic.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-500-italic.woff2) format("woff2");
     unicode-range: U+0370-0377, U+037A-037F, U+0384-038A, U+038C, U+038E-03A1, U+03A3-03FF;
 }
 
@@ -397,8 +365,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 500;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-vietnamese-500-italic.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-vietnamese-500-italic.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-vietnamese-500-italic.woff2) format("woff2");
     unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329,
         U+1EA0-1EF9, U+20AB;
 }
@@ -410,8 +377,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 500;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-ext-500-italic.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-ext-500-italic.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-ext-500-italic.woff2) format("woff2");
     unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -422,8 +388,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 500;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-500-italic.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-500-italic.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-500-italic.woff2) format("woff2");
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191,
         U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
@@ -435,8 +400,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 700;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-ext-700-italic.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-ext-700-italic.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-ext-700-italic.woff2) format("woff2");
     unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
 }
 
@@ -447,8 +411,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 700;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-700-italic.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-700-italic.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-cyrillic-700-italic.woff2) format("woff2");
     unicode-range: U+0301, U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 
@@ -459,8 +422,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 700;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-ext-700-italic.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-ext-700-italic.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-ext-700-italic.woff2) format("woff2");
     unicode-range: U+1F00-1FFF;
 }
 
@@ -471,8 +433,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 700;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-700-italic.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-700-italic.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-greek-700-italic.woff2) format("woff2");
     unicode-range: U+0370-0377, U+037A-037F, U+0384-038A, U+038C, U+038E-03A1, U+03A3-03FF;
 }
 
@@ -483,8 +444,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 700;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-vietnamese-700-italic.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-vietnamese-700-italic.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-vietnamese-700-italic.woff2) format("woff2");
     unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+0300-0301, U+0303-0304, U+0308-0309, U+0323, U+0329,
         U+1EA0-1EF9, U+20AB;
 }
@@ -496,8 +456,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 700;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-ext-700-italic.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-ext-700-italic.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-ext-700-italic.woff2) format("woff2");
     unicode-range: U+0100-02AF, U+0304, U+0308, U+0329, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -508,8 +467,7 @@
     font-display: swap;
     size-adjust: 119%;
     font-weight: 700;
-    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-700-italic.woff2) format("woff2"),
-        url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-700-italic.woff) format("woff");
+    src: url(https://cdn.jsdelivr.net/npm/@fontsource/alegreya-sans@5.0.12/files/alegreya-sans-latin-700-italic.woff2) format("woff2");
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191,
         U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }


### PR DESCRIPTION
These fonts are never used because we have woff2 sources. This saves 1MB in the bundle

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/JuliaPluto/Pluto.jl", rev="remove-woff1-imports")
julia> using Pluto
```
