### PR TITLE
Desktop app: main menu from logo, open in new window, string export types

### DIFF
--- a/frontend/Desktop.d.ts
+++ b/frontend/Desktop.d.ts
@@ -4,35 +4,19 @@ declare global {
      * related types and interfaces.
      */
     namespace Desktop {
-        /**
-         * This enum has to be in sync with the enum "PlutoExport"
-         * defined in PlutoDesktop/{branch:master}/types/enums.ts
-         *
-         * @note Unfortunately enums can't be exported from .d.ts files.
-         * Inorder to use this, just map integers to the enum values
-         * - PlutoExport.FILE -> **0**
-         * - PlutoExport.HTML -> **1**
-         * - PlutoExport.STATE -> **2**
-         * - PlutoExport.PDF -> **3**
-         */
-        enum PlutoExport {
-            FILE,
-            HTML,
-            STATE,
-            PDF,
-        }
+        type PlutoExport = "file" | "html" | "state" | "pdf"
 
         /**
-         * This type has to be in sync with the interface "Window"
-         * defined in PlutoDesktop/{branch:master}/src/renderer/preload.d.ts
+         * This type has to be in sync with the API exposed
+         * in PlutoDesktop/{branch:main}/src/preload.ts
          */
         type PlutoDesktop = {
             ipcRenderer: {
-                sendMessage(channel: String, args: unknown[]): void
                 on(channel: string, func: (...args: unknown[]) => void): (() => void) | undefined
                 once(channel: string, func: (...args: unknown[]) => void): void
             }
             isBackendLoaded(): Promise<boolean>
+            openMainMenu(): void
             fileSystem: {
                 /**
                  * @param type [default = 'new'] whether you want to open a new notebook
@@ -41,8 +25,7 @@ declare global {
                  * opens that notebook. If false and no path is there, opens the file selector.
                  * If true, opens a new blank notebook.
                  */
-                openNotebook(type?: "url" | "path" | "new", pathOrURL?: string): void
-                shutdownNotebook(id?: string): void
+                openNotebook(type?: "url" | "path" | "new", pathOrURL?: string, options?: { newWindow?: boolean }): void
                 moveNotebook(id?: string): void
                 exportNotebook(id: string, type: PlutoExport): void
             }

--- a/frontend/components/DesktopInterface.js
+++ b/frontend/components/DesktopInterface.js
@@ -3,10 +3,20 @@ export const open_from_path = () => {
     // @ts-ignore
     window.plutoDesktop.fileSystem.openNotebook("path")
 }
+export const open_from_path_in_new_window = (/** @type string */ path) => {
+    console.log("Calling plutoDesktop -> open_from_path_in_new_window")
+    // @ts-ignore
+    window.plutoDesktop.fileSystem.openNotebook("path", path, { newWindow: true })
+}
 export const open_from_url = (/** @type string */ url) => {
     console.log("Calling plutoDesktop -> open_from_url")
     // @ts-ignore
     window.plutoDesktop.fileSystem.openNotebook("url", url)
+}
+export const open_main_menu = () => {
+    console.log("Calling plutoDesktop -> open_main_menu")
+    // @ts-ignore
+    window.plutoDesktop.openMainMenu()
 }
 
 export const move_notebook = () => {
@@ -15,7 +25,10 @@ export const move_notebook = () => {
     window.plutoDesktop.fileSystem.moveNotebook()
 }
 
-export const export_notebook = (notebook_id, type) => {
+export const export_notebook = (
+    /** @type {string} */ notebook_id,
+    /** @type {Desktop.PlutoExport} */ type
+) => {
     console.log("Calling plutoDesktop -> export_notebook")
     // @ts-ignore
     window.plutoDesktop.fileSystem.exportNotebook(notebook_id, type)

--- a/frontend/components/Editor.js
+++ b/frontend/components/Editor.js
@@ -50,7 +50,7 @@ import { ProjectTomlEditor } from "./ProjectTomlEditor.js"
 import { getCurrentLanguage, getWritingDirection, t, th } from "../common/lang.js"
 import { InlineIonicon, PlutoLandUpload } from "./PlutoLandUpload.js"
 import { BigPkgTerminal } from "./PkgTerminalView.js"
-import { is_desktop, move_notebook, wait_for_file_move } from "./DesktopInterface.js"
+import { is_desktop, move_notebook, open_main_menu, wait_for_file_move } from "./DesktopInterface.js"
 import { with_query_params } from "../common/URLTools.js"
 import semver from "../imports/semver-es.js"
 import { ConfirmBeforeLongRuntime, maybe_abort_long_runtime } from "./ConfirmBeforeLongRuntime.js"
@@ -1251,21 +1251,24 @@ all patches: ${JSON.stringify(patches, null, 1)}
         this.desktop_submit_file_change = async () => {
             this.setState({ moving_file: true })
 
-            const file_moved_promise = wait_for_file_move()
-            // ask the electron backend to start moving the notebook. The promise above will be resolved once it is done.
-            move_notebook()
+            try {
+                const file_moved_promise = wait_for_file_move()
+                // ask the electron backend to start moving the notebook. The promise above will be resolved once it is done.
+                move_notebook()
 
-            const loc = await file_moved_promise
-            if (!!loc)
-                await this.setStatePromise(
-                    immer((/** @type {EditorState} */ state) => {
-                        state.notebook.in_temp_dir = false
-                        state.notebook.path = loc
-                    })
-                )
-            this.setState({ moving_file: false })
-            // @ts-ignore
-            document.activeElement?.blur()
+                const loc = await file_moved_promise
+                if (!!loc)
+                    await this.setStatePromise(
+                        immer((/** @type {EditorState} */ state) => {
+                            state.notebook.in_temp_dir = false
+                            state.notebook.path = loc
+                        })
+                    )
+                // @ts-ignore
+                document.activeElement?.blur()
+            } finally {
+                this.setState({ moving_file: false })
+            }
         }
 
         this.delete_selected = () => {
@@ -1679,9 +1682,15 @@ ${t("t_key_autosave_description")}`
                                 : null
                         }
                         <nav id="at_the_top">
-                            <a href=${
-                                this.state.binder_session_url != null ? `${this.state.binder_session_url}?token=${this.state.binder_session_token}` : "./"
-                            }>
+                            <a
+                                href=${this.state.binder_session_url != null ? `${this.state.binder_session_url}?token=${this.state.binder_session_token}` : "./"}
+                                onClick=${(e) => {
+                                    if (is_desktop()) {
+                                        e.preventDefault()
+                                        open_main_menu()
+                                    }
+                                }}
+                            >
                                 <h1><img id="logo-big" src=${url_logo_big} alt="Pluto.jl" /><img id="logo-small" src=${url_logo_small} aria-hidden="true" /></h1>
                             </a>
                             ${
@@ -1699,7 +1708,8 @@ ${t("t_key_autosave_description")}`
                                           client=${this.client}
                                           value=${notebook.in_temp_dir ? "" : notebook.path}
                                           on_submit=${this.submit_file_change}
-                                          on_desktop_submit=${this.desktop_submit_file_change}
+                                          on_desktop_submit=${is_desktop() ? this.desktop_submit_file_change : null}
+                                          readonly=${is_desktop()}
                                           clear_on_blur=${false}
                                           suggest_new_file=${{
                                               base: this.client.session_options?.server?.notebook_path_suggestion ?? "",

--- a/frontend/components/ExportBanner.js
+++ b/frontend/components/ExportBanner.js
@@ -132,7 +132,7 @@ export const ExportBanner = ({
             <div id="container">
                 <div class="export_title">${t("t_export_category_export")}</div>
                 <!-- no "download" attribute here: we want the jl contents to be shown in a new tab -->
-                <a href=${notebookfile_url} target="_blank" class="export_card" onClick=${(e) => exportNotebookDesktop(e, 0, notebook_id)}>
+                <a href=${notebookfile_url} target="_blank" class="export_card" onClick=${(e) => exportNotebookDesktop(e, "file", notebook_id)}>
                     <header role="none"><${Triangle} fill="#a270ba" /> ${t("t_export_card_notebook_file")}</header>
                     <section>${th("t_export_card_notebook_file_description")}</section>
                 </a>

--- a/frontend/components/FilePicker.js
+++ b/frontend/components/FilePicker.js
@@ -47,11 +47,13 @@ export const set_cm_value = (/** @type{EditorView} */ cm, /** @type {string} */ 
  *  button_label: String,
  *  placeholder: String,
  *  on_submit: (new_path: String) => Promise<void>,
+ *  on_desktop_submit?: () => Promise<void>,
  *  client: import("../common/PlutoConnection.js").PlutoConnection,
  *  clear_on_blur: Boolean,
+ *  readonly: Boolean,
  * }} props
  */
-export const FilePicker = ({ value, suggest_new_file, button_label, placeholder, on_submit, client, clear_on_blur }) => {
+export const FilePicker = ({ value, readonly, suggest_new_file, button_label, placeholder, on_submit, on_desktop_submit, client, clear_on_blur }) => {
     const [current_value, set_current_value] = useState(value)
 
     const [url_value, set_url_value] = useState("")
@@ -60,7 +62,7 @@ export const FilePicker = ({ value, suggest_new_file, button_label, placeholder,
     const base = useRef(/** @type {any} */ (null))
     const cm = useRef(/** @type {EditorView?} */ (null))
 
-    const is_button_disabled = current_value.length === 0 || current_value === forced_value.current
+    const is_button_disabled = on_desktop_submit == null && (current_value.length === 0 || current_value === forced_value.current)
     const value_different = current_value !== forced_value.current
     const suggest_button = current_value !== forced_value.current && /\.\w*$/.test(current_value)
 
@@ -82,7 +84,11 @@ export const FilePicker = ({ value, suggest_new_file, button_label, placeholder,
         if (current_cm == null) return
         run(async () => {
             try {
-                await on_submit(current_cm.state.doc.toString())
+                if (on_desktop_submit != null) {
+                    await on_desktop_submit()
+                } else {
+                    await on_submit(current_cm.state.doc.toString())
+                }
                 current_cm.dom.blur()
             } catch (error) {
                 set_cm_value(current_cm, forced_value.current, true)
@@ -160,6 +166,7 @@ export const FilePicker = ({ value, suggest_new_file, button_label, placeholder,
                         { dark: usesDarkTheme }
                     ),
                     // EditorView.updateListener.of(onCM6Update),
+                    EditorState.readOnly.of(readonly),
                     history(),
                     autocompletion({
                         activateOnTyping: true,

--- a/frontend/components/PlutoLandUpload.js
+++ b/frontend/components/PlutoLandUpload.js
@@ -98,7 +98,7 @@ export const PlutoLandUpload = ({ notebook_id }) => {
                     target="_blank"
                     download=${download_filename ?? ""}
                     onClick=${(e) => {
-                        exportNotebookDesktop(e, 1, notebook_id)
+                        exportNotebookDesktop(e, "html", notebook_id)
                         close()
                     }}
                 >

--- a/frontend/components/welcome/Recent.js
+++ b/frontend/components/welcome/Recent.js
@@ -6,6 +6,8 @@ import { cl } from "../../common/ClassTable.js"
 import { link_edit, link_open_path } from "./Open.js"
 import { ProcessStatus } from "../../common/ProcessStatus.js"
 import { t, th } from "../../common/lang.js"
+import { has_ctrl_or_cmd_pressed } from "../../common/KeyboardShortcuts.js"
+import { is_desktop, open_from_path_in_new_window } from "../DesktopInterface.js"
 
 /**
  * @typedef CombinedNotebook
@@ -217,7 +219,14 @@ export const Recent = ({ client, connected, remote_notebooks, CustomRecent, on_s
                           href=${running ? link_edit(nb.entry?.notebook_id) : link_open_path(nb.path)}
                           title=${nb.path}
                           onClick=${(e) => {
-                              if (!running) {
+                              const open_in_new_context = has_ctrl_or_cmd_pressed(e) || e.shiftKey || e.button === 1
+                              if (is_desktop() && open_in_new_context) {
+                                  e.preventDefault()
+                                  open_from_path_in_new_window(nb.path)
+                                  return
+                              }
+
+                              if (!running && !open_in_new_context) {
                                   on_start_navigation(shortest_path(nb.path, all_paths))
                                   set_notebook_state(nb.path, {
                                       transitioning: true,

--- a/sample/Basic.jl
+++ b/sample/Basic.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.14.0
+# v1.0.1
 
 using Markdown
 using InteractiveUtils


### PR DESCRIPTION
_Written by AI_

Improvements to the [PlutoDesktop](https://github.com/JuliaPluto/PlutoDesktop) integration, developed together with the API cleanup in JuliaPluto/PlutoDesktop#128. Everything below only affects behavior when running inside the desktop app (`window.plutoDesktop` present).

## Changes

- **Logo click opens the main menu in a new window.** In the browser the logo navigates to `./`; on desktop this replaced the notebook window. It now calls the new `openMainMenu()` bridge so the notebook stays open.
- **Open recent notebooks in a new window.** Ctrl/Cmd/Shift/middle-click on a recent notebook opens it in a new desktop window via `openNotebook("path", path, { newWindow: true })`.
- **`PlutoExport` is now a string union** (`"file" | "html" | "state" | "pdf"`) instead of enum integers that had to be kept in sync with PlutoDesktop manually. Call sites in `ExportBanner.js` and `PlutoLandUpload.js` updated.
- **File picker on desktop:** the path field is readonly (moving is done through the native dialog), the Move button is always enabled, and `moving_file` is reset in a `finally` block so a cancelled/failed move no longer leaves the UI stuck.
- **`Desktop.d.ts` synced with the actual preload API** of PlutoDesktop: removed `sendMessage` and `shutdownNotebook` (no longer exposed), added `openMainMenu()` and the `newWindow` option.
- `sample/Basic.jl` notebook-format version bump picked up while testing.

## Testing

Tested on Windows against PlutoDesktop `cleanup/dead-code-and-simplify` (JuliaPluto/PlutoDesktop#128): startup, welcome page, opening recents, logo → main menu in new window, ctrl+click → new window, move dialog + cancel recovery, notebook file export, clean quit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Try this Pull Request!
Open Julia and type:
```jl
julia> import Pkg
julia> Pkg.activate(temp=true)
julia> Pkg.add(url="https://github.com/JuliaPluto/Pluto.jl", rev="desktop-changes-july-2026")
julia> using Pluto
```
