### PR TITLE
CodeMirror: show kwargs in italic

### DIFF
--- a/frontend/components/CellInput.js
+++ b/frontend/components/CellInput.js
@@ -68,6 +68,7 @@ import { AiSuggestionPlugin } from "./CellInput/ai_suggestion.js"
 import { detect_indent_unit } from "./CellInput/detect_indent_unit.js"
 import { t } from "../common/lang.js"
 import { get_settings } from "./Settings.js"
+import { highlightKwargsPlugin } from "./CellInput/highlight_kwargs.js"
 
 // @ts-ignore
 window.PLUTO_TOGGLE_CM_MIXED_PARSER = () => console.error("Use the Settings menu instead.")
@@ -78,6 +79,7 @@ window.PLUTO_TOGGLE_CM_AUTOCOMPLETE_ON_TYPE = () => console.error("Use the Setti
 
 const common_style_tags = [
     { tag: tags.comment, color: "var(--cm-color-comment)", fontStyle: "italic", filter: "none" },
+
     { tag: tags.variableName, color: "var(--cm-color-variable)", fontWeight: 700 },
     { tag: tags.propertyName, color: "var(--cm-color-symbol)", fontWeight: 700 },
     { tag: tags.macroName, color: "var(--cm-color-macro)", fontWeight: 700 },
@@ -88,10 +90,11 @@ const common_style_tags = [
     { tag: tags.character, color: "var(--cm-color-literal)" },
     { tag: tags.literal, color: "var(--cm-color-literal)" },
     { tag: tags.keyword, color: "var(--cm-color-keyword)" },
-    // TODO: normal operators
-    { tag: tags.definitionOperator, color: "var(--cm-color-keyword)" },
+    { tag: tags.definitionOperator, color: "var(--cm-color-definition)" },
     { tag: tags.logicOperator, color: "var(--cm-color-keyword)" },
-    { tag: tags.controlOperator, color: "var(--cm-color-keyword)" },
+    { tag: [tags.controlKeyword, tags.controlOperator], color: "var(--cm-color-control-operator)" },
+    { tag: tags.attributeName, color: `pink`, fontStyle: "italic" },
+
     { tag: tags.bracket, color: "var(--cm-color-bracket)" },
     { tag: tags.self, color: "var(--cm-color-keyword)" },
     { tag: tags.null, color: "var(--cm-color-literal)" },
@@ -610,6 +613,7 @@ export const CellInput = ({
                     syntaxHighlighting(pluto_syntax_colors_css),
                     lineNumbers(),
                     highlightSpecialChars(),
+                    highlightKwargsPlugin(),
                     history(),
                     drawSelection(),
                     EditorState.allowMultipleSelections.of(true),

--- a/frontend/components/CellInput/highlight_kwargs.js
+++ b/frontend/components/CellInput/highlight_kwargs.js
@@ -1,0 +1,90 @@
+// Show keyword arguments in italic.
+
+import { Decoration, EditorView, syntaxTree, ViewPlugin, ViewUpdate } from "../../imports/CodemirrorPlutoSetup.js"
+
+/**
+ * @param {EditorView} view
+ */
+const create_kwarg_decorations = (view) => {
+    let widgets = []
+    for (let { from, to } of view.visibleRanges) {
+        syntaxTree(view.state).iterate({
+            from,
+            to,
+            enter: (node_ref) => {
+                if (node_ref.name == "Identifier") {
+                    const node = node_ref.node
+
+                    const is_first_child = (/** @type {import("./scopestate_statefield.js").SyntaxNode} */ n) => n.prevSibling == null
+
+                    const is_kwarg = (/** @type {import("./scopestate_statefield.js").SyntaxNode | null} */ n) => {
+                        if (!n) return false
+                        if (
+                            // f(x; NODE)
+                            n.matchContext(["KeywordArguments", "Arguments", "CallExpression"].reverse())
+                        ) {
+                            return true
+                        } else if (
+                            // f(x; NODE=123)
+                            n.matchContext(["KwArg", "KeywordArguments", "Arguments", "CallExpression"].reverse()) ||
+                            // f(x, NODE=123)
+                            n.matchContext(["KwArg", "Arguments", "CallExpression"].reverse())
+                        ) {
+                            // is first child?
+                            return is_first_child(n)
+                        }
+                    }
+
+                    /** @type {import("./scopestate_statefield.js").SyntaxNode | null} */
+                    let node_to_check = node
+
+                    // NODE::Soething
+                    if (node.matchContext(["BinaryExpression"]) && node.node.prevSibling == null) {
+                        node_to_check = node.parent
+                    }
+                    // NODE...
+                    if (node.matchContext(["SplatExpression"])) {
+                        node_to_check = node.parent
+                    }
+
+                    if (is_kwarg(node_to_check)) {
+                        const deco = Decoration.mark({
+                            class: "cm-julia-kwarg",
+                        })
+                        widgets.push(deco.range(node.from, node.to))
+                    }
+                }
+            },
+        })
+    }
+    return Decoration.set(widgets)
+}
+
+export const highlightKwargsPlugin = () =>
+    ViewPlugin.fromClass(
+        class {
+            updateDecos(view) {
+                this.decorations = create_kwarg_decorations(view)
+            }
+
+            /**
+             * @param {EditorView} view
+             */
+            constructor(view) {
+                this.decorations = Decoration.set([])
+                this.updateDecos(view)
+            }
+
+            /**
+             * @param {ViewUpdate} update
+             */
+            update(update) {
+                if (update.docChanged || update.viewportChanged || syntaxTree(update.startState) != syntaxTree(update.state)) {
+                    this.updateDecos(update.view)
+                }
+            }
+        },
+        {
+            decorations: (v) => v.decorations,
+        }
+    )

--- a/frontend/editor.css
+++ b/frontend/editor.css
@@ -4267,6 +4267,9 @@ pluto-input:focus-within .cm-editor .cm-matchingBracket {
     vertical-align: top;
     margin-left: -1px;
 }
+.cm-julia-kwarg {
+    font-style: italic;
+}
 
 /* PLUTO HOOKS - special styling for cell that runs hook */
 /* New feature, new section in the css! */

--- a/frontend/themes/dark.css
+++ b/frontend/themes/dark.css
@@ -186,7 +186,6 @@
         --footer-filepicker-button-color: black;
         --footer-filepicker-focus-color: #c1c1c1;
         --footnote-border-color: rgba(114, 225, 231, 0.15);
-
         --settings-bg-color: rgb(30 34 31);
         --settings-p2-color: #898989;
         --settings-header-bg-color: #f9dadf;
@@ -210,6 +209,8 @@
         --cm-color-editor-text: oklch(90% 3% 0deg);
         --cm-color-comment: oklch(80% 30% 0deg);
         --cm-color-keyword: oklch(70% 40% 30deg);
+        --cm-color-definition: oklch(72.266% 0.04982 26.319);
+        --cm-color-control-operator: oklch(0.72 0.19 353.17);
         --cm-color-symbol: oklch(80% 30% 60deg);
         --cm-color-macro: oklch(80% 30% 150deg);
         --cm-color-command: oklch(80% 10% 120deg);

--- a/frontend/themes/light.css
+++ b/frontend/themes/light.css
@@ -209,6 +209,8 @@
         --cm-color-editor-text: oklch(30% 0% 0deg);
         --cm-color-comment: oklch(45% 60% 0deg);
         --cm-color-keyword: oklch(45% 80% 30deg);
+        --cm-color-definition: oklch(28.455% 0.11677 29.223);
+        --cm-color-control-operator: oklch(56.456% 0.23502 350.694);
         --cm-color-symbol: oklch(45% 80% 90deg);
         --cm-color-command: oklch(35% 100% 120deg);
         --cm-color-macro: oklch(45% 80% 150deg);


### PR DESCRIPTION
<img width="742" height="170" alt="Scherm­afbeelding 2026-06-18 om 16 21 06" src="https://github.com/user-attachments/assets/daa8bcbd-ad85-4584-b4d9-46941c9c438c" />


## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/JuliaPluto/Pluto.jl", rev="syntax-highlighting-italic-kwargs")
julia> using Pluto
```
