### PR TITLE
AbstractPlutoDingetjes.Display.ReactDOMElement

### DIFF
--- a/frontend/components/CellOutput.js
+++ b/frontend/components/CellOutput.js
@@ -4,7 +4,7 @@ import DOMPurify from "../imports/DOMPurify.js"
 import { ansi_to_html } from "../imports/AnsiUp.js"
 
 import { ErrorMessage, ParseError } from "./ErrorMessage.js"
-import { TreeView, TableView, DivElement } from "./TreeView.js"
+import { TreeView, TableView, ReactDOMElement } from "./TreeView.js"
 
 import {
     add_bonds_disabled_message_handler,
@@ -192,8 +192,8 @@ export const OutputBody = ({ mime, body, cell_id, persist_js_state = false, last
         case "application/vnd.pluto.stacktrace+object":
             return html`<div><${ErrorMessage} cell_id=${cell_id} ...${body} /></div>`
             break
-        case "application/vnd.pluto.divelement+object":
-            return DivElement({ cell_id, ...body, persist_js_state, sanitize_html })
+        case "application/vnd.pluto.reactdomelement+object":
+            return ReactDOMElement({ cell_id, ...body, persist_js_state, sanitize_html })
             break
         case "text/plain":
             if (body) {

--- a/frontend/components/CellOutput.js
+++ b/frontend/components/CellOutput.js
@@ -195,6 +195,21 @@ export const OutputBody = ({ mime, body, cell_id, persist_js_state = false, last
         case "application/vnd.pluto.reactdomelement+object":
             return ReactDOMElement({ cell_id, ...body, persist_js_state, sanitize_html })
             break
+        case "application/vnd.pluto.divelement+object": {
+            // TODO: remove me in the future. @deprecate Does not need to be a breaking Pluto release, just sometime after July 2026
+            // Backwards-compat: statefiles produced by older Pluto versions still contain DivElement, see https://github.com/JuliaPluto/Pluto.jl/pull/3544
+            const attributes = {}
+            if (body?.style) attributes.style = body.style
+            if (body?.classname) attributes.class = body.classname
+            return ReactDOMElement({
+                cell_id,
+                tag: "div",
+                attributes,
+                children: body?.children ?? [],
+                persist_js_state,
+                sanitize_html,
+            })
+        }
         case "text/plain":
             if (body) {
                 return html`<div><${ANSITextOutput} body=${body} /></div>`

--- a/frontend/components/TreeView.js
+++ b/frontend/components/TreeView.js
@@ -250,8 +250,11 @@ export const TableView = ({ mime, body, cell_id, persist_js_state, sanitize_html
 }
 
 export let ReactDOMElement = ({ cell_id, tag, attributes, children, persist_js_state = false, sanitize_html = true }) => {
-    const mimepair_output = (pair) =>
-        html`<${SimpleOutputBody} cell_id=${cell_id} mime=${pair[1]} body=${pair[0]} persist_js_state=${persist_js_state} sanitize_html=${sanitize_html} />`
+    const mimepair_output = (pair) => {
+        const [body, mime] = pair
+        const key = mime === "application/vnd.pluto.reactdomelement+object" ? body?.attributes?.key : undefined
+        return html`<${SimpleOutputBody} key=${key} cell_id=${cell_id} mime=${mime} body=${body} persist_js_state=${persist_js_state} sanitize_html=${sanitize_html} />`
+    }
 
     return html`<${tag ?? "div"} ...${attributes ?? {}}>${(children ?? []).map(mimepair_output)}<//>`
 }

--- a/frontend/components/TreeView.js
+++ b/frontend/components/TreeView.js
@@ -5,6 +5,7 @@ import { PlutoActionsContext } from "../common/PlutoContext.js"
 import { useEventListener } from "../common/useEventListener.js"
 import { is_noop_action } from "../common/SliderServerClient.js"
 import { t } from "../common/lang.js"
+import { SafePreviewSanitizeMessage } from "./SafePreviewUI.js"
 
 // this is different from OutputBody because:
 // it does not wrap in <div>. We want to do that in OutputBody for reasons that I forgot (feel free to try and remove it), but we dont want it here
@@ -250,10 +251,20 @@ export const TableView = ({ mime, body, cell_id, persist_js_state, sanitize_html
 }
 
 export let ReactDOMElement = ({ cell_id, tag, attributes, children, persist_js_state = false, sanitize_html = true }) => {
+    if (sanitize_html) {
+        return html`<div dangerouslySetInnerHTML=${SafePreviewSanitizeMessage}></div>`
+    }
     const mimepair_output = (pair) => {
         const [body, mime] = pair
         const key = mime === "application/vnd.pluto.reactdomelement+object" ? body?.attributes?.key : undefined
-        return html`<${SimpleOutputBody} key=${key} cell_id=${cell_id} mime=${mime} body=${body} persist_js_state=${persist_js_state} sanitize_html=${sanitize_html} />`
+        return html`<${SimpleOutputBody}
+            key=${key}
+            cell_id=${cell_id}
+            mime=${mime}
+            body=${body}
+            persist_js_state=${persist_js_state}
+            sanitize_html=${sanitize_html}
+        />`
     }
 
     return html`<${tag ?? "div"} ...${attributes ?? {}}>${(children ?? []).map(mimepair_output)}<//>`

--- a/frontend/components/TreeView.js
+++ b/frontend/components/TreeView.js
@@ -249,9 +249,9 @@ export const TableView = ({ mime, body, cell_id, persist_js_state, sanitize_html
     </table>`
 }
 
-export let DivElement = ({ cell_id, style, classname, children, persist_js_state = false, sanitize_html = true }) => {
+export let ReactDOMElement = ({ cell_id, tag, attributes, children, persist_js_state = false, sanitize_html = true }) => {
     const mimepair_output = (pair) =>
         html`<${SimpleOutputBody} cell_id=${cell_id} mime=${pair[1]} body=${pair[0]} persist_js_state=${persist_js_state} sanitize_html=${sanitize_html} />`
 
-    return html`<div style=${style} class=${classname}>${children.map(mimepair_output)}</div>`
+    return html`<${tag ?? "div"} ...${attributes ?? {}}>${(children ?? []).map(mimepair_output)}<//>`
 }

--- a/sample/test_embed_display.jl
+++ b/sample/test_embed_display.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.20.24
+# v0.20.25
 
 using Markdown
 using InteractiveUtils
@@ -340,6 +340,9 @@ force_html(@embed(test_bond))
 # ╔═╡ 207cddb2-bbad-4e61-b7c6-7e89032b6f7f
 Main.PlutoRunner._EmbeddableDisplay_enable_html_shortcut[] = enable_html_shortcut
 
+# ╔═╡ 410c9cae-d648-4f29-bab2-2fba57b36ebf
+import Plots
+
 # ╔═╡ b7944093-6eb1-41b3-8f6b-096bd83a9315
 function ingredients(path::String)
 	# this is from the Julia source code (evalfile in base/loading.jl)
@@ -474,5 +477,6 @@ pers_3_trigger; pers_3()
 # ╠═f0cc4061-8e20-41a6-9c1b-bc04f075eb5e
 # ╠═dc5bf49b-694e-465d-83d0-cc237f884902
 # ╠═7668e4a3-9cc9-4400-b400-0ec67b6b2090
+# ╠═410c9cae-d648-4f29-bab2-2fba57b36ebf
 # ╠═0d0d4096-3b07-425f-9a5f-adbd3b30877e
 # ╟─b7944093-6eb1-41b3-8f6b-096bd83a9315

--- a/src/runner/PlutoRunner/src/PlutoRunner.jl
+++ b/src/runner/PlutoRunner/src/PlutoRunner.jl
@@ -83,6 +83,7 @@ include("./ide features/docs.jl")
 include("./bonds.jl")
 include("./js/published_to_js.jl")
 include("./display/embed_display.jl")
+include("./display/ReactDOMElement.jl")
 include("./display/DivElement.jl")
 
 include("./js/jslink.jl")

--- a/src/runner/PlutoRunner/src/PlutoRunner.jl
+++ b/src/runner/PlutoRunner/src/PlutoRunner.jl
@@ -75,6 +75,7 @@ include("./display/syntax error.jl")
 include("./display/Exception.jl")
 include("./display/mime dance.jl")
 include("./display/tree viewer.jl")
+include("./display/ReactDOMElement.jl")
 
 
 include("./integrations.jl")
@@ -83,7 +84,6 @@ include("./ide features/docs.jl")
 include("./bonds.jl")
 include("./js/published_to_js.jl")
 include("./display/embed_display.jl")
-include("./display/ReactDOMElement.jl")
 include("./display/DivElement.jl")
 
 include("./js/jslink.jl")

--- a/src/runner/PlutoRunner/src/display/DivElement.jl
+++ b/src/runner/PlutoRunner/src/display/DivElement.jl
@@ -1,21 +1,22 @@
-    
+
+# Internal-only helper struct, superseded by `AbstractPlutoDingetjes.Display.ReactDOMElement`.
+# Kept so existing internal call sites continue to work; its wire format is now produced by
+# delegating to the new ReactDOMElement MIME.
 Base.@kwdef struct DivElement
     children::Vector
     style::String=""
     class::Union{String,Nothing}=nothing
 end
 
-tree_data(@nospecialize(e::DivElement), context::Context) = Dict{Symbol, Any}(
-    :style => e.style, 
-    :classname => e.class, 
-    :children => Any[
-        with_auto_id_counter(context, i) do io
-            format_output_default(value, io)
-        end
-        for (i, value) in enumerate(e.children)
-    ],
-)
-pluto_showable(::MIME"application/vnd.pluto.divelement+object", ::DivElement) = true
+function Base.show(io::IO, ::MIME"application/vnd.pluto.reactdomelement+object", e::DivElement)
+    attrs = Dict{String,Any}()
+    isempty(e.style)    || (attrs["style"] = e.style)
+    e.class === nothing || (attrs["class"] = e.class)
+    # Build a ReactDOMElement-shaped value without taking a hard dep on AbstractPlutoDingetjes
+    # being loaded: any object with `tag`, `attributes`, `children` fields is accepted by
+    # `_reactdom_to_dict`.
+    (tag = "div", attributes = attrs, children = e.children)
+end
 
 function Base.show(io::IO, m::MIME"text/html", e::DivElement)
     Base.show(io, m, embed_display(e))

--- a/src/runner/PlutoRunner/src/display/ReactDOMElement.jl
+++ b/src/runner/PlutoRunner/src/display/ReactDOMElement.jl
@@ -1,0 +1,26 @@
+
+# Convert a user-returned `AbstractPlutoDingetjes.Display.ReactDOMElement` to the wire Dict, recursively formatting children through Pluto's usual display pipeline.
+
+function reactdom_data(@nospecialize(x), context::Context)
+    # The user's show method returns a ReactDOMElement (no writes to `io`).
+    el = Base.invokelatest(show, context, MIME"application/vnd.pluto.reactdomelement+object"(), x)
+    _reactdom_to_dict(el, context)
+end
+
+function _reactdom_to_dict(@nospecialize(el), context::Context)
+    Dict{Symbol,Any}(
+        :tag => String(el.tag),
+        :attributes => Dict{String,Any}(string(k) => v for (k, v) in el.attributes),
+        :children => Any[
+            with_auto_id_counter(context, i) do io
+                format_output_default(value, io)
+            end
+            for (i, value) in enumerate(el.children)
+        ],
+    )
+end
+
+# TODO: get `"key"` attribute. Maybe key should be separate? And how do we dispatch here?
+get_key(i, value) = i
+
+

--- a/src/runner/PlutoRunner/src/display/ReactDOMElement.jl
+++ b/src/runner/PlutoRunner/src/display/ReactDOMElement.jl
@@ -12,7 +12,7 @@ function _reactdom_to_dict(@nospecialize(el), context::Context)
         :tag => String(el.tag),
         :attributes => Dict{String,Any}(string(k) => v for (k, v) in el.attributes),
         :children => Any[
-            with_auto_id_counter(context, i) do io
+            with_auto_id_counter(context, get_react_child_key(i, value)) do io
                 format_output_default(value, io)
             end
             for (i, value) in enumerate(el.children)
@@ -20,7 +20,8 @@ function _reactdom_to_dict(@nospecialize(el), context::Context)
     )
 end
 
-# TODO: get `"key"` attribute. Maybe key should be separate? And how do we dispatch here?
-get_key(i, value) = i
+get_react_child_key(i, value) = i
+# In integrations.jl, we will add a specific method for ReactDOMElement that looks for a "key" in the attributes.
+
 
 

--- a/src/runner/PlutoRunner/src/display/mime dance.jl
+++ b/src/runner/PlutoRunner/src/display/mime dance.jl
@@ -8,7 +8,7 @@ The MIMEs that Pluto supports, in order of how much I like them.
 
 `text/plain` should always match - the difference between `show(::IO, ::MIME"text/plain", x)` and `show(::IO, x)` is an unsolved mystery.
 """
-const allmimes = MIME[MIME"application/vnd.pluto.table+object"(); MIME"application/vnd.pluto.divelement+object"(); MIME"text/html"(); imagemimes; MIME"application/vnd.pluto.tree+object"(); MIME"text/latex"(); MIME"text/plain"()]
+const allmimes = MIME[MIME"application/vnd.pluto.table+object"(); MIME"application/vnd.pluto.reactdomelement+object"(); MIME"text/html"(); imagemimes; MIME"application/vnd.pluto.tree+object"(); MIME"text/latex"(); MIME"text/plain"()]
 
 
 "Return a `(String, Any)` tuple containing function output as the second entry."
@@ -86,8 +86,8 @@ function show_richest(io::IO, @nospecialize(x))::Tuple{<:Any,MIME}
             show(io, MIME"text/plain"(), x)
             nothing, MIME"text/plain"()
         end
-    elseif mime isa MIME"application/vnd.pluto.divelement+object"
-        tree_data(x, io), mime
+    elseif mime isa MIME"application/vnd.pluto.reactdomelement+object"
+        reactdom_data(x, io), mime
     elseif mime ∈ imagemimes
         show(io, mime, x)
         nothing, mime

--- a/src/runner/PlutoRunner/src/integrations.jl
+++ b/src/runner/PlutoRunner/src/integrations.jl
@@ -42,6 +42,9 @@ const integrations = Integration[
                 if isdefined(AbstractPlutoDingetjes.Display, Symbol("@embed"))
                     supported!(getfield(AbstractPlutoDingetjes.Display, Symbol("@embed")))
                 end
+                if isdefined(AbstractPlutoDingetjes.Display, :ReactDOMElement)
+                    supported!(AbstractPlutoDingetjes.Display.ReactDOMElement)
+                end
             end
 
         end,

--- a/src/runner/PlutoRunner/src/integrations.jl
+++ b/src/runner/PlutoRunner/src/integrations.jl
@@ -46,7 +46,17 @@ const integrations = Integration[
                     supported!(AbstractPlutoDingetjes.Display.ReactDOMElement)
                 end
             end
-
+            
+            function get_react_child_key(i, value::AbstractPlutoDingetjes.Display.ReactDOMElement)
+                found = get(value.attributes, "key", get(value.attributes, :key, nothing))
+                if found === nothing
+                    i
+                elseif found isa Union{Symbol,Int64}
+                    found
+                else
+                    Symbol(string(found))
+                end
+            end
         end,
     ),
     Integration(


### PR DESCRIPTION
New API to replace `PlutoRunner.DivElement`. This API is:
- More stable (not using Pluto internals)
- More general
  - you can set the tag name (not just `div`) and 
  - you can set any attribute (not just `style` and `class`)

Matching PR https://github.com/JuliaPluto/AbstractPlutoDingetjes.jl/pull/20

# TODO
- [x] Debug `key` more
- [x] More testing
- [x] Test DivElement
- [x] Docs



# Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/JuliaPluto/Pluto.jl", rev="ReactDOMElement")
julia> using Pluto
```
