### PR TITLE
Improve automatic error hint to run Pkg.add

### DIFF
--- a/frontend/components/ErrorMessage.js
+++ b/frontend/components/ErrorMessage.js
@@ -513,7 +513,13 @@ export const ErrorMessage = ({ msg, stacktrace, plain_error, cell_id }) => {
         {
             pattern: /^ArgumentError: Package (.*) not found in current path/,
             display: (/** @type{string} */ x) => {
-                if (pluto_actions.get_notebook().nbpkg?.enabled === false) return default_rewriter.display(x)
+                if (pluto_actions.get_notebook().nbpkg?.enabled === false) {
+                    const rewritten = x
+                        .split("\n")
+                        .map((line) => (line.includes("Pkg.add") ? t("t_package_not_found_manual_pkg_activate_hint") : line))
+                        .join("\n")
+                    return default_rewriter.display(rewritten)
+                }
 
                 const match = x.match(/^ArgumentError: Package (.*) not found in current path/)
                 const package_name = (match?.[1] ?? "").replaceAll("`", "")


### PR DESCRIPTION
It can be confusing when Pkg tells the user to run

```julia
import Pkg; Pkg.add("Example")
```

This error explains that the user should modify their environment. Without the command, because they should decide how to do it (given that they did Pkg.activate themselves)

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/JuliaPluto/Pluto.jl", rev="error-hint-pkg-add")
julia> using Pluto
```
