### PR TITLE
Match detected indent unit (tab/space) automatically

### DIFF
--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -228,9 +228,7 @@ export const LastRemoteCodeSetTimeFacet = Facet.define({
     compare: _.isEqual,
 })
 
-// Per-cell detected indent unit ("\t" or "    "). Re-detected on every doc
-// change; when the doc has no indented lines, we keep the previous value to
-// avoid flapping while the user is typing into an empty cell.
+// Per-cell detected indent unit ("\t" or "    "). Re-detected on every doc change.
 const indentUnitField = StateField.define({
     create: (state) => detect_indent_unit(state.doc, "\t"),
     update: (value, tr) => (tr.docChanged ? detect_indent_unit(tr.state.doc, value) : value),

--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -41,6 +41,7 @@ import {
     setDiagnostics,
     moveLineUp,
     Facet,
+    StateField,
 } from "../imports/CodemirrorPlutoSetup.js"
 
 import { markdown, html as htmlLang, javascript, sqlLang, python, julia_mixed } from "./CellInput/mixedParsers.js"
@@ -64,6 +65,7 @@ import { moveLineDown } from "../imports/CodemirrorPlutoSetup.js"
 import { open_pluto_popup } from "../common/open_pluto_popup.js"
 import { AIContext } from "./AIContext.js"
 import { AiSuggestionPlugin } from "./CellInput/ai_suggestion.js"
+import { detect_indent_unit } from "./CellInput/detect_indent_unit.js"
 import { t } from "../common/lang.js"
 
 export const ENABLE_CM_MIXED_PARSER = window.localStorage.getItem("ENABLE_CM_MIXED_PARSER") === "true"
@@ -224,6 +226,14 @@ let useCompartment = (/** @type {import("../imports/Preact.js").Ref<EditorView?>
 export const LastRemoteCodeSetTimeFacet = Facet.define({
     combine: (values) => values[0],
     compare: _.isEqual,
+})
+
+// Per-cell detected indent unit ("\t" or "    "). Re-detected on every doc
+// change; when the doc has no indented lines, we keep the previous value to
+// avoid flapping while the user is typing into an empty cell.
+const indentUnitField = StateField.define({
+    create: (state) => detect_indent_unit(state.doc, "\t"),
+    update: (value, tr) => (tr.docChanged ? detect_indent_unit(tr.state.doc, value) : value),
 })
 
 let line_and_ch_to_cm6_position = (/** @type {import("../imports/CodemirrorPlutoSetup.js").Text} */ doc, { line, ch }) => {
@@ -402,10 +412,11 @@ export const CellInput = ({
             if (anySelect) {
                 return indentMore(cm)
             } else {
+                const unit = cm.state.facet(indentUnit)
                 cm.dispatch(
                     cm.state.changeByRange((selection) => ({
-                        range: EditorSelection.cursor(selection.from + 1),
-                        changes: { from: selection.from, to: selection.to, insert: "\t" },
+                        range: EditorSelection.cursor(selection.from + unit.length),
+                        changes: { from: selection.from, to: selection.to, insert: unit },
                     }))
                 )
                 return true
@@ -680,7 +691,8 @@ export const CellInput = ({
                         }
                     }),
                     EditorState.tabSize.of(4),
-                    indentUnit.of("\t"),
+                    indentUnitField,
+                    indentUnit.from(indentUnitField),
                     ...(ENABLE_CM_MIXED_PARSER
                         ? [
                               julia_mixed(),

--- a/frontend/components/CellInput/detect_indent_unit.js
+++ b/frontend/components/CellInput/detect_indent_unit.js
@@ -8,7 +8,7 @@
 export const detect_indent_unit = (doc, fallback) => {
     let tab_lines = 0
     let space_lines = 0
-    const max_lines = Math.min(doc.lines, 500)
+    const max_lines = Math.min(doc.lines, 20)
     for (let i = 1; i <= max_lines; i++) {
         const text = doc.line(i).text
         if (text[0] === "\t") tab_lines++

--- a/frontend/components/CellInput/detect_indent_unit.js
+++ b/frontend/components/CellInput/detect_indent_unit.js
@@ -1,0 +1,19 @@
+/**
+ * Detect whether a CodeMirror document is indented with tabs or 4 spaces.
+ *
+ * @param {import("../../imports/CodemirrorPlutoSetup.js").Text} doc
+ * @param {"\t" | "    "} fallback Returned when no indented lines are found.
+ * @returns {"\t" | "    "}
+ */
+export const detect_indent_unit = (doc, fallback) => {
+    let tab_lines = 0
+    let space_lines = 0
+    const max_lines = Math.min(doc.lines, 500)
+    for (let i = 1; i <= max_lines; i++) {
+        const text = doc.line(i).text
+        if (text[0] === "\t") tab_lines++
+        else if (text[0] === " " && text[1] === " ") space_lines++
+    }
+    if (tab_lines === 0 && space_lines === 0) return fallback
+    return tab_lines >= space_lines ? "\t" : "    "
+}

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -55,6 +55,8 @@ import { is_desktop, move_notebook, wait_for_file_move } from "./DesktopInterfac
 import { with_query_params } from "../common/URLTools.js"
 import semver from "../imports/semver-es.js"
 import { ConfirmBeforeLongRuntime, maybe_abort_long_runtime } from "./ConfirmBeforeLongRuntime.js"
+import { detect_indent_unit } from "./CellInput/detect_indent_unit.js"
+import { Text } from "../imports/CodemirrorPlutoSetup.js"
 
 // This is imported asynchronously - uncomment for development
 // import environment from "../common/Environment.js"
@@ -501,7 +503,8 @@ export class Editor extends Component {
             wrap_remote_cell: async (cell_id, block_start = "begin", block_end = "end") => {
                 const cell = this.state.notebook.cell_inputs[cell_id]
                 if (!cell) return
-                const new_code = `${block_start}\n\t${cell.code.replace(/\n/g, "\n\t")}\n${block_end}`
+                const unit = detect_indent_unit(Text.of(cell.code.split("\n")), "\t")
+                const new_code = `${block_start}\n${unit}${cell.code.replace(/\n/g, `\n${unit}`)}\n${block_end}`
 
                 await this.setStatePromise(
                     immer((/** @type {EditorState} */ state) => {


### PR DESCRIPTION
This PR checks if the current cell uses mostly spaces or tabs for indentation, and continues using it. This isn't a complete answer to the tabs/spaces drama but it helps with some situations.

Written with 🤖

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/JuliaPluto/Pluto.jl", rev="match-tab-spaces-automatic")
julia> using Pluto
```
