### PR TITLE
When recovering a notebook Pkg environment, write new compat entries

### DIFF
--- a/src/packages/Packages.jl
+++ b/src/packages/Packages.jl
@@ -173,6 +173,10 @@ function sync_nbpkg_core(
                         Status.report_business!(pkg_status, :instantiate1) do
                             _instantiate(notebook, iolistener)
                         end
+                        
+                        # this might have updated packages or removed compat entries, so let's update the auto-compat entries.
+                        PkgCompat.clear_auto_compat_entries!(notebook.nbpkg_ctx)
+                        PkgCompat.write_auto_compat_entries!(notebook.nbpkg_ctx)
                     end
                     
                     to_add = filter(PkgCompat.package_exists, added)


### PR DESCRIPTION
Fix #3540 

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/JuliaPluto/Pluto.jl", rev="pkg-init-write_auto_compat_entries")
julia> using Pluto
```
