### PR TITLE
Add ARIA disclosure attributes to bottom-right panel tab buttons

### DIFF
--- a/frontend/components/BottomRightPanel.js
+++ b/frontend/components/BottomRightPanel.js
@@ -113,7 +113,7 @@ export let BottomRightPanel = ({
 
     return html`
         <aside id="helpbox-wrapper" ref=${container_ref}>
-            <pluto-helpbox class=${cl({ hidden, [`helpbox-${open_tab ?? hidden}`]: true })}>
+            <pluto-helpbox id="pluto-helpbox" class=${cl({ hidden, [`helpbox-${open_tab ?? hidden}`]: true })}>
                 <header translate=${false}>
                     <button
                         title=${t("t_panel_docs_description")}
@@ -122,6 +122,8 @@ export let BottomRightPanel = ({
                             "helpbox-docs": true,
                             "active": open_tab === "docs",
                         })}
+                        aria-expanded=${open_tab === "docs"}
+                        aria-controls="pluto-helpbox"
                         onClick=${() => {
                             focus_docs_on_open_ref.current = true
                             set_open_tab(open_tab === "docs" ? null : "docs")
@@ -141,6 +143,8 @@ export let BottomRightPanel = ({
                             "something_is_happening": busy || !connected,
                         })}
                         id="process-status-tab-button"
+                        aria-expanded=${open_tab === "process"}
+                        aria-controls="pluto-helpbox"
                         onClick=${() => {
                             set_open_tab(open_tab === "process" ? null : "process")
                         }}


### PR DESCRIPTION
## What

Adds `aria-expanded` and `aria-controls` attributes to the two tab buttons that toggle the **live docs** and **process status** panels in the bottom-right helpbox (`BottomRightPanel.js`).

## Why

As described in #3274, these `<button>` elements act as toggle controls (open/close a panel) but expose no semantics to assistive technologies — screen-reader users cannot tell that the buttons control a different region of the page or whether the panel is currently expanded.

## How

The interaction matches the [W3C WAI-ARIA disclosure pattern](https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/):

- `aria-expanded` is bound to the open state (`open_tab === "docs"` / `open_tab === "process"`), so it flips between `true` and `false` as the user toggles the panel.
- `aria-controls` points to the `<pluto-helpbox>` element, which holds the disclosed content (the helpbox is the single container that swaps between docs view and status view depending on which tab is active). An `id="pluto-helpbox"` is added so the reference is resolvable.

Fix #3274

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/Yayabtw/Pluto.jl", rev="aria-attributes-tab-buttons")
julia> using Pluto
```
