### PR TITLE
Fix confirm runtime colors

### DIFF
--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -867,9 +867,9 @@ dialog.confirm-before-long-runtime {
     font-size: 0.9em;
     margin-block-end: 2rem;
     padding: 1em 1.2em;
-    background: hsl(0deg 0% 12.85%);
+    background: var(--confirm-runtime-bonus-bg);
     border-radius: 3px;
-    border-inline-start: 3px solid #636363;
+    border-inline-start: 3px solid var(--confirm-runtime-bonus-border);
 }
 
 .confirm-before-long-runtime .final button {
@@ -881,7 +881,7 @@ dialog.confirm-before-long-runtime {
 
 .confirm-before-long-runtime .final button.final-yes {
     background: var(--confirm-runtime-yes-bg);
-    color: #000000;
+    color: var(--confirm-runtime-yes-color);
     border-color: var(--confirm-runtime-yes-border);
     position: relative;
     overflow: hidden;

--- a/frontend/themes/dark.css
+++ b/frontend/themes/dark.css
@@ -248,12 +248,12 @@
 
         /* confirm-before-long-runtime dialog */
         --confirm-runtime-bg: linear-gradient(180deg, hsl(0 0% 19% / 1), hsl(243 14% 23% / 1));
-        --confirm-runtime-bonus-bg: hsl(0deg 0% 17%);
-        --confirm-runtime-bonus-border: #4a4a66;
+        --confirm-runtime-bonus-bg: hsl(0deg 0% 12.85%);
+        --confirm-runtime-bonus-border: #636363;
         --confirm-runtime-button-bg: #3a3a3a;
         --confirm-runtime-button-border: #5a5a5a;
         --confirm-runtime-yes-bg: #ddd1d6;
-        --confirm-runtime-yes-color: #1a1a1a;
+        --confirm-runtime-yes-color: #000;
         --confirm-runtime-yes-border: #9f9f9f;
         --confirm-runtime-yes-progress: linear-gradient(90deg, #f0f0f0, #9a9a9a);
     }

--- a/frontend/themes/light.css
+++ b/frontend/themes/light.css
@@ -254,7 +254,7 @@
         --confirm-runtime-button-bg: #f4f4f4;
         --confirm-runtime-button-border: #c1c1c1;
         --confirm-runtime-yes-bg: black;
-        --confirm-runtime-yes-color: #eaeaea;
+        --confirm-runtime-yes-color: #fff;
         --confirm-runtime-yes-border: #9b9b9b;
         --confirm-runtime-yes-progress: linear-gradient(90deg, black, #757575);
     }


### PR DESCRIPTION
Fix color mistakes in #3529

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/JuliaPluto/Pluto.jl", rev="fix-confirm-runtime-colors")
julia> using Pluto
```
