### PR TITLE
File picker: dont clear on blur

### DIFF
--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -1700,7 +1700,7 @@ ${t("t_key_autosave_description")}`
                                           value=${notebook.in_temp_dir ? "" : notebook.path}
                                           on_submit=${this.submit_file_change}
                                           on_desktop_submit=${this.desktop_submit_file_change}
-                                          clear_on_blur=${true}
+                                          clear_on_blur=${false}
                                           suggest_new_file=${{
                                               base: this.client.session_options?.server?.notebook_path_suggestion ?? "",
                                           }}

--- a/frontend/components/FilePicker.js
+++ b/frontend/components/FilePicker.js
@@ -15,6 +15,7 @@ import {
 import { tab_help_plugin } from "./CellInput/tab_help_plugin.js"
 import _ from "../imports/lodash-es.js"
 import { get_settings } from "./Settings.js"
+import { cl } from "../common/ClassTable.js"
 
 let { autocompletion, completionKeymap } = autocomplete
 
@@ -60,7 +61,8 @@ export const FilePicker = ({ value, suggest_new_file, button_label, placeholder,
     const cm = useRef(/** @type {EditorView?} */ (null))
 
     const is_button_disabled = current_value.length === 0 || current_value === forced_value.current
-    const suggest_button = current_value !== forced_value.current && current_value.endsWith(".jl")
+    const value_different = current_value !== forced_value.current
+    const suggest_button = current_value !== forced_value.current && /\.\w*$/.test(current_value)
 
     const suggest_not_tmp = () => {
         const current_cm = cm.current
@@ -116,6 +118,10 @@ export const FilePicker = ({ value, suggest_new_file, button_label, placeholder,
         const usesDarkTheme = window.matchMedia("(prefers-color-scheme: dark)").matches
         const keyMapSubmit = () => {
             onSubmit()
+            return true
+        }
+        const keyMapClear = () => {
+            set_cm_value(current_cm, forced_value.current, true)
             return true
         }
         cm.current = new EditorView({
@@ -194,6 +200,17 @@ export const FilePicker = ({ value, suggest_new_file, button_label, placeholder,
                             run: keyMapSubmit,
                         },
                         {
+                            key: "Escape",
+                            run: (cm) => {
+                                // If there is autocomplete open, close that. It will return `true`
+                                return assert_not_null(close_autocomplete_command).run(cm)
+                            },
+                        },
+                        {
+                            key: "Escape",
+                            run: keyMapClear,
+                        },
+                        {
                             key: "Ctrl-Enter",
                             mac: "Cmd-Enter",
                             run: keyMapSubmit,
@@ -247,7 +264,7 @@ export const FilePicker = ({ value, suggest_new_file, button_label, placeholder,
     })
 
     return html`
-        <pluto-filepicker class=${suggest_button ? "suggest_button" : ""} ref=${base} onfocusout=${onBlur}>
+        <pluto-filepicker class=${cl({ suggest_button, value_different })} ref=${base} onfocusout=${onBlur}>
             <button onClick=${onSubmit} disabled=${is_button_disabled}>${button_label}</button>
         </pluto-filepicker>
     `

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -1110,6 +1110,14 @@ div.desktop_picker_group span {
     border-start-end-radius: 0;
 }
 
+nav#at_the_top > pluto-filepicker.value_different .cm-editor {
+    border-color: var(--code-differs-cell-color);
+}
+
+nav#at_the_top > pluto-filepicker .cm-editor .cm-content {
+    padding-inline-end: 4ch;
+}
+
 pluto-filepicker .cm-scroller {
     scrollbar-width: none; /* Firefox */
 }
@@ -1237,26 +1245,26 @@ nav#at_the_top:after {
 }
 
 @media (any-pointer: fine) {
-    nav#at_the_top > pluto-filepicker .cm-editor,
+    nav#at_the_top > pluto-filepicker:not(.value_different) .cm-editor,
     nav#at_the_top > div.desktop_picker_group span {
         border: 2px solid transparent;
         border-inline-end: none;
         transition: border 0.15s ease-in-out;
     }
-    nav#at_the_top > pluto-filepicker button,
+    nav#at_the_top > pluto-filepicker:not(.value_different) button,
     nav#at_the_top > div.desktop_picker_group button {
         opacity: 0;
         transition: opacity 0.15s ease-in-out;
     }
-    header:hover > nav#at_the_top > pluto-filepicker .cm-editor,
-    header:focus-within > nav#at_the_top > pluto-filepicker .cm-editor,
+    header:hover > nav#at_the_top > pluto-filepicker:not(.value_different) .cm-editor,
+    header:focus-within > nav#at_the_top > pluto-filepicker:not(.value_different) .cm-editor,
     header:hover > nav#at_the_top > div.desktop_picker_group span,
     header:focus-within > nav#at_the_top > div.desktop_picker_group span {
         border: 2px solid var(--footer-input-border-color);
         border-inline-end: none;
     }
-    header:hover > nav#at_the_top > pluto-filepicker button,
-    header:focus-within > nav#at_the_top > pluto-filepicker button,
+    header:hover > nav#at_the_top > pluto-filepicker:not(.value_different) button,
+    header:focus-within > nav#at_the_top > pluto-filepicker:not(.value_different) button,
     header:hover > nav#at_the_top > div.desktop_picker_group button,
     header:focus-within > nav#at_the_top > div.desktop_picker_group button {
         opacity: 1;


### PR DESCRIPTION
This PR changes the behaviour of the file picker when it loses focus – it no longer clears the field.

New in this PR:
- Don't clear on blur
- Orange outline when value is different (to notify user that they still need to submit)
- Tweak behaviour of `.suggest_button` from #3347 
- Add `Esc` key to clear and reset the field.

Fix #3300

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/JuliaPluto/Pluto.jl", rev="file-input-dont-clear-on-blur")
julia> using Pluto
```
