### PR TITLE
Fix frontend CI test race condition

### DIFF
--- a/test/frontend/helpers/common.js
+++ b/test/frontend/helpers/common.js
@@ -151,15 +151,16 @@ export const waitForContentToBecome = async (
 }
 
 export const clickAndWaitForNavigation = async (/** @type {import("puppeteer").Page} */ page, /** @type {string} */ selector) => {
-    // Use a shorter timeout for networkidle0 since it can be unreliable with persistent connections
-    // Fall back to domcontentloaded if networkidle0 times out
-    let t = with_connections_debug(page, () => page.waitForNavigation({ waitUntil: "networkidle0", timeout: 10000 })).catch((e) => {
-        console.warn("Network idle never happened after navigation... weird!", e)
-        // Fallback to domcontentloaded which is more reliable
-        return page.waitForNavigation({ waitUntil: "domcontentloaded", timeout: 30000 })
-    })
+    // Both watchers must be registered BEFORE clicking, otherwise the fallback
+    // waitForNavigation call may be set up after domcontentloaded has already fired,
+    // causing it to wait indefinitely for the next navigation.
+    let domContentPromise = page.waitForNavigation({ waitUntil: "domcontentloaded", timeout: 30000 })
+    let networkIdlePromise = with_connections_debug(page, () => page.waitForNavigation({ waitUntil: "networkidle0", timeout: 10000 }))
     await page.click(selector)
-    await t
+    await networkIdlePromise.catch((e) => {
+        console.warn("Network idle never happened after navigation... weird!", e)
+        return domContentPromise
+    })
 }
 
 const dismissBeforeUnloadDialogs = (page) => {


### PR DESCRIPTION
## Summary

- `clickAndWaitForNavigation` registered the `domcontentloaded` fallback watcher *inside* the `.catch()` handler — meaning it was only set up after the 10s `networkidle0` timeout expired, by which time `domcontentloaded` had already fired
- The fallback then waited 30s for a *second* navigation that never came, causing `safe_preview.js` to time out at ~40s
- The `slide_controls.js` failure cascaded from this: the hung test left the Julia server stressed, causing `gotoPlutoMainMenu`'s 30s `page.goto` to also time out

## Fix

Register both `waitForNavigation` watchers **before** calling `page.click()`, so neither can miss the navigation event. When `networkidle0` times out (expected — WebSocket keeps the network busy), the `domContentPromise` is already resolved and the catch handler returns immediately.

## Reviewer notes

Only `test/frontend/helpers/common.js` is changed. No production code affected.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/JuliaPluto/Pluto.jl", rev="claude/mystifying-yalow-6cfeb8")
julia> using Pluto
```
