### PR TITLE
Detect JULIAHUB_APP_URL for launch URL

### DIFF
--- a/src/webserver/WebServer.jl
+++ b/src/webserver/WebServer.jl
@@ -355,7 +355,10 @@ function pretty_address(session::ServerSession, hostIP, port)
     root = if session.options.server.root_url !== nothing
         @assert endswith(session.options.server.root_url, "/")
         replace(session.options.server.root_url, "{PORT}" => string(Int(port)))
+    elseif haskey(ENV, "JULIAHUB_APP_URL")
+        "$(ENV["JULIAHUB_APP_URL"])proxy/$(Int(port))/"
     elseif haskey(ENV, "JH_APP_URL")
+        # legacy name for JULIAHUB_APP_URL, still set on older JuliaHub jobs
         "$(ENV["JH_APP_URL"])proxy/$(Int(port))/"
     else
         host_str = string(hostIP)

--- a/test/webserver.jl
+++ b/test/webserver.jl
@@ -49,6 +49,46 @@ using Pluto.WorkspaceManager: WorkspaceManager, poll
     close(server)
 end
 
+@testset "pretty_address" begin
+    make_session(; kwargs...) = Pluto.ServerSession(;
+        options=Pluto.Configuration.from_flat_kwargs(;
+            launch_browser=false,
+            require_secret_for_access=false,
+            require_secret_for_open_links=false,
+            kwargs...,
+        ),
+    )
+    call(session) = Pluto.pretty_address(session, Sockets.IPv4("127.0.0.1"), 1234)
+
+    clean_env(f) = withenv(f, "JULIAHUB_APP_URL" => nothing, "JH_APP_URL" => nothing)
+
+    clean_env() do
+        @test call(make_session()) == "http://localhost:1234/"
+    end
+
+    clean_env() do
+        session = make_session(; root_url="https://x.example/{PORT}/")
+        @test call(session) == "https://x.example/1234/"
+    end
+
+    withenv("JULIAHUB_APP_URL" => "https://x.juliahub.com/", "JH_APP_URL" => nothing) do
+        @test call(make_session()) == "https://x.juliahub.com/proxy/1234/"
+    end
+
+    withenv("JULIAHUB_APP_URL" => nothing, "JH_APP_URL" => "https://legacy.juliahub.com/") do
+        @test call(make_session()) == "https://legacy.juliahub.com/proxy/1234/"
+    end
+
+    withenv("JULIAHUB_APP_URL" => "https://new.juliahub.com/", "JH_APP_URL" => "https://legacy.juliahub.com/") do
+        @test call(make_session()) == "https://new.juliahub.com/proxy/1234/"
+    end
+
+    withenv("JULIAHUB_APP_URL" => "https://x.juliahub.com/", "JH_APP_URL" => nothing) do
+        session = make_session(; root_url="https://override.example/{PORT}/")
+        @test call(session) == "https://override.example/1234/"
+    end
+end
+
 @testset "UTF-8 to Codemirror UTF-16 byte mapping" begin
     # range ends are non inclusives
     tests = [


### PR DESCRIPTION
JuliaHub renamed JH_APP_URL to JULIAHUB_APP_URL on its current job images. Pluto only checked the old name, so the printed launch URL fell back to the bare localhost form even though a proxy URL was available.

Check JULIAHUB_APP_URL first and keep JH_APP_URL as a fallback for older job environments. Add a pretty_address testset covering the default, root_url override, both env var names, precedence, and root_url winning over the env vars.

Fixes #3530

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/MichaelHatherly/Pluto.jl", rev="mh/fix-juliahub-app-url")
julia> using Pluto
```
