### PR TITLE
Make "cell preview" in stack trace localizable

### DIFF
--- a/frontend/components/ErrorMessage.js
+++ b/frontend/components/ErrorMessage.js
@@ -197,6 +197,7 @@ const LinePreview = ({ frame, num_context_lines = 2 }) => {
                 }}
                 href=${`#${cell_id}`}
                 class="frame-line-preview"
+                style=${`--after-content: "${t("t_code_snippet_cell_preview_label")}";`}
                 ><div>
                     <pre>
 ${lines.map((line, i) =>

--- a/frontend/lang/english.json
+++ b/frontend/lang/english.json
@@ -46,6 +46,7 @@
     "t_anonymous_function_abbr": "A (mini-)function that is defined without the 'function' keyword, but using -> or 'do'.",
     "t_display_complete_type_information_of_this_function_call": "Display the complete type information of this function call",
     "t_show_types": "...show types...",
+    "t_code_snippet_cell_preview_label": "cell preview",
     "t_multiple_expressions_in_one_cell": "Multiple expressions in one cell",
     "t_how_would_you_like_to_fix_it": "How would you like to fix it?",
     "t_split_this_cell_into_cells": "Split this cell into {{count}} cells",

--- a/frontend/treeview.css
+++ b/frontend/treeview.css
@@ -412,7 +412,7 @@ jlerror li .frame-line-preview pre:not(.asdfdsaf) {
 }
 
 jlerror li:not(.from_this_cell) .frame-line-preview pre::after {
-    content: "cell preview";
+    content: var(--after-content);
     display: block;
     position: absolute;
     bottom: 0;


### PR DESCRIPTION


## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/JuliaPluto/Pluto.jl", rev="i18n-cell-preview-error-message")
julia> using Pluto
```
