### PR TITLE
Fix MoreAnalysis tests after deprecation removal

### DIFF
--- a/test/MoreAnalysis.jl
+++ b/test/MoreAnalysis.jl
@@ -21,30 +21,30 @@ using Test
     
     @testset "Recursive stuff" begin
         
-        @test cell_indices(MoreAnalysis.downstream_recursive(notebook, notebook.topology, notebook.cells[1:1])) == 3:7
-        @test cell_indices(MoreAnalysis.upstream_recursive(notebook, notebook.topology, notebook.cells[1:1])) == []
+        @test cell_indices(MoreAnalysis.downstream_recursive(notebook.topology, notebook.cells[1:1])) == 3:7
+        @test cell_indices(MoreAnalysis.upstream_recursive(notebook.topology, notebook.cells[1:1])) == []
         
-        @test cell_indices(MoreAnalysis.downstream_recursive(notebook, notebook.topology, notebook.cells[6:6])) == [7]
-        @test cell_indices(MoreAnalysis.upstream_recursive(notebook, notebook.topology, notebook.cells[6:6])) == [1,2,3,4]
+        @test cell_indices(MoreAnalysis.downstream_recursive(notebook.topology, notebook.cells[6:6])) == [7]
+        @test cell_indices(MoreAnalysis.upstream_recursive(notebook.topology, notebook.cells[6:6])) == [1,2,3,4]
         
-        @test cell_indices(MoreAnalysis.downstream_recursive(notebook, notebook.topology, notebook.cells[7:7])) == []
-        @test cell_indices(MoreAnalysis.upstream_recursive(notebook, notebook.topology, notebook.cells[7:7])) == 1:6
+        @test cell_indices(MoreAnalysis.downstream_recursive(notebook.topology, notebook.cells[7:7])) == []
+        @test cell_indices(MoreAnalysis.upstream_recursive(notebook.topology, notebook.cells[7:7])) == 1:6
         
-        @test cell_indices(MoreAnalysis.downstream_recursive(notebook, notebook.topology, notebook.cells[4:5])) == 6:7
-        @test cell_indices(MoreAnalysis.upstream_recursive(notebook, notebook.topology, notebook.cells[4:5])) == 1:3
+        @test cell_indices(MoreAnalysis.downstream_recursive(notebook.topology, notebook.cells[4:5])) == 6:7
+        @test cell_indices(MoreAnalysis.upstream_recursive(notebook.topology, notebook.cells[4:5])) == 1:3
         
-        @test cell_indices(MoreAnalysis.downstream_recursive(notebook, notebook.topology, notebook.cells[1:2])) == 3:7
-        @test cell_indices(MoreAnalysis.upstream_recursive(notebook, notebook.topology, notebook.cells[1:2])) == []
+        @test cell_indices(MoreAnalysis.downstream_recursive(notebook.topology, notebook.cells[1:2])) == 3:7
+        @test cell_indices(MoreAnalysis.upstream_recursive(notebook.topology, notebook.cells[1:2])) == []
         
-        @test cell_indices(MoreAnalysis.downstream_recursive(notebook, notebook.topology, notebook.cells[1:7])) == 3:7
-        @test cell_indices(MoreAnalysis.upstream_recursive(notebook, notebook.topology, notebook.cells[1:7])) == 1:6
+        @test cell_indices(MoreAnalysis.downstream_recursive(notebook.topology, notebook.cells[1:7])) == 3:7
+        @test cell_indices(MoreAnalysis.upstream_recursive(notebook.topology, notebook.cells[1:7])) == 1:6
         
         
-        @test cell_indices(MoreAnalysis.downstream_recursive(notebook, notebook.topology, notebook.cells[[1,3]])) == 3:7
-        @test cell_indices(MoreAnalysis.upstream_recursive(notebook, notebook.topology, notebook.cells[[1,3]])) == [1]
+        @test cell_indices(MoreAnalysis.downstream_recursive(notebook.topology, notebook.cells[[1,3]])) == 3:7
+        @test cell_indices(MoreAnalysis.upstream_recursive(notebook.topology, notebook.cells[[1,3]])) == [1]
         
-        @test MoreAnalysis.upstream_recursive(notebook, notebook.topology, Cell[]) == Set{Cell}()
-        @test MoreAnalysis.downstream_recursive(notebook, notebook.topology, Cell[]) == Set{Cell}()
+        @test MoreAnalysis.upstream_recursive(notebook.topology, Cell[]) == Set{Cell}()
+        @test MoreAnalysis.downstream_recursive(notebook.topology, Cell[]) == Set{Cell}()
     end
     
     @testset "Bond connections" begin
@@ -53,7 +53,7 @@ using Test
         #     MoreAnalysis.find_bound_variables(cell.parsedcode)
         # end)
 
-        connections = MoreAnalysis.bound_variable_connections_graph(notebook)
+        connections = MoreAnalysis.bound_variable_connections_graph(notebook.topology)
 
         @test !isempty(connections)
         wanted_connections = Dict(


### PR DESCRIPTION
After #3560 removed the deprecated `notebook` first argument from `downstream_recursive`, `upstream_recursive`, and `bound_variable_connections_graph` (they now take a `NotebookTopology`), `test/MoreAnalysis.jl` was still calling them with the old `notebook` argument. That throws a `MethodError`, so the `MoreAnalysis` testset errors (4 passed, 17 errored) and the backend test suite has been red on `main` since that merge.

This updates the test to the current topology-only signatures (e.g. `downstream_recursive(notebook.topology, cells)` and `bound_variable_connections_graph(notebook.topology)`).

Verified locally: `MoreAnalysis` testset is now 22/22 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/JuliaPluto/Pluto.jl", rev="fix-moreanalysis-test-signatures")
julia> using Pluto
```
